### PR TITLE
fix: Prettier formatting in GameCard

### DIFF
--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -48,5 +48,9 @@ export function GameCard({ game }: GameCardProps) {
     return card
   }
 
-  return <Link href={`/games/${game.slug}`} className="h-full">{card}</Link>
+  return (
+    <Link href={`/games/${game.slug}`} className="h-full">
+      {card}
+    </Link>
+  )
 }


### PR DESCRIPTION
## Summary
- Breaks the `className="h-full"` prop onto its own line on the `Link` wrapper in `GameCard.tsx` to satisfy Prettier's line-length rules.

This was introduced in the previous commit that made game cards equal height.

## Test plan
- [x] `pnpm exec prettier --check .` passes locally
- [x] CI lint & test job passes