### PR TITLE
fix: resolve build failures on main

### DIFF
--- a/src/app/games/bounce/page.tsx
+++ b/src/app/games/bounce/page.tsx
@@ -1,4 +1,4 @@
-import GameLayout from '@/components/GameLayout'
+import { GameLayout } from '@/components/GameLayout'
 import BounceGame from '@/games/bounce/BounceGame'
 
 export default function BouncePage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Library Games',
@@ -13,7 +10,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>{children}</body>
+      <body className="font-sans">{children}</body>
     </html>
   )
 }

--- a/src/games/bounce/logic.test.ts
+++ b/src/games/bounce/logic.test.ts
@@ -149,6 +149,7 @@ describe('stepGame', () => {
       ...base,
       ball: { x: 100, y: 200, vx: 0, vy: 1 },
       stars: [{ id: 0, x: 100, y: 200, collected: false }],
+      nextStarId: 1,
       platforms: [],
       cameraY: 0,
     }


### PR DESCRIPTION
## Summary
- Replace `next/font/google` (Inter) with Tailwind `font-sans` system font stack so the build works in network-restricted CI environments
- Fix `bounce/page.tsx` default import → named import for `GameLayout` (the component only has a named export)
- Set `nextStarId: 1` in the star-collection test to prevent newly generated stars from colliding with the manually placed star `id: 0`, fixing a flaky test failure

## Test plan
- [x] `pnpm build` completes successfully
- [x] `pnpm test` — all 169 tests pass
- [x] `pnpm lint` — no lint or formatting errors

https://claude.ai/code/session_01SH88xrGWbALotyfbhMHiTd