### PR TITLE
ci: add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote Claude Code on the web sessions
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install gh CLI if not present
+if ! command -v gh &>/dev/null; then
+  apt-get install -y gh
+fi
+
+# Install pnpm dependencies
+pnpm install
+
+# Persist GH_REPO so gh CLI works without a github.com remote URL
+echo 'export GH_REPO=kkulykk/library-games' >> "$CLAUDE_ENV_FILE"
+
+# Persist GH_TOKEN if gh is already authenticated (credentials cached from prior session)
+if gh auth token &>/dev/null; then
+  echo "export GH_TOKEN=$(gh auth token)" >> "$CLAUDE_ENV_FILE"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/session-start.sh` — installs `gh` CLI if missing, runs `pnpm install`, and exports `GH_REPO` + `GH_TOKEN` into the session environment
- Adds `.claude/settings.json` to register the hook

After this merges, every new Claude Code on the web session will have `gh` ready and the repo pre-configured automatically.

https://claude.ai/code/session_01SH88xrGWbALotyfbhMHiTd