### PR TITLE
Add Tic-Tac-Toe game (single-player vs AI + two-player local)

### DIFF
--- a/src/app/games/tic-tac-toe/page.tsx
+++ b/src/app/games/tic-tac-toe/page.tsx
@@ -1,0 +1,10 @@
+import { GameLayout } from '@/components/GameLayout'
+import { TicTacToeGame } from '@/games/tic-tac-toe/TicTacToeGame'
+
+export default function TicTacToePage() {
+  return (
+    <GameLayout title="Tic-Tac-Toe">
+      <TicTacToeGame />
+    </GameLayout>
+  )
+}

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -104,6 +104,15 @@ export const games: GameMeta[] = [
     emoji: '🟢',
   },
   {
+    slug: 'tic-tac-toe',
+    title: 'Tic-Tac-Toe',
+    description: 'Classic X and O game. Play against a friend locally or challenge the computer.',
+    tags: ['classic', 'strategy', 'multiplayer'],
+    status: 'live',
+    category: 'single-player',
+    emoji: '⭕',
+  },
+  {
     slug: 'skribbl',
     title: 'Skribbl',
     description: 'Draw and guess with friends online. Pictionary-style fun for everyone.',

--- a/src/games/tic-tac-toe/TicTacToeGame.tsx
+++ b/src/games/tic-tac-toe/TicTacToeGame.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { createInitialState, makeMove, getAIMove, isGameOver, type GameState } from './logic'
+import { cn } from '@/lib/utils'
+
+type GameMode = 'single' | 'dual'
+
+export function TicTacToeGame() {
+  const [mode, setMode] = useState<GameMode | null>(null)
+  const [state, setState] = useState<GameState>(createInitialState())
+  const [aiThinking, setAiThinking] = useState(false)
+
+  // AI move for single-player mode (AI plays as O)
+  useEffect(() => {
+    if (mode !== 'single') return
+    if (state.currentPlayer !== 'O') return
+    if (isGameOver(state)) return
+
+    setAiThinking(true)
+    const timeout = setTimeout(() => {
+      const move = getAIMove(state.board, 'O')
+      if (move !== -1) {
+        setState((prev) => makeMove(prev, move))
+      }
+      setAiThinking(false)
+    }, 400)
+
+    return () => clearTimeout(timeout)
+  }, [mode, state])
+
+  function handleCellClick(index: number) {
+    if (aiThinking) return
+    if (mode === 'single' && state.currentPlayer === 'O') return
+    setState((prev) => makeMove(prev, index))
+  }
+
+  function restart() {
+    setState(createInitialState())
+    setAiThinking(false)
+  }
+
+  function changeMode() {
+    setMode(null)
+    setState(createInitialState())
+    setAiThinking(false)
+  }
+
+  if (mode === null) {
+    return (
+      <div className="flex flex-col items-center gap-6">
+        <h2 className="text-xl font-bold">Choose Mode</h2>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <button
+            onClick={() => setMode('single')}
+            className="flex flex-col items-center gap-1 rounded-2xl bg-secondary px-8 py-5 text-center font-semibold transition-colors hover:bg-secondary/70"
+          >
+            <span className="text-3xl">🤖</span>
+            <span>vs Computer</span>
+            <span className="text-xs font-normal text-muted-foreground">You are X</span>
+          </button>
+          <button
+            onClick={() => setMode('dual')}
+            className="flex flex-col items-center gap-1 rounded-2xl bg-secondary px-8 py-5 text-center font-semibold transition-colors hover:bg-secondary/70"
+          >
+            <span className="text-3xl">👥</span>
+            <span>2 Players</span>
+            <span className="text-xs font-normal text-muted-foreground">Local co-op</span>
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const statusText = () => {
+    if (state.winner) {
+      if (mode === 'single') {
+        return state.winner === 'X' ? 'You win! 🎉' : 'Computer wins!'
+      }
+      return `Player ${state.winner} wins! 🎉`
+    }
+    if (state.isDraw) return "It's a draw!"
+    if (mode === 'single') {
+      return state.currentPlayer === 'X' ? 'Your turn (X)' : 'Computer thinking…'
+    }
+    return `Player ${state.currentPlayer}'s turn`
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      {/* Status */}
+      <div
+        className={cn(
+          'rounded-xl px-6 py-2 text-center text-sm font-semibold',
+          state.winner
+            ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200'
+            : state.isDraw
+              ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'
+              : 'bg-secondary text-secondary-foreground'
+        )}
+      >
+        {statusText()}
+      </div>
+
+      {/* Board */}
+      <div className="grid grid-cols-3 gap-2">
+        {state.board.map((cell, index) => {
+          const isWinningCell = state.winningLine?.includes(index) ?? false
+          return (
+            <button
+              key={index}
+              onClick={() => handleCellClick(index)}
+              disabled={cell !== null || isGameOver(state) || aiThinking}
+              aria-label={`Cell ${index + 1}${cell ? ` (${cell})` : ''}`}
+              className={cn(
+                'flex h-20 w-20 select-none items-center justify-center rounded-2xl text-4xl font-bold transition-all duration-150 sm:h-24 sm:w-24',
+                isWinningCell && 'bg-emerald-200 dark:bg-emerald-800',
+                !isWinningCell && cell === null && !isGameOver(state) && !aiThinking
+                  ? 'bg-secondary hover:bg-secondary/70 active:scale-95'
+                  : !isWinningCell
+                    ? 'bg-secondary/50'
+                    : '',
+                cell === 'X'
+                  ? 'text-blue-600 dark:text-blue-400'
+                  : 'text-rose-600 dark:text-rose-400'
+              )}
+            >
+              {cell}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        <button
+          onClick={restart}
+          className="rounded-lg bg-secondary px-5 py-2 text-sm font-semibold text-secondary-foreground hover:bg-secondary/80"
+        >
+          Restart
+        </button>
+        <button
+          onClick={changeMode}
+          className="rounded-lg border px-5 py-2 text-sm font-semibold hover:bg-secondary"
+        >
+          Change Mode
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/games/tic-tac-toe/logic.test.ts
+++ b/src/games/tic-tac-toe/logic.test.ts
@@ -1,0 +1,187 @@
+import {
+  createInitialState,
+  makeMove,
+  checkWinner,
+  checkDraw,
+  getAIMove,
+  isGameOver,
+  type Board,
+  type Cell,
+} from './logic'
+
+describe('createInitialState', () => {
+  it('creates an empty board', () => {
+    const state = createInitialState()
+    expect(state.board).toHaveLength(9)
+    state.board.forEach((cell) => expect(cell).toBeNull())
+  })
+
+  it('starts with player X', () => {
+    const state = createInitialState()
+    expect(state.currentPlayer).toBe('X')
+  })
+
+  it('has no winner or draw at start', () => {
+    const state = createInitialState()
+    expect(state.winner).toBeNull()
+    expect(state.isDraw).toBe(false)
+    expect(state.winningLine).toBeNull()
+  })
+})
+
+describe('checkWinner', () => {
+  it('detects row win', () => {
+    const board: Board = ['X', 'X', 'X', null, null, null, null, null, null]
+    const { winner, line } = checkWinner(board)
+    expect(winner).toBe('X')
+    expect(line).toEqual([0, 1, 2])
+  })
+
+  it('detects column win', () => {
+    const board: Board = ['O', null, null, 'O', null, null, 'O', null, null]
+    const { winner, line } = checkWinner(board)
+    expect(winner).toBe('O')
+    expect(line).toEqual([0, 3, 6])
+  })
+
+  it('detects diagonal win', () => {
+    const board: Board = ['X', null, null, null, 'X', null, null, null, 'X']
+    const { winner, line } = checkWinner(board)
+    expect(winner).toBe('X')
+    expect(line).toEqual([0, 4, 8])
+  })
+
+  it('detects anti-diagonal win', () => {
+    const board: Board = [null, null, 'O', null, 'O', null, 'O', null, null]
+    const { winner, line } = checkWinner(board)
+    expect(winner).toBe('O')
+    expect(line).toEqual([2, 4, 6])
+  })
+
+  it('returns null when no winner', () => {
+    const board: Board = ['X', 'O', null, null, null, null, null, null, null]
+    const { winner, line } = checkWinner(board)
+    expect(winner).toBeNull()
+    expect(line).toBeNull()
+  })
+})
+
+describe('checkDraw', () => {
+  it('returns true when all cells are filled with no winner', () => {
+    const board: Board = ['X', 'O', 'X', 'X', 'O', 'O', 'O', 'X', 'X']
+    expect(checkDraw(board)).toBe(true)
+  })
+
+  it('returns false when board has empty cells', () => {
+    const board: Board = ['X', 'O', null, null, null, null, null, null, null]
+    expect(checkDraw(board)).toBe(false)
+  })
+})
+
+describe('makeMove', () => {
+  it('places the current player mark on the board', () => {
+    const state = createInitialState()
+    const next = makeMove(state, 4)
+    expect(next.board[4]).toBe('X')
+  })
+
+  it('switches the current player after a move', () => {
+    const state = createInitialState()
+    const next = makeMove(state, 0)
+    expect(next.currentPlayer).toBe('O')
+  })
+
+  it('ignores a move on an occupied cell', () => {
+    let state = createInitialState()
+    state = makeMove(state, 0)
+    const afterInvalid = makeMove(state, 0)
+    expect(afterInvalid).toBe(state) // same reference
+  })
+
+  it('ignores moves after game is over', () => {
+    let state = createInitialState()
+    // X wins top row
+    state = makeMove(state, 0) // X
+    state = makeMove(state, 3) // O
+    state = makeMove(state, 1) // X
+    state = makeMove(state, 4) // O
+    state = makeMove(state, 2) // X wins
+    const afterWin = makeMove(state, 8)
+    expect(afterWin).toBe(state)
+  })
+
+  it('detects a win', () => {
+    let state = createInitialState()
+    state = makeMove(state, 0) // X
+    state = makeMove(state, 3) // O
+    state = makeMove(state, 1) // X
+    state = makeMove(state, 4) // O
+    state = makeMove(state, 2) // X wins
+    expect(state.winner).toBe('X')
+    expect(state.winningLine).toEqual([0, 1, 2])
+  })
+
+  it('detects a draw', () => {
+    // Draw: X X O / O O X / X O X  — sequence verified to produce no winner
+    let state = createInitialState()
+    const moves = [0, 4, 1, 2, 6, 3, 5, 7, 8] // alternating X/O
+    for (const m of moves) state = makeMove(state, m)
+    expect(state.winner).toBeNull()
+    expect(state.isDraw).toBe(true)
+  })
+})
+
+describe('getAIMove', () => {
+  it('returns a valid empty cell index', () => {
+    const board: Board = Array(9).fill(null) as Cell[]
+    const move = getAIMove(board, 'O')
+    expect(move).toBeGreaterThanOrEqual(0)
+    expect(move).toBeLessThan(9)
+    expect(board[move]).toBeNull()
+  })
+
+  it('blocks opponent from winning', () => {
+    // Near-endgame: X threatens diagonal (0,4,8). O must block at 8; blocking leads to draw.
+    // Board: X O X / X X O / O _ _  (two empty cells: 7 and 8)
+    const board: Board = ['X', 'O', 'X', 'X', 'X', 'O', 'O', null, null]
+    const move = getAIMove(board, 'O')
+    expect(move).toBe(8)
+  })
+
+  it('takes the winning move', () => {
+    // O has row 1 almost complete (indices 3 and 4); playing at 5 wins immediately.
+    const board: Board = ['X', 'X', null, 'O', 'O', null, 'X', null, null]
+    const move = getAIMove(board, 'O')
+    expect(move).toBe(5)
+  })
+
+  it('returns -1 when no moves available', () => {
+    const board: Board = ['X', 'O', 'X', 'X', 'O', 'O', 'O', 'X', 'X']
+    const move = getAIMove(board, 'O')
+    expect(move).toBe(-1)
+  })
+})
+
+describe('isGameOver', () => {
+  it('returns false when game is ongoing', () => {
+    const state = createInitialState()
+    expect(isGameOver(state)).toBe(false)
+  })
+
+  it('returns true when there is a winner', () => {
+    let state = createInitialState()
+    state = makeMove(state, 0)
+    state = makeMove(state, 3)
+    state = makeMove(state, 1)
+    state = makeMove(state, 4)
+    state = makeMove(state, 2)
+    expect(isGameOver(state)).toBe(true)
+  })
+
+  it('returns true on a draw', () => {
+    let state = createInitialState()
+    const moves = [0, 4, 2, 1, 7, 3, 5, 6, 8]
+    for (const m of moves) state = makeMove(state, m)
+    expect(isGameOver(state)).toBe(true)
+  })
+})

--- a/src/games/tic-tac-toe/logic.ts
+++ b/src/games/tic-tac-toe/logic.ts
@@ -1,0 +1,108 @@
+export type Player = 'X' | 'O'
+export type Cell = Player | null
+export type Board = Cell[] // 9-element array representing a 3×3 grid
+
+export interface GameState {
+  board: Board
+  currentPlayer: Player
+  winner: Player | null
+  isDraw: boolean
+  winningLine: number[] | null
+}
+
+export const WINNING_LINES: number[][] = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8], // rows
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8], // cols
+  [0, 4, 8],
+  [2, 4, 6], // diagonals
+]
+
+export function createInitialState(): GameState {
+  return {
+    board: Array(9).fill(null) as Cell[],
+    currentPlayer: 'X',
+    winner: null,
+    isDraw: false,
+    winningLine: null,
+  }
+}
+
+export function checkWinner(board: Board): { winner: Player | null; line: number[] | null } {
+  for (const line of WINNING_LINES) {
+    const [a, b, c] = line
+    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
+      return { winner: board[a] as Player, line }
+    }
+  }
+  return { winner: null, line: null }
+}
+
+export function checkDraw(board: Board): boolean {
+  return board.every((cell) => cell !== null)
+}
+
+export function makeMove(state: GameState, index: number): GameState {
+  if (state.board[index] !== null || state.winner !== null || state.isDraw) {
+    return state
+  }
+
+  const newBoard = [...state.board] as Board
+  newBoard[index] = state.currentPlayer
+
+  const { winner, line } = checkWinner(newBoard)
+  const isDraw = !winner && checkDraw(newBoard)
+
+  return {
+    board: newBoard,
+    currentPlayer: state.currentPlayer === 'X' ? 'O' : 'X',
+    winner,
+    isDraw,
+    winningLine: line,
+  }
+}
+
+// Minimax for perfect AI play
+function minimax(board: Board, isMaximizing: boolean, aiPlayer: Player): number {
+  const humanPlayer: Player = aiPlayer === 'O' ? 'X' : 'O'
+  const { winner } = checkWinner(board)
+
+  if (winner === aiPlayer) return 10
+  if (winner === humanPlayer) return -10
+  if (checkDraw(board)) return 0
+
+  const scores: number[] = []
+  for (let i = 0; i < 9; i++) {
+    if (board[i] !== null) continue
+    const next = [...board] as Board
+    next[i] = isMaximizing ? aiPlayer : humanPlayer
+    scores.push(minimax(next, !isMaximizing, aiPlayer))
+  }
+
+  return isMaximizing ? Math.max(...scores) : Math.min(...scores)
+}
+
+export function getAIMove(board: Board, aiPlayer: Player): number {
+  let bestScore = -Infinity
+  let bestMove = -1
+
+  for (let i = 0; i < 9; i++) {
+    if (board[i] !== null) continue
+    const next = [...board] as Board
+    next[i] = aiPlayer
+    const score = minimax(next, false, aiPlayer)
+    if (score > bestScore) {
+      bestScore = score
+      bestMove = i
+    }
+  }
+
+  return bestMove
+}
+
+export function isGameOver(state: GameState): boolean {
+  return state.winner !== null || state.isDraw
+}


### PR DESCRIPTION
## Summary

- Adds a fully playable Tic-Tac-Toe game at `/games/tic-tac-toe`
- **Single-player mode**: player (X) vs unbeatable minimax AI (O) with a natural 400ms thinking delay
- **Two-player mode**: local co-op, players alternate X and O on the same device
- Mode selection screen shown on load; both modes support Restart and Change Mode actions
- Winning cells highlighted in green; status bar shows current turn, winner, or draw

## Implementation

- `src/data/games.ts` — added game metadata (live, single-player category, ⭕ emoji)
- `src/games/tic-tac-toe/logic.ts` — pure functions: `createInitialState`, `makeMove`, `checkWinner`, `checkDraw`, `isGameOver`, `getAIMove` (minimax)
- `src/games/tic-tac-toe/logic.test.ts` — 23 unit tests covering all logic paths
- `src/games/tic-tac-toe/TicTacToeGame.tsx` — `'use client'` React component
- `src/app/games/tic-tac-toe/page.tsx` — route wrapping game in `GameLayout`

## Test plan

- [ ] All 192 tests pass (`pnpm test`)
- [ ] Lint clean (`pnpm lint`)
- [ ] Single-player: AI always responds after ~400ms; AI cannot be beaten with perfect play
- [ ] Two-player: turns alternate correctly between X and O
- [ ] Win condition highlights the winning three cells
- [ ] Draw is detected and displayed
- [ ] Restart resets the board; Change Mode returns to the mode selection screen

https://claude.ai/code/session_01XpexD242AvxAm14cuKn332