### PR TITLE
ci: build and upload artifact on every commit, deploy only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
   build:
     name: Build
     needs: lint-and-test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -91,6 +90,7 @@ jobs:
   deploy:
     name: Deploy
     needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- Removed the `main`-only gate from the `build` job so it runs on every push and PR
- `deploy` job retains the `main`-only condition, using the artifact from the same workflow run
- No rebuild on merge to main — `actions/deploy-pages` picks up the uploaded artifact directly

## Test plan
- [ ] Push to a feature branch — verify `lint-and-test` and `build` jobs both run and artifact is uploaded
- [ ] Open a PR — verify same two jobs run and pass
- [ ] Merge to `main` — verify `deploy` runs immediately after `build` without a separate rebuild step

https://claude.ai/code/session_014jRnzFLTRDuMri8TU8DF7U