### PR TITLE
feat: implement Skribbl drawing & guessing game

### DIFF
--- a/src/app/games/skribbl/page.tsx
+++ b/src/app/games/skribbl/page.tsx
@@ -1,0 +1,10 @@
+import { GameLayout } from '@/components/GameLayout'
+import { SkribblGame } from '@/games/skribbl/SkribblGame'
+
+export default function SkribblPage() {
+  return (
+    <GameLayout title="Skribbl">
+      <SkribblGame />
+    </GameLayout>
+  )
+}

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -117,7 +117,7 @@ export const games: GameMeta[] = [
     title: 'Skribbl',
     description: 'Draw and guess with friends online. Pictionary-style fun for everyone.',
     tags: ['multiplayer', 'drawing'],
-    status: 'coming-soon',
+    status: 'live',
     category: 'online-multiplayer',
     emoji: '🎨',
   },

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -1,0 +1,991 @@
+'use client'
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+import { isSupabaseConfigured } from '@/lib/supabase'
+import { useSkribblRoom } from './useSkribblRoom'
+import { getCurrentDrawer, type DrawStroke, type DrawPoint, type GameState } from './logic'
+
+// ─── Drawing Canvas ───────────────────────────────────────────────────────────
+
+const COLORS = [
+  '#000000',
+  '#FFFFFF',
+  '#808080',
+  '#C0C0C0',
+  '#800000',
+  '#FF0000',
+  '#FF6600',
+  '#FFCC00',
+  '#FFFF00',
+  '#00FF00',
+  '#008000',
+  '#00FFFF',
+  '#0000FF',
+  '#800080',
+  '#FF00FF',
+  '#FF69B4',
+]
+
+const BRUSH_SIZES = [3, 6, 12, 24]
+
+interface CanvasProps {
+  strokes: DrawStroke[]
+  isDrawer: boolean
+  onStrokeComplete: (stroke: DrawStroke) => void
+  onClear: () => void
+  onUndo: () => void
+}
+
+function DrawingCanvas({ strokes, isDrawer, onStrokeComplete, onClear, onUndo }: CanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [color, setColor] = useState('#000000')
+  const [brushSize, setBrushSize] = useState(6)
+  const [tool, setTool] = useState<'pen' | 'eraser'>('pen')
+  const [isDrawing, setIsDrawing] = useState(false)
+  const currentStrokeRef = useRef<DrawPoint[]>([])
+
+  const drawAll = useCallback(
+    (ctx: CanvasRenderingContext2D, allStrokes: DrawStroke[], currentPoints?: DrawPoint[]) => {
+      ctx.fillStyle = '#FFFFFF'
+      ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+
+      const toDraw = [...allStrokes]
+      if (currentPoints && currentPoints.length > 0) {
+        toDraw.push({ points: currentPoints })
+      }
+
+      for (const stroke of toDraw) {
+        if (stroke.points.length === 0) continue
+        ctx.beginPath()
+        ctx.lineCap = 'round'
+        ctx.lineJoin = 'round'
+
+        const first = stroke.points[0]
+        ctx.strokeStyle = first.tool === 'eraser' ? '#FFFFFF' : first.color
+        ctx.lineWidth = first.size
+
+        ctx.moveTo(first.x, first.y)
+        for (let i = 1; i < stroke.points.length; i++) {
+          ctx.lineTo(stroke.points[i].x, stroke.points[i].y)
+        }
+        if (stroke.points.length === 1) {
+          ctx.lineTo(first.x + 0.1, first.y + 0.1)
+        }
+        ctx.stroke()
+      }
+    },
+    []
+  )
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    drawAll(ctx, strokes)
+  }, [strokes, drawAll])
+
+  function getPos(e: React.MouseEvent | React.TouchEvent): { x: number; y: number } | null {
+    const canvas = canvasRef.current
+    if (!canvas) return null
+    const rect = canvas.getBoundingClientRect()
+    const scaleX = canvas.width / rect.width
+    const scaleY = canvas.height / rect.height
+    if ('touches' in e) {
+      const touch = e.touches[0] || e.changedTouches[0]
+      return {
+        x: (touch.clientX - rect.left) * scaleX,
+        y: (touch.clientY - rect.top) * scaleY,
+      }
+    }
+    return {
+      x: (e.clientX - rect.left) * scaleX,
+      y: (e.clientY - rect.top) * scaleY,
+    }
+  }
+
+  function handleStart(e: React.MouseEvent | React.TouchEvent) {
+    if (!isDrawer) return
+    e.preventDefault()
+    const pos = getPos(e)
+    if (!pos) return
+    setIsDrawing(true)
+    const point: DrawPoint = {
+      x: pos.x,
+      y: pos.y,
+      color: tool === 'eraser' ? '#FFFFFF' : color,
+      size: brushSize,
+      tool,
+    }
+    currentStrokeRef.current = [point]
+
+    const ctx = canvasRef.current?.getContext('2d')
+    if (ctx) drawAll(ctx, strokes, currentStrokeRef.current)
+  }
+
+  function handleMove(e: React.MouseEvent | React.TouchEvent) {
+    if (!isDrawing || !isDrawer) return
+    e.preventDefault()
+    const pos = getPos(e)
+    if (!pos) return
+    const point: DrawPoint = {
+      x: pos.x,
+      y: pos.y,
+      color: tool === 'eraser' ? '#FFFFFF' : color,
+      size: brushSize,
+      tool,
+    }
+    currentStrokeRef.current.push(point)
+
+    const ctx = canvasRef.current?.getContext('2d')
+    if (ctx) drawAll(ctx, strokes, currentStrokeRef.current)
+  }
+
+  function handleEnd() {
+    if (!isDrawing || !isDrawer) return
+    setIsDrawing(false)
+    if (currentStrokeRef.current.length > 0) {
+      onStrokeComplete({ points: currentStrokeRef.current })
+      currentStrokeRef.current = []
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="overflow-hidden rounded-xl border-2 border-border bg-white shadow-inner">
+        <canvas
+          ref={canvasRef}
+          width={600}
+          height={400}
+          className={cn(
+            'h-auto w-full touch-none',
+            isDrawer ? 'cursor-crosshair' : 'cursor-default'
+          )}
+          onMouseDown={handleStart}
+          onMouseMove={handleMove}
+          onMouseUp={handleEnd}
+          onMouseLeave={handleEnd}
+          onTouchStart={handleStart}
+          onTouchMove={handleMove}
+          onTouchEnd={handleEnd}
+        />
+      </div>
+
+      {isDrawer && (
+        <div className="flex flex-wrap items-center justify-center gap-2 rounded-xl bg-secondary/60 p-2">
+          {/* Colors */}
+          <div className="flex flex-wrap gap-1">
+            {COLORS.map((c) => (
+              <button
+                key={c}
+                onClick={() => {
+                  setColor(c)
+                  setTool('pen')
+                }}
+                className={cn(
+                  'h-6 w-6 rounded-full border-2 transition-transform hover:scale-110',
+                  color === c && tool === 'pen'
+                    ? 'scale-110 border-foreground'
+                    : 'border-transparent'
+                )}
+                style={{ backgroundColor: c }}
+                title={c}
+              />
+            ))}
+          </div>
+
+          <div className="mx-1 h-6 w-px bg-border" />
+
+          {/* Brush sizes */}
+          <div className="flex items-center gap-1">
+            {BRUSH_SIZES.map((s) => (
+              <button
+                key={s}
+                onClick={() => setBrushSize(s)}
+                className={cn(
+                  'flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+                  brushSize === s ? 'bg-foreground/20' : 'hover:bg-foreground/10'
+                )}
+                title={`Size ${s}`}
+              >
+                <div
+                  className="rounded-full bg-foreground"
+                  style={{ width: Math.min(s, 20), height: Math.min(s, 20) }}
+                />
+              </button>
+            ))}
+          </div>
+
+          <div className="mx-1 h-6 w-px bg-border" />
+
+          {/* Tools */}
+          <button
+            onClick={() => setTool(tool === 'eraser' ? 'pen' : 'eraser')}
+            className={cn(
+              'rounded-lg px-2 py-1 text-xs font-medium transition-colors',
+              tool === 'eraser' ? 'bg-foreground/20 text-foreground' : 'hover:bg-foreground/10'
+            )}
+          >
+            {tool === 'eraser' ? 'Eraser' : 'Eraser'}
+          </button>
+          <button
+            onClick={onUndo}
+            className="rounded-lg px-2 py-1 text-xs font-medium hover:bg-foreground/10"
+          >
+            Undo
+          </button>
+          <button
+            onClick={onClear}
+            className="rounded-lg px-2 py-1 text-xs font-medium text-red-500 hover:bg-red-500/10"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Chat / Guess Panel ───────────────────────────────────────────────────────
+
+interface ChatPanelProps {
+  messages: GameState['messages']
+  isDrawer: boolean
+  hasGuessed: boolean
+  onGuess: (text: string) => void
+}
+
+function ChatPanel({ messages, isDrawer, hasGuessed, onGuess }: ChatPanelProps) {
+  const [input, setInput] = useState('')
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [messages.length])
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!input.trim()) return
+    onGuess(input)
+    setInput('')
+  }
+
+  const canGuess = !isDrawer && !hasGuessed
+
+  return (
+    <div className="flex h-full flex-col rounded-xl border bg-background">
+      <div className="border-b px-3 py-2 text-xs font-semibold text-muted-foreground">Chat</div>
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-2" style={{ minHeight: 200 }}>
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={cn(
+              'mb-1 rounded-lg px-2 py-1 text-xs',
+              msg.isCorrect &&
+                'bg-emerald-100 font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+              msg.isSystem && !msg.isCorrect && 'italic text-muted-foreground'
+            )}
+          >
+            {!msg.isSystem && <span className="mr-1 font-semibold">{msg.playerName}:</span>}
+            {msg.text}
+          </div>
+        ))}
+        {messages.length === 0 && (
+          <p className="py-4 text-center text-xs text-muted-foreground">
+            {isDrawer ? 'Players will guess here' : 'Type your guesses below'}
+          </p>
+        )}
+      </div>
+      <form onSubmit={handleSubmit} className="border-t p-2">
+        <div className="flex gap-1">
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={
+              isDrawer ? "You're drawing!" : hasGuessed ? 'Already guessed!' : 'Type your guess...'
+            }
+            disabled={!canGuess}
+            maxLength={50}
+            className="flex-1 rounded-lg border bg-background px-2 py-1.5 text-xs outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50"
+          />
+          <button
+            type="submit"
+            disabled={!canGuess || !input.trim()}
+            className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+          >
+            Send
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+// ─── Scoreboard ───────────────────────────────────────────────────────────────
+
+interface ScoreboardProps {
+  players: GameState['players']
+  currentDrawerId: string | null
+  guessedPlayers: string[]
+  playerId: string
+}
+
+function Scoreboard({ players, currentDrawerId, guessedPlayers, playerId }: ScoreboardProps) {
+  const sorted = [...players].sort((a, b) => b.score - a.score)
+  return (
+    <div className="rounded-xl border bg-background">
+      <div className="border-b px-3 py-2 text-xs font-semibold text-muted-foreground">
+        Scoreboard
+      </div>
+      <div className="p-2">
+        {sorted.map((p, i) => (
+          <div
+            key={p.id}
+            className={cn(
+              'flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs',
+              p.id === playerId && 'bg-primary/10'
+            )}
+          >
+            <span className="w-4 text-center font-bold text-muted-foreground">{i + 1}</span>
+            <span
+              className={cn(
+                'h-2 w-2 rounded-full',
+                p.id === currentDrawerId
+                  ? 'bg-amber-400'
+                  : guessedPlayers.includes(p.id)
+                    ? 'bg-emerald-400'
+                    : 'bg-gray-300'
+              )}
+            />
+            <span className="flex-1 truncate font-medium">
+              {p.name}
+              {p.id === playerId && <span className="ml-1 text-muted-foreground">(you)</span>}
+            </span>
+            {p.id === currentDrawerId && (
+              <span className="text-[10px] text-amber-600 dark:text-amber-400">drawing</span>
+            )}
+            <span className="font-bold tabular-nums">{p.score}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ─── Timer ────────────────────────────────────────────────────────────────────
+
+interface TimerProps {
+  startTime: number
+  duration: number
+  onTimeUp: () => void
+}
+
+function Timer({ startTime, duration, onTimeUp }: TimerProps) {
+  const [remaining, setRemaining] = useState(duration)
+  const calledRef = useRef(false)
+
+  useEffect(() => {
+    calledRef.current = false
+    const interval = setInterval(() => {
+      const elapsed = (Date.now() - startTime) / 1000
+      const left = Math.max(0, duration - elapsed)
+      setRemaining(Math.ceil(left))
+      if (left <= 0 && !calledRef.current) {
+        calledRef.current = true
+        onTimeUp()
+      }
+    }, 250)
+    return () => clearInterval(interval)
+  }, [startTime, duration, onTimeUp])
+
+  const pct = (remaining / duration) * 100
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-2 flex-1 overflow-hidden rounded-full bg-secondary">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-300',
+            pct > 50 ? 'bg-emerald-500' : pct > 20 ? 'bg-amber-500' : 'bg-red-500'
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span
+        className={cn(
+          'min-w-[2rem] text-center text-sm font-bold tabular-nums',
+          remaining <= 10 && 'text-red-500'
+        )}
+      >
+        {remaining}s
+      </span>
+    </div>
+  )
+}
+
+// ─── Screens ──────────────────────────────────────────────────────────────────
+
+function SetupRequired() {
+  return (
+    <div className="mx-auto max-w-md rounded-2xl border bg-secondary/40 p-6 text-center">
+      <div className="mb-3 text-4xl">🔧</div>
+      <h2 className="mb-2 text-lg font-bold">Supabase setup required</h2>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Online multiplayer requires a Supabase project. Create a free project at{' '}
+        <span className="font-medium text-foreground">supabase.com</span>, run the schema from{' '}
+        <code className="rounded bg-secondary px-1 text-xs">supabase-schema.sql</code>, then set:
+      </p>
+      <pre className="rounded-lg bg-secondary p-3 text-left text-xs">
+        {`NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co\nNEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...`}
+      </pre>
+    </div>
+  )
+}
+
+interface EntryScreenProps {
+  onCreate: (name: string) => void
+  onJoin: (code: string, name: string) => void
+  onRestore?: () => void
+  savedSession: { roomCode: string; playerName: string } | null
+  loading: boolean
+  error: string | null
+}
+
+function EntryScreen({
+  onCreate,
+  onJoin,
+  onRestore,
+  savedSession,
+  loading,
+  error,
+}: EntryScreenProps) {
+  const [name, setName] = useState('')
+  const [joinCode, setJoinCode] = useState('')
+  const [mode, setMode] = useState<'choose' | 'create' | 'join'>('choose')
+
+  if (mode === 'choose') {
+    return (
+      <div className="flex flex-col items-center gap-6">
+        <div className="text-center">
+          <div className="mb-3 text-5xl">🎨</div>
+          <h2 className="text-xl font-black tracking-tight">Skribbl Online</h2>
+          <p className="text-sm text-muted-foreground">2-8 players &middot; Draw & Guess</p>
+        </div>
+        {savedSession && (
+          <button
+            onClick={onRestore}
+            className="w-64 rounded-xl border-2 border-dashed border-primary/40 px-6 py-3 text-center text-sm transition-colors hover:bg-secondary"
+          >
+            <div className="font-semibold">Resume session</div>
+            <div className="text-xs text-muted-foreground">
+              {savedSession.playerName} &middot; Room {savedSession.roomCode}
+            </div>
+          </button>
+        )}
+        <div className="flex gap-3">
+          <button
+            onClick={() => setMode('create')}
+            className="flex w-36 flex-col items-center gap-2 rounded-2xl bg-secondary px-6 py-5 text-center font-semibold transition-all hover:bg-secondary/70 hover:shadow-lg active:scale-95"
+          >
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+              <span className="text-2xl">+</span>
+            </div>
+            <span>Create Room</span>
+            <span className="text-xs font-normal text-muted-foreground">Host a game</span>
+          </button>
+          <button
+            onClick={() => setMode('join')}
+            className="flex w-36 flex-col items-center gap-2 rounded-2xl bg-secondary px-6 py-5 text-center font-semibold transition-all hover:bg-secondary/70 hover:shadow-lg active:scale-95"
+          >
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+              <span className="text-2xl">&rarr;</span>
+            </div>
+            <span>Join Room</span>
+            <span className="text-xs font-normal text-muted-foreground">Enter a code</span>
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const isCreate = mode === 'create'
+  return (
+    <div className="flex w-72 flex-col gap-4">
+      <button
+        onClick={() => setMode('choose')}
+        className="self-start text-sm text-muted-foreground hover:text-foreground"
+      >
+        &larr; Back
+      </button>
+      <h2 className="text-lg font-bold">{isCreate ? 'Create Room' : 'Join Room'}</h2>
+      {error && (
+        <p className="rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
+      )}
+      <label className="flex flex-col gap-1">
+        <span className="text-xs font-medium text-muted-foreground">Your name</span>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Enter your name"
+          maxLength={16}
+          className="rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/40"
+        />
+      </label>
+      {!isCreate && (
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-muted-foreground">Room code</span>
+          <input
+            value={joinCode}
+            onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+            placeholder="e.g. AB12"
+            maxLength={4}
+            className="rounded-lg border bg-background px-3 py-2 text-sm uppercase tracking-widest outline-none focus:ring-2 focus:ring-primary/40"
+          />
+        </label>
+      )}
+      <button
+        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
+        onClick={() => {
+          if (isCreate) onCreate(name.trim())
+          else onJoin(joinCode, name.trim())
+        }}
+        className="rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition-opacity disabled:opacity-50"
+      >
+        {loading ? 'Connecting\u2026' : isCreate ? 'Create Room' : 'Join Room'}
+      </button>
+    </div>
+  )
+}
+
+interface LobbyScreenProps {
+  gameState: GameState
+  playerId: string
+  roomCode: string
+  onStart: () => void
+  onLeave: () => void
+}
+
+function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyScreenProps) {
+  const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
+  const [copied, setCopied] = useState(false)
+
+  function copyCode() {
+    navigator.clipboard.writeText(roomCode).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className="flex w-80 flex-col gap-5">
+      <div className="rounded-2xl bg-secondary p-5 text-center">
+        <p className="mb-1 text-xs font-medium text-muted-foreground">
+          Room code &mdash; share with friends
+        </p>
+        <p className="mb-3 text-4xl font-black tracking-widest">{roomCode}</p>
+        <button
+          onClick={copyCode}
+          className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+        >
+          {copied ? 'Copied!' : 'Copy code'}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <p className="text-xs font-medium text-muted-foreground">
+          Players ({gameState.players.length}/8)
+        </p>
+        {gameState.players.map((p, i) => (
+          <div
+            key={p.id}
+            className="flex items-center gap-2 rounded-lg bg-secondary px-3 py-2 text-sm"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            <span
+              className={cn('h-2 w-2 rounded-full', p.isHost ? 'bg-amber-400' : 'bg-green-400')}
+            />
+            <span className="font-medium">{p.name}</span>
+            {p.isHost && <span className="ml-auto text-xs text-muted-foreground">host</span>}
+            {p.id === playerId && !p.isHost && (
+              <span className="ml-auto text-xs text-muted-foreground">you</span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {isHost && gameState.players.length < 2 && (
+        <p className="text-center text-xs text-muted-foreground">
+          Waiting for at least one more player&hellip;
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        {isHost && (
+          <button
+            disabled={gameState.players.length < 2}
+            onClick={onStart}
+            className="flex-1 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition-opacity disabled:opacity-40"
+          >
+            Start Game
+          </button>
+        )}
+        {!isHost && (
+          <p className="flex-1 text-center text-sm text-muted-foreground">
+            Waiting for host to start&hellip;
+          </p>
+        )}
+        <button
+          onClick={onLeave}
+          className="rounded-lg border px-4 py-2.5 text-sm font-semibold hover:bg-secondary"
+        >
+          Leave
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Word Picker ──────────────────────────────────────────────────────────────
+
+interface WordPickerProps {
+  words: string[]
+  onPick: (word: string) => void
+}
+
+function WordPicker({ words, onPick }: WordPickerProps) {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="text-center">
+        <h2 className="text-lg font-bold">Choose a word to draw</h2>
+        <p className="text-sm text-muted-foreground">Pick one of the three options</p>
+      </div>
+      <div className="flex gap-3">
+        {words.map((word) => (
+          <button
+            key={word}
+            onClick={() => onPick(word)}
+            className="rounded-xl bg-secondary px-6 py-4 text-sm font-bold transition-all hover:bg-primary hover:text-primary-foreground hover:shadow-lg active:scale-95"
+          >
+            {word}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ─── Round End Screen ─────────────────────────────────────────────────────────
+
+interface RoundEndProps {
+  gameState: GameState
+  playerId: string
+  onNext: () => void
+  onLeave: () => void
+}
+
+function RoundEndScreen({ gameState, playerId, onNext, onLeave }: RoundEndProps) {
+  const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
+  const drawer = getCurrentDrawer(gameState)
+
+  return (
+    <div className="flex flex-col items-center gap-5">
+      <div className="text-center">
+        <h2 className="text-xl font-bold">Time&apos;s up!</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The word was: <span className="font-bold text-foreground">{gameState.word}</span>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {drawer?.name} was drawing &middot; Round {gameState.round}/{gameState.totalRounds}
+        </p>
+      </div>
+
+      <Scoreboard
+        players={gameState.players}
+        currentDrawerId={null}
+        guessedPlayers={[]}
+        playerId={playerId}
+      />
+
+      <div className="flex gap-3">
+        {isHost ? (
+          <button
+            onClick={onNext}
+            className="rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground active:scale-95"
+          >
+            Next Turn
+          </button>
+        ) : (
+          <p className="text-sm text-muted-foreground">Waiting for host&hellip;</p>
+        )}
+        <button
+          onClick={onLeave}
+          className="rounded-lg border px-5 py-2.5 text-sm font-semibold hover:bg-secondary"
+        >
+          Leave
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Finished Screen ──────────────────────────────────────────────────────────
+
+interface FinishedScreenProps {
+  gameState: GameState
+  playerId: string
+  onPlayAgain: () => void
+  onLeave: () => void
+}
+
+function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedScreenProps) {
+  const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
+  const sorted = [...gameState.players].sort((a, b) => b.score - a.score)
+  const winner = sorted[0]
+  const isWinner = winner?.id === playerId
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <div className="text-6xl">{isWinner ? '\uD83C\uDFC6' : '\uD83C\uDFAE'}</div>
+      <div className="text-center">
+        <h2 className="text-2xl font-black">
+          {isWinner ? 'You win!' : `${winner?.name ?? '?'} wins!`}
+        </h2>
+        <p className="text-sm text-muted-foreground">Final score: {winner?.score ?? 0} points</p>
+      </div>
+
+      <div className="w-72">
+        <Scoreboard
+          players={gameState.players}
+          currentDrawerId={null}
+          guessedPlayers={[]}
+          playerId={playerId}
+        />
+      </div>
+
+      <div className="flex gap-3">
+        {isHost ? (
+          <button
+            onClick={onPlayAgain}
+            className="rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground active:scale-95"
+          >
+            Play Again
+          </button>
+        ) : (
+          <p className="text-sm text-muted-foreground">Waiting for host&hellip;</p>
+        )}
+        <button
+          onClick={onLeave}
+          className="rounded-lg border px-5 py-2.5 text-sm font-semibold hover:bg-secondary"
+        >
+          Leave
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Game Board (drawing phase) ───────────────────────────────────────────────
+
+interface GameBoardProps {
+  gameState: GameState
+  playerId: string
+  dispatch: (action: Parameters<ReturnType<typeof useSkribblRoom>['dispatch']>[0]) => void
+  onLeave: () => void
+}
+
+function GameBoardScreen({ gameState, playerId, dispatch, onLeave }: GameBoardProps) {
+  const drawer = getCurrentDrawer(gameState)
+  const isDrawer = drawer?.id === playerId
+  const hasGuessed = gameState.guessedPlayers.includes(playerId)
+
+  const handleTimeUp = useCallback(() => {
+    dispatch({ type: 'END_TURN', playerId })
+  }, [dispatch, playerId])
+
+  return (
+    <div className="flex w-full max-w-5xl flex-col gap-3 px-2">
+      {/* Top bar: round, hint/word, timer */}
+      <div className="flex items-center gap-3 rounded-xl bg-secondary/60 px-4 py-2">
+        <span className="text-xs font-semibold text-muted-foreground">
+          Round {gameState.round}/{gameState.totalRounds}
+        </span>
+        <div className="flex-1 text-center">
+          {isDrawer ? (
+            <span className="text-sm font-bold">
+              Draw: <span className="text-primary">{gameState.word}</span>
+            </span>
+          ) : (
+            <span className="text-lg font-bold tracking-[0.3em]">{gameState.hint}</span>
+          )}
+        </div>
+        <div className="w-32">
+          {gameState.drawStartTime && (
+            <Timer
+              startTime={gameState.drawStartTime}
+              duration={gameState.turnDuration}
+              onTimeUp={handleTimeUp}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Main layout: scoreboard | canvas | chat */}
+      <div className="flex flex-col gap-3 lg:flex-row">
+        {/* Scoreboard */}
+        <div className="w-full shrink-0 lg:w-44">
+          <Scoreboard
+            players={gameState.players}
+            currentDrawerId={drawer?.id ?? null}
+            guessedPlayers={gameState.guessedPlayers}
+            playerId={playerId}
+          />
+        </div>
+
+        {/* Canvas */}
+        <div className="flex-1">
+          <DrawingCanvas
+            strokes={gameState.strokes}
+            isDrawer={isDrawer}
+            onStrokeComplete={(stroke) => dispatch({ type: 'ADD_STROKE', playerId, stroke })}
+            onClear={() => dispatch({ type: 'CLEAR_CANVAS', playerId })}
+            onUndo={() => dispatch({ type: 'UNDO_STROKE', playerId })}
+          />
+        </div>
+
+        {/* Chat */}
+        <div className="w-full shrink-0 lg:w-56">
+          <ChatPanel
+            messages={gameState.messages}
+            isDrawer={isDrawer}
+            hasGuessed={hasGuessed}
+            onGuess={(text) => dispatch({ type: 'GUESS', playerId, text })}
+          />
+        </div>
+      </div>
+
+      {/* Status + leave */}
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">
+          {isDrawer
+            ? "You're drawing!"
+            : hasGuessed
+              ? 'You guessed it! Waiting for others...'
+              : `${drawer?.name} is drawing`}
+        </p>
+        <button
+          onClick={onLeave}
+          className="rounded-lg border px-3 py-1.5 text-xs hover:bg-secondary"
+        >
+          Leave
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function SkribblGame() {
+  const {
+    gameState,
+    playerId,
+    roomCode,
+    status,
+    error,
+    savedSession,
+    createRoom,
+    joinRoom,
+    restoreSession,
+    dispatch,
+    leaveRoom,
+  } = useSkribblRoom()
+
+  if (!isSupabaseConfigured) return <SetupRequired />
+
+  const isLoading = status === 'creating' || status === 'joining' || status === 'restoring'
+
+  if (!gameState || !playerId || !roomCode) {
+    return (
+      <EntryScreen
+        onCreate={createRoom}
+        onJoin={joinRoom}
+        onRestore={savedSession ? restoreSession : undefined}
+        savedSession={savedSession}
+        loading={isLoading}
+        error={error}
+      />
+    )
+  }
+
+  if (gameState.phase === 'lobby') {
+    return (
+      <LobbyScreen
+        gameState={gameState}
+        playerId={playerId}
+        roomCode={roomCode}
+        onStart={() => dispatch({ type: 'START_GAME', playerId })}
+        onLeave={leaveRoom}
+      />
+    )
+  }
+
+  if (gameState.phase === 'picking') {
+    const drawer = getCurrentDrawer(gameState)
+    const isDrawer = drawer?.id === playerId
+
+    if (isDrawer) {
+      return (
+        <WordPicker
+          words={gameState.wordChoices}
+          onPick={(word) => dispatch({ type: 'PICK_WORD', playerId, word })}
+        />
+      )
+    }
+
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <div className="text-5xl">🎨</div>
+        <h2 className="text-lg font-bold">{drawer?.name} is picking a word...</h2>
+        <p className="text-sm text-muted-foreground">Get ready to guess!</p>
+      </div>
+    )
+  }
+
+  if (gameState.phase === 'drawing') {
+    return (
+      <GameBoardScreen
+        gameState={gameState}
+        playerId={playerId}
+        dispatch={dispatch}
+        onLeave={leaveRoom}
+      />
+    )
+  }
+
+  if (gameState.phase === 'round-end') {
+    return (
+      <RoundEndScreen
+        gameState={gameState}
+        playerId={playerId}
+        onNext={() => dispatch({ type: 'NEXT_TURN', playerId })}
+        onLeave={leaveRoom}
+      />
+    )
+  }
+
+  if (gameState.phase === 'finished') {
+    return (
+      <FinishedScreen
+        gameState={gameState}
+        playerId={playerId}
+        onPlayAgain={() => dispatch({ type: 'PLAY_AGAIN', playerId })}
+        onLeave={leaveRoom}
+      />
+    )
+  }
+
+  return null
+}

--- a/src/games/skribbl/logic.test.ts
+++ b/src/games/skribbl/logic.test.ts
@@ -1,0 +1,407 @@
+import {
+  createLobbyState,
+  addPlayer,
+  removePlayer,
+  applyAction,
+  generateHint,
+  revealHintLetters,
+  calculateGuessScore,
+  calculateDrawerScore,
+  pickRandomWords,
+  getCurrentDrawer,
+  type Player,
+  type GameState,
+} from './logic'
+
+function makeHost(): Player {
+  return { id: 'host', name: 'Host', isHost: true, score: 0 }
+}
+
+function makePlayer(id: string, name: string): Player {
+  return { id, name, isHost: false, score: 0 }
+}
+
+function lobbyWithPlayers(): GameState {
+  let state = createLobbyState(makeHost())
+  state = addPlayer(state, makePlayer('p2', 'Player2'))
+  state = addPlayer(state, makePlayer('p3', 'Player3'))
+  return state
+}
+
+function startedGame(): GameState {
+  const state = lobbyWithPlayers()
+  return applyAction(state, { type: 'START_GAME', playerId: 'host' })
+}
+
+describe('createLobbyState', () => {
+  it('creates lobby with host', () => {
+    const state = createLobbyState(makeHost())
+    expect(state.phase).toBe('lobby')
+    expect(state.players).toHaveLength(1)
+    expect(state.players[0].isHost).toBe(true)
+    expect(state.round).toBe(1)
+    expect(state.totalRounds).toBe(3)
+  })
+})
+
+describe('addPlayer', () => {
+  it('adds a player to lobby', () => {
+    const state = createLobbyState(makeHost())
+    const next = addPlayer(state, makePlayer('p2', 'Player2'))
+    expect(next.players).toHaveLength(2)
+  })
+
+  it('does not add duplicate', () => {
+    const state = createLobbyState(makeHost())
+    const next = addPlayer(state, makePlayer('host', 'Host'))
+    expect(next.players).toHaveLength(1)
+  })
+
+  it('caps at 8 players', () => {
+    let state = createLobbyState(makeHost())
+    for (let i = 2; i <= 8; i++) {
+      state = addPlayer(state, makePlayer(`p${i}`, `P${i}`))
+    }
+    expect(state.players).toHaveLength(8)
+    const next = addPlayer(state, makePlayer('p9', 'P9'))
+    expect(next.players).toHaveLength(8)
+  })
+
+  it('does not add during non-lobby phase', () => {
+    const state = startedGame()
+    const next = addPlayer(state, makePlayer('p4', 'P4'))
+    expect(next.players).toHaveLength(3)
+  })
+})
+
+describe('removePlayer', () => {
+  it('removes a player', () => {
+    const state = lobbyWithPlayers()
+    const next = removePlayer(state, 'p2')
+    expect(next.players).toHaveLength(2)
+  })
+
+  it('adjusts drawer index when removing before it', () => {
+    let state = lobbyWithPlayers()
+    state = { ...state, currentDrawerIndex: 2 }
+    const next = removePlayer(state, 'p2')
+    expect(next.currentDrawerIndex).toBe(1)
+  })
+
+  it('no-ops for unknown player', () => {
+    const state = lobbyWithPlayers()
+    const next = removePlayer(state, 'unknown')
+    expect(next).toBe(state)
+  })
+})
+
+describe('START_GAME', () => {
+  it('transitions to picking phase', () => {
+    const state = startedGame()
+    expect(state.phase).toBe('picking')
+    expect(state.wordChoices).toHaveLength(3)
+  })
+
+  it('only host can start', () => {
+    const state = lobbyWithPlayers()
+    const next = applyAction(state, { type: 'START_GAME', playerId: 'p2' })
+    expect(next.phase).toBe('lobby')
+  })
+
+  it('needs at least 2 players', () => {
+    const state = createLobbyState(makeHost())
+    const next = applyAction(state, { type: 'START_GAME', playerId: 'host' })
+    expect(next.phase).toBe('lobby')
+  })
+
+  it('resets scores on start', () => {
+    let state = lobbyWithPlayers()
+    state = { ...state, players: state.players.map((p) => ({ ...p, score: 100 })) }
+    const next = applyAction(state, { type: 'START_GAME', playerId: 'host' })
+    expect(next.players.every((p) => p.score === 0)).toBe(true)
+  })
+})
+
+describe('PICK_WORD', () => {
+  it('transitions to drawing phase', () => {
+    const state = startedGame()
+    const drawer = getCurrentDrawer(state)!
+    const word = state.wordChoices[0]
+    const next = applyAction(state, { type: 'PICK_WORD', playerId: drawer.id, word })
+    expect(next.phase).toBe('drawing')
+    expect(next.word).toBe(word)
+    expect(next.hint).toBeTruthy()
+    expect(next.drawStartTime).toBeTruthy()
+  })
+
+  it('only drawer can pick', () => {
+    const state = startedGame()
+    const word = state.wordChoices[0]
+    const next = applyAction(state, { type: 'PICK_WORD', playerId: 'p2', word })
+    expect(next.phase).toBe('picking')
+  })
+
+  it('rejects word not in choices', () => {
+    const state = startedGame()
+    const drawer = getCurrentDrawer(state)!
+    const next = applyAction(state, { type: 'PICK_WORD', playerId: drawer.id, word: 'zzzzz' })
+    expect(next.phase).toBe('picking')
+  })
+})
+
+describe('ADD_STROKE / CLEAR_CANVAS / UNDO_STROKE', () => {
+  function drawingState(): GameState {
+    const state = startedGame()
+    const drawer = getCurrentDrawer(state)!
+    return applyAction(state, {
+      type: 'PICK_WORD',
+      playerId: drawer.id,
+      word: state.wordChoices[0],
+    })
+  }
+
+  it('drawer can add strokes', () => {
+    const state = drawingState()
+    const drawer = getCurrentDrawer(state)!
+    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
+    const next = applyAction(state, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
+    expect(next.strokes).toHaveLength(1)
+  })
+
+  it('non-drawer cannot add strokes', () => {
+    const state = drawingState()
+    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
+    const next = applyAction(state, { type: 'ADD_STROKE', playerId: 'p2', stroke })
+    expect(next.strokes).toHaveLength(0)
+  })
+
+  it('drawer can clear canvas', () => {
+    const state = drawingState()
+    const drawer = getCurrentDrawer(state)!
+    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
+    let next = applyAction(state, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
+    next = applyAction(next, { type: 'CLEAR_CANVAS', playerId: drawer.id })
+    expect(next.strokes).toHaveLength(0)
+  })
+
+  it('drawer can undo last stroke', () => {
+    const state = drawingState()
+    const drawer = getCurrentDrawer(state)!
+    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
+    let next = applyAction(state, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
+    next = applyAction(next, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
+    expect(next.strokes).toHaveLength(2)
+    next = applyAction(next, { type: 'UNDO_STROKE', playerId: drawer.id })
+    expect(next.strokes).toHaveLength(1)
+  })
+})
+
+describe('GUESS', () => {
+  function drawingState(): GameState {
+    const state = startedGame()
+    const drawer = getCurrentDrawer(state)!
+    return applyAction(state, {
+      type: 'PICK_WORD',
+      playerId: drawer.id,
+      word: state.wordChoices[0],
+    })
+  }
+
+  it('correct guess awards score and adds system message', () => {
+    const state = drawingState()
+    const word = state.word!
+    const next = applyAction(state, { type: 'GUESS', playerId: 'p2', text: word })
+    expect(next.guessedPlayers).toContain('p2')
+    expect(next.players.find((p) => p.id === 'p2')!.score).toBeGreaterThan(0)
+    expect(next.messages.some((m) => m.isCorrect)).toBe(true)
+  })
+
+  it('wrong guess adds chat message', () => {
+    const state = drawingState()
+    const next = applyAction(state, { type: 'GUESS', playerId: 'p2', text: 'wrongguess' })
+    expect(next.guessedPlayers).not.toContain('p2')
+    expect(next.messages).toHaveLength(1)
+    expect(next.messages[0].text).toBe('wrongguess')
+  })
+
+  it('drawer cannot guess', () => {
+    const state = drawingState()
+    const drawer = getCurrentDrawer(state)!
+    const next = applyAction(state, { type: 'GUESS', playerId: drawer.id, text: state.word! })
+    expect(next.guessedPlayers).toHaveLength(0)
+  })
+
+  it('player cannot guess twice', () => {
+    const state = drawingState()
+    const word = state.word!
+    let next = applyAction(state, { type: 'GUESS', playerId: 'p2', text: word })
+    const score = next.players.find((p) => p.id === 'p2')!.score
+    next = applyAction(next, { type: 'GUESS', playerId: 'p2', text: word })
+    expect(next.players.find((p) => p.id === 'p2')!.score).toBe(score)
+  })
+
+  it('ends turn when all players guess correctly', () => {
+    const state = drawingState()
+    const word = state.word!
+    let next = applyAction(state, { type: 'GUESS', playerId: 'p2', text: word })
+    next = applyAction(next, { type: 'GUESS', playerId: 'p3', text: word })
+    expect(next.phase).toBe('round-end')
+  })
+
+  it('case insensitive matching', () => {
+    const state = drawingState()
+    const word = state.word!
+    const next = applyAction(state, { type: 'GUESS', playerId: 'p2', text: word.toUpperCase() })
+    expect(next.guessedPlayers).toContain('p2')
+  })
+})
+
+describe('END_TURN', () => {
+  it('transitions to round-end', () => {
+    const state = startedGame()
+    const drawer = getCurrentDrawer(state)!
+    let next = applyAction(state, {
+      type: 'PICK_WORD',
+      playerId: drawer.id,
+      word: state.wordChoices[0],
+    })
+    next = applyAction(next, { type: 'END_TURN', playerId: 'host' })
+    expect(next.phase).toBe('round-end')
+  })
+})
+
+describe('NEXT_TURN', () => {
+  function roundEndState(): GameState {
+    let state = startedGame()
+    const drawer = getCurrentDrawer(state)!
+    state = applyAction(state, {
+      type: 'PICK_WORD',
+      playerId: drawer.id,
+      word: state.wordChoices[0],
+    })
+    state = applyAction(state, { type: 'END_TURN', playerId: 'host' })
+    return state
+  }
+
+  it('advances to next drawer', () => {
+    const state = roundEndState()
+    const next = applyAction(state, { type: 'NEXT_TURN', playerId: 'host' })
+    expect(next.phase).toBe('picking')
+    expect(next.currentDrawerIndex).toBe(1)
+  })
+
+  it('only host can advance', () => {
+    const state = roundEndState()
+    const next = applyAction(state, { type: 'NEXT_TURN', playerId: 'p2' })
+    expect(next.phase).toBe('round-end')
+  })
+
+  it('advances round after all players draw', () => {
+    let state = startedGame()
+    // Go through all 3 players in round 1
+    for (let i = 0; i < 3; i++) {
+      const drawer = getCurrentDrawer(state)!
+      state = applyAction(state, {
+        type: 'PICK_WORD',
+        playerId: drawer.id,
+        word: state.wordChoices[0],
+      })
+      state = applyAction(state, { type: 'END_TURN', playerId: 'host' })
+      state = applyAction(state, { type: 'NEXT_TURN', playerId: 'host' })
+    }
+    expect(state.round).toBe(2)
+    expect(state.currentDrawerIndex).toBe(0)
+  })
+
+  it('finishes game after all rounds', () => {
+    let state = startedGame()
+    // 3 rounds × 3 players = 9 turns
+    for (let r = 0; r < 3; r++) {
+      for (let i = 0; i < 3; i++) {
+        const drawer = getCurrentDrawer(state)!
+        state = applyAction(state, {
+          type: 'PICK_WORD',
+          playerId: drawer.id,
+          word: state.wordChoices[0],
+        })
+        state = applyAction(state, { type: 'END_TURN', playerId: 'host' })
+        if (r === 2 && i === 2) break // last turn goes to finished
+        state = applyAction(state, { type: 'NEXT_TURN', playerId: 'host' })
+      }
+    }
+    expect(state.phase).toBe('round-end')
+    state = applyAction(state, { type: 'NEXT_TURN', playerId: 'host' })
+    expect(state.phase).toBe('finished')
+  })
+})
+
+describe('PLAY_AGAIN', () => {
+  it('restarts from finished state', () => {
+    let state = startedGame()
+    state = { ...state, phase: 'finished' }
+    const next = applyAction(state, { type: 'PLAY_AGAIN', playerId: 'host' })
+    expect(next.phase).toBe('picking')
+    expect(next.round).toBe(1)
+    expect(next.players.every((p) => p.score === 0)).toBe(true)
+  })
+})
+
+describe('generateHint', () => {
+  it('generates underscores for letters', () => {
+    expect(generateHint('apple')).toBe('_ _ _ _ _')
+  })
+
+  it('preserves spaces', () => {
+    expect(generateHint('ice cream')).toBe('_ _ _    _ _ _ _ _')
+  })
+})
+
+describe('revealHintLetters', () => {
+  it('reveals specified number of letters', () => {
+    const hint = revealHintLetters('apple', 2)
+    const revealed = hint.split(' ').filter((ch) => ch !== '_' && ch !== '')
+    expect(revealed.length).toBe(2)
+  })
+})
+
+describe('calculateGuessScore', () => {
+  it('gives higher score for faster guesses', () => {
+    const fast = calculateGuessScore(1000, 80000, 3, 0)
+    const slow = calculateGuessScore(70000, 80000, 3, 0)
+    expect(fast).toBeGreaterThan(slow)
+  })
+
+  it('gives bonus for early guess order', () => {
+    const first = calculateGuessScore(10000, 80000, 3, 0)
+    const last = calculateGuessScore(10000, 80000, 3, 2)
+    expect(first).toBeGreaterThan(last)
+  })
+})
+
+describe('calculateDrawerScore', () => {
+  it('returns 0 when no one guessed', () => {
+    expect(calculateDrawerScore(0, 3)).toBe(0)
+  })
+
+  it('gives full score when all guessed', () => {
+    expect(calculateDrawerScore(3, 3)).toBe(100)
+  })
+
+  it('gives partial score', () => {
+    const score = calculateDrawerScore(1, 3)
+    expect(score).toBeGreaterThan(0)
+    expect(score).toBeLessThan(100)
+  })
+})
+
+describe('pickRandomWords', () => {
+  it('returns requested number of words', () => {
+    expect(pickRandomWords(3)).toHaveLength(3)
+  })
+
+  it('excludes specified words', () => {
+    const words = pickRandomWords(3, ['apple', 'banana'])
+    expect(words).not.toContain('apple')
+    expect(words).not.toContain('banana')
+  })
+})

--- a/src/games/skribbl/logic.ts
+++ b/src/games/skribbl/logic.ts
@@ -1,0 +1,492 @@
+let msgCounter = 0
+function generateMsgId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `msg-${Date.now()}-${++msgCounter}`
+}
+
+export type GamePhase = 'lobby' | 'picking' | 'drawing' | 'round-end' | 'finished'
+
+export interface Player {
+  id: string
+  name: string
+  isHost: boolean
+  score: number
+}
+
+export interface ChatMessage {
+  id: string
+  playerId: string
+  playerName: string
+  text: string
+  isCorrect?: boolean
+  isSystem?: boolean
+}
+
+export interface DrawPoint {
+  x: number
+  y: number
+  color: string
+  size: number
+  tool: 'pen' | 'eraser'
+}
+
+export interface DrawStroke {
+  points: DrawPoint[]
+}
+
+export interface GameState {
+  phase: GamePhase
+  players: Player[]
+  currentDrawerIndex: number
+  round: number
+  totalRounds: number
+  /** The word the drawer must draw (only visible to drawer client-side). */
+  word: string | null
+  /** Word choices offered to the drawer during picking phase. */
+  wordChoices: string[]
+  /** Hint shown to guessers: e.g. "_ _ _ _ _" */
+  hint: string
+  /** Strokes on the canvas — synced to all players. */
+  strokes: DrawStroke[]
+  /** Chat / guess messages. */
+  messages: ChatMessage[]
+  /** Player IDs who guessed correctly this turn. */
+  guessedPlayers: string[]
+  /** Timestamp (ms) when the drawing phase started. */
+  drawStartTime: number | null
+  /** Seconds allowed per turn. */
+  turnDuration: number
+  /** When the turn ended (null if still active). */
+  turnEndTime: number | null
+}
+
+export type GameAction =
+  | { type: 'START_GAME'; playerId: string }
+  | { type: 'PICK_WORD'; playerId: string; word: string }
+  | { type: 'ADD_STROKE'; playerId: string; stroke: DrawStroke }
+  | { type: 'CLEAR_CANVAS'; playerId: string }
+  | { type: 'UNDO_STROKE'; playerId: string }
+  | { type: 'GUESS'; playerId: string; text: string }
+  | { type: 'END_TURN'; playerId: string }
+  | { type: 'NEXT_TURN'; playerId: string }
+  | { type: 'PLAY_AGAIN'; playerId: string }
+
+// ─── Word list ────────────────────────────────────────────────────────────────
+
+const WORDS = [
+  'apple',
+  'banana',
+  'guitar',
+  'castle',
+  'dragon',
+  'rocket',
+  'bridge',
+  'flower',
+  'island',
+  'pirate',
+  'sunset',
+  'turtle',
+  'wizard',
+  'candle',
+  'forest',
+  'hammer',
+  'ladder',
+  'mirror',
+  'pencil',
+  'planet',
+  'rabbit',
+  'shield',
+  'spider',
+  'trophy',
+  'camera',
+  'cherry',
+  'crown',
+  'diamond',
+  'elephant',
+  'fountain',
+  'ghost',
+  'helmet',
+  'iceberg',
+  'jellyfish',
+  'kite',
+  'lighthouse',
+  'mushroom',
+  'notebook',
+  'octopus',
+  'penguin',
+  'rainbow',
+  'snowflake',
+  'telescope',
+  'umbrella',
+  'volcano',
+  'waterfall',
+  'anchor',
+  'butterfly',
+  'compass',
+  'dolphin',
+  'eagle',
+  'firework',
+  'giraffe',
+  'helicopter',
+  'keyboard',
+  'lantern',
+  'mountain',
+  'necklace',
+  'parachute',
+  'sailboat',
+  'tornado',
+  'unicorn',
+  'windmill',
+  'airplane',
+  'backpack',
+  'cactus',
+  'drumstick',
+  'envelope',
+  'flamingo',
+  'grapes',
+  'hourglass',
+  'igloo',
+  'juggler',
+  'kangaroo',
+  'lemon',
+  'mermaid',
+  'ninja',
+  'owl',
+  'pineapple',
+  'queen',
+  'robot',
+  'starfish',
+  'train',
+  'violin',
+  'whale',
+  'zebra',
+  'astronaut',
+  'bowling',
+  'cupcake',
+  'dinosaur',
+  'feather',
+  'goldfish',
+  'horseshoe',
+  'icecream',
+  'jigsaw',
+  'koala',
+  'lobster',
+  'magnet',
+  'newspaper',
+  'pumpkin',
+  'scarecrow',
+  'treasure',
+  'waffle',
+  'xylophone',
+  'yacht',
+  'zipper',
+  'bathtub',
+  'chandelier',
+  'dominoes',
+  'escalator',
+  'frying pan',
+  'globe',
+  'hammock',
+  'island',
+  'jukebox',
+  'kayak',
+  'lollipop',
+  'mailbox',
+  'nest',
+  'oven',
+  'puzzle',
+  'quicksand',
+  'rollercoaster',
+  'sandwich',
+  'toaster',
+  'vacuum',
+  'wrench',
+]
+
+export function pickRandomWords(count: number, exclude: string[] = []): string[] {
+  const available = WORDS.filter((w) => !exclude.includes(w))
+  const shuffled = [...available].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, count)
+}
+
+export function generateHint(word: string): string {
+  return word
+    .split('')
+    .map((ch) => (ch === ' ' ? '  ' : '_'))
+    .join(' ')
+}
+
+export function revealHintLetters(word: string, revealCount: number): string {
+  const indices: number[] = []
+  for (let i = 0; i < word.length; i++) {
+    if (word[i] !== ' ') indices.push(i)
+  }
+  const shuffled = [...indices].sort(() => Math.random() - 0.5)
+  const toReveal = new Set(shuffled.slice(0, revealCount))
+
+  return word
+    .split('')
+    .map((ch, i) => {
+      if (ch === ' ') return '  '
+      if (toReveal.has(i)) return ch
+      return '_'
+    })
+    .join(' ')
+}
+
+// ─── Scoring ──────────────────────────────────────────────────────────────────
+
+export function calculateGuessScore(
+  elapsedMs: number,
+  turnDurationMs: number,
+  totalGuessers: number,
+  guessOrder: number
+): number {
+  const timeRatio = Math.max(0, 1 - elapsedMs / turnDurationMs)
+  const baseScore = Math.round(100 + 400 * timeRatio)
+  const orderBonus = Math.max(0, Math.round(50 * (1 - guessOrder / totalGuessers)))
+  return baseScore + orderBonus
+}
+
+export function calculateDrawerScore(guessedCount: number, totalGuessers: number): number {
+  if (totalGuessers === 0 || guessedCount === 0) return 0
+  return Math.round(100 * (guessedCount / totalGuessers))
+}
+
+// ─── State helpers ────────────────────────────────────────────────────────────
+
+export function createLobbyState(host: Player): GameState {
+  return {
+    phase: 'lobby',
+    players: [{ ...host, score: 0 }],
+    currentDrawerIndex: 0,
+    round: 1,
+    totalRounds: 3,
+    word: null,
+    wordChoices: [],
+    hint: '',
+    strokes: [],
+    messages: [],
+    guessedPlayers: [],
+    drawStartTime: null,
+    turnDuration: 80,
+    turnEndTime: null,
+  }
+}
+
+export function addPlayer(state: GameState, player: Player): GameState {
+  if (state.phase !== 'lobby') return state
+  if (state.players.some((p) => p.id === player.id)) return state
+  if (state.players.length >= 8) return state
+  return { ...state, players: [...state.players, { ...player, score: 0 }] }
+}
+
+export function removePlayer(state: GameState, playerId: string): GameState {
+  const idx = state.players.findIndex((p) => p.id === playerId)
+  if (idx === -1) return state
+  const players = state.players.filter((p) => p.id !== playerId)
+  let drawerIdx = state.currentDrawerIndex
+  if (idx < drawerIdx) drawerIdx--
+  if (drawerIdx >= players.length) drawerIdx = 0
+  return { ...state, players, currentDrawerIndex: drawerIdx }
+}
+
+export function getCurrentDrawer(state: GameState): Player | null {
+  return state.players[state.currentDrawerIndex] ?? null
+}
+
+function startPickingPhase(state: GameState): GameState {
+  const choices = pickRandomWords(3)
+  return {
+    ...state,
+    phase: 'picking',
+    wordChoices: choices,
+    word: null,
+    hint: '',
+    strokes: [],
+    guessedPlayers: [],
+    drawStartTime: null,
+    turnEndTime: null,
+  }
+}
+
+function advanceToNextTurn(state: GameState): GameState {
+  const nextDrawerIdx = state.currentDrawerIndex + 1
+  if (nextDrawerIdx >= state.players.length) {
+    // End of round
+    if (state.round >= state.totalRounds) {
+      return { ...state, phase: 'finished' }
+    }
+    return startPickingPhase({
+      ...state,
+      round: state.round + 1,
+      currentDrawerIndex: 0,
+    })
+  }
+  return startPickingPhase({
+    ...state,
+    currentDrawerIndex: nextDrawerIdx,
+  })
+}
+
+// ─── Action dispatcher ────────────────────────────────────────────────────────
+
+export function applyAction(state: GameState, action: GameAction): GameState {
+  const host = state.players.find((p) => p.isHost)
+
+  if (action.type === 'START_GAME') {
+    if (host?.id !== action.playerId) return state
+    if (state.phase !== 'lobby') return state
+    if (state.players.length < 2) return state
+    return startPickingPhase({
+      ...state,
+      players: state.players.map((p) => ({ ...p, score: 0 })),
+      round: 1,
+      currentDrawerIndex: 0,
+      messages: [],
+    })
+  }
+
+  if (action.type === 'PLAY_AGAIN') {
+    if (host?.id !== action.playerId) return state
+    if (state.phase !== 'finished') return state
+    return startPickingPhase({
+      ...state,
+      players: state.players.map((p) => ({ ...p, score: 0 })),
+      round: 1,
+      currentDrawerIndex: 0,
+      messages: [],
+    })
+  }
+
+  if (action.type === 'PICK_WORD') {
+    if (state.phase !== 'picking') return state
+    const drawer = getCurrentDrawer(state)
+    if (drawer?.id !== action.playerId) return state
+    if (!state.wordChoices.includes(action.word)) return state
+    return {
+      ...state,
+      phase: 'drawing',
+      word: action.word,
+      wordChoices: [],
+      hint: generateHint(action.word),
+      drawStartTime: Date.now(),
+    }
+  }
+
+  if (action.type === 'ADD_STROKE') {
+    if (state.phase !== 'drawing') return state
+    const drawer = getCurrentDrawer(state)
+    if (drawer?.id !== action.playerId) return state
+    return { ...state, strokes: [...state.strokes, action.stroke] }
+  }
+
+  if (action.type === 'CLEAR_CANVAS') {
+    if (state.phase !== 'drawing') return state
+    const drawer = getCurrentDrawer(state)
+    if (drawer?.id !== action.playerId) return state
+    return { ...state, strokes: [] }
+  }
+
+  if (action.type === 'UNDO_STROKE') {
+    if (state.phase !== 'drawing') return state
+    const drawer = getCurrentDrawer(state)
+    if (drawer?.id !== action.playerId) return state
+    if (state.strokes.length === 0) return state
+    return { ...state, strokes: state.strokes.slice(0, -1) }
+  }
+
+  if (action.type === 'GUESS') {
+    if (state.phase !== 'drawing') return state
+    const drawer = getCurrentDrawer(state)
+    if (drawer?.id === action.playerId) return state // drawer can't guess
+    if (state.guessedPlayers.includes(action.playerId)) return state // already guessed
+
+    const player = state.players.find((p) => p.id === action.playerId)
+    if (!player) return state
+
+    const guess = action.text.trim().toLowerCase()
+    const answer = (state.word ?? '').toLowerCase()
+
+    // Check if correct
+    if (guess === answer) {
+      const elapsed = Date.now() - (state.drawStartTime ?? Date.now())
+      const totalGuessers = state.players.length - 1
+      const guessOrder = state.guessedPlayers.length
+      const guessScore = calculateGuessScore(
+        elapsed,
+        state.turnDuration * 1000,
+        totalGuessers,
+        guessOrder
+      )
+      const newGuessedPlayers = [...state.guessedPlayers, action.playerId]
+
+      // Update scores
+      const drawerBonus = calculateDrawerScore(newGuessedPlayers.length, totalGuessers)
+      const players = state.players.map((p) => {
+        if (p.id === action.playerId) return { ...p, score: p.score + guessScore }
+        if (p.id === drawer?.id) {
+          const prevBonus = calculateDrawerScore(state.guessedPlayers.length, totalGuessers)
+          return { ...p, score: p.score - prevBonus + drawerBonus }
+        }
+        return p
+      })
+
+      const msg: ChatMessage = {
+        id: generateMsgId(),
+        playerId: action.playerId,
+        playerName: player.name,
+        text: `${player.name} guessed the word!`,
+        isCorrect: true,
+        isSystem: true,
+      }
+
+      const allGuessed = newGuessedPlayers.length >= totalGuessers
+      const newState: GameState = {
+        ...state,
+        players,
+        guessedPlayers: newGuessedPlayers,
+        messages: [...state.messages, msg],
+      }
+
+      if (allGuessed) {
+        return {
+          ...newState,
+          phase: 'round-end',
+          turnEndTime: Date.now(),
+        }
+      }
+
+      return newState
+    }
+
+    // Wrong guess — add as chat message
+    const msg: ChatMessage = {
+      id: generateMsgId(),
+      playerId: action.playerId,
+      playerName: player.name,
+      text: action.text.trim(),
+    }
+    return { ...state, messages: [...state.messages, msg] }
+  }
+
+  if (action.type === 'END_TURN') {
+    if (state.phase !== 'drawing') return state
+    // Anyone can trigger end turn (timer expiry)
+    return {
+      ...state,
+      phase: 'round-end',
+      turnEndTime: Date.now(),
+    }
+  }
+
+  if (action.type === 'NEXT_TURN') {
+    if (state.phase !== 'round-end') return state
+    if (host?.id !== action.playerId) return state
+    return advanceToNextTurn(state)
+  }
+
+  return state
+}

--- a/src/games/skribbl/useSkribblRoom.ts
+++ b/src/games/skribbl/useSkribblRoom.ts
@@ -1,0 +1,259 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import {
+  addPlayer,
+  applyAction,
+  createLobbyState,
+  type GameAction,
+  type GameState,
+  type Player,
+} from './logic'
+
+const SESSION_KEY = 'skribbl_session'
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000
+
+interface Session {
+  roomCode: string
+  playerId: string
+  playerName: string
+  ts: number
+}
+
+function saveSession(session: Omit<Session, 'ts'>) {
+  try {
+    localStorage.setItem(SESSION_KEY, JSON.stringify({ ...session, ts: Date.now() }))
+  } catch {}
+}
+
+function loadSession(): Session | null {
+  try {
+    const raw = localStorage.getItem(SESSION_KEY)
+    if (!raw) return null
+    const data: Session = JSON.parse(raw)
+    if (Date.now() - data.ts > SESSION_TTL_MS) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+function clearSession() {
+  try {
+    localStorage.removeItem(SESSION_KEY)
+  } catch {}
+}
+
+function generateRoomCode(): string {
+  return Math.random().toString(36).substring(2, 6).toUpperCase()
+}
+
+export type RoomStatus = 'idle' | 'restoring' | 'creating' | 'joining' | 'connected' | 'error'
+
+export interface UseSkribblRoomReturn {
+  gameState: GameState | null
+  playerId: string | null
+  roomCode: string | null
+  status: RoomStatus
+  error: string | null
+  savedSession: Session | null
+  createRoom: (playerName: string) => Promise<void>
+  joinRoom: (code: string, playerName: string) => Promise<void>
+  restoreSession: () => Promise<void>
+  dispatch: (action: GameAction) => Promise<void>
+  leaveRoom: () => void
+}
+
+export function useSkribblRoom(): UseSkribblRoomReturn {
+  const [gameState, setGameState] = useState<GameState | null>(null)
+  const [playerId, setPlayerId] = useState<string | null>(null)
+  const [roomCode, setRoomCode] = useState<string | null>(null)
+  const [status, setStatus] = useState<RoomStatus>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const [savedSession, setSavedSession] = useState<Session | null>(null)
+  const channelRef = useRef<ReturnType<NonNullable<typeof supabase>['channel']> | null>(null)
+
+  useEffect(() => {
+    setSavedSession(loadSession())
+  }, [])
+
+  function subscribeToRoom(code: string) {
+    if (!supabase) return
+    channelRef.current?.unsubscribe()
+    channelRef.current = supabase
+      .channel(`skribbl:${code}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'skribbl_rooms',
+          filter: `code=eq.${code}`,
+        },
+        (payload) => {
+          setGameState(payload.new.state as GameState)
+        }
+      )
+      .subscribe()
+  }
+
+  const createRoom = useCallback(async (playerName: string) => {
+    if (!supabase) return
+    setStatus('creating')
+    setError(null)
+
+    const id = crypto.randomUUID()
+    const code = generateRoomCode()
+    const host: Player = { id, name: playerName, isHost: true, score: 0 }
+    const initialState = createLobbyState(host)
+
+    const { error: err } = await supabase
+      .from('skribbl_rooms')
+      .insert({ code, state: initialState })
+
+    if (err) {
+      setError('Failed to create room. Try again.')
+      setStatus('error')
+      return
+    }
+
+    setPlayerId(id)
+    setRoomCode(code)
+    setGameState(initialState)
+    setStatus('connected')
+    saveSession({ roomCode: code, playerId: id, playerName })
+    subscribeToRoom(code)
+  }, [])
+
+  const joinRoom = useCallback(async (code: string, playerName: string) => {
+    if (!supabase) return
+    setStatus('joining')
+    setError(null)
+
+    const normalizedCode = code.trim().toUpperCase()
+    const { data, error: err } = await supabase
+      .from('skribbl_rooms')
+      .select('state')
+      .eq('code', normalizedCode)
+      .single()
+
+    if (err || !data) {
+      setError('Room not found. Check the code and try again.')
+      setStatus('error')
+      return
+    }
+
+    const currentState = data.state as GameState
+
+    if (currentState.phase !== 'lobby') {
+      setError('This game has already started.')
+      setStatus('error')
+      return
+    }
+
+    const id = crypto.randomUUID()
+    const player: Player = { id, name: playerName, isHost: false, score: 0 }
+    const newState = addPlayer(currentState, player)
+
+    if (newState.players.length === currentState.players.length) {
+      setError('Room is full.')
+      setStatus('error')
+      return
+    }
+
+    const { error: updateErr } = await supabase
+      .from('skribbl_rooms')
+      .update({ state: newState })
+      .eq('code', normalizedCode)
+
+    if (updateErr) {
+      setError('Failed to join room. Try again.')
+      setStatus('error')
+      return
+    }
+
+    setPlayerId(id)
+    setRoomCode(normalizedCode)
+    setGameState(newState)
+    setStatus('connected')
+    saveSession({ roomCode: normalizedCode, playerId: id, playerName })
+    subscribeToRoom(normalizedCode)
+  }, [])
+
+  const restoreSession = useCallback(async () => {
+    const session = loadSession()
+    if (!session || !supabase) return
+    setStatus('restoring')
+
+    const { data } = await supabase
+      .from('skribbl_rooms')
+      .select('state')
+      .eq('code', session.roomCode)
+      .single()
+
+    if (!data) {
+      clearSession()
+      setSavedSession(null)
+      setStatus('idle')
+      return
+    }
+
+    const state = data.state as GameState
+    const stillInGame = state.players.some((p) => p.id === session.playerId)
+    if (!stillInGame) {
+      clearSession()
+      setSavedSession(null)
+      setStatus('idle')
+      return
+    }
+
+    setPlayerId(session.playerId)
+    setRoomCode(session.roomCode)
+    setGameState(state)
+    setStatus('connected')
+    subscribeToRoom(session.roomCode)
+  }, [])
+
+  const dispatch = useCallback(
+    async (action: GameAction) => {
+      if (!gameState || !roomCode || !supabase) return
+      const newState = applyAction(gameState, action)
+      if (newState === gameState) return
+      await supabase.from('skribbl_rooms').update({ state: newState }).eq('code', roomCode)
+    },
+    [gameState, roomCode]
+  )
+
+  const leaveRoom = useCallback(() => {
+    channelRef.current?.unsubscribe()
+    channelRef.current = null
+    setGameState(null)
+    setPlayerId(null)
+    setRoomCode(null)
+    setStatus('idle')
+    setError(null)
+    clearSession()
+    setSavedSession(null)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      channelRef.current?.unsubscribe()
+    }
+  }, [])
+
+  return {
+    gameState,
+    playerId,
+    roomCode,
+    status,
+    error,
+    savedSession,
+    createRoom,
+    joinRoom,
+    restoreSession,
+    dispatch,
+    leaveRoom,
+  }
+}

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -69,3 +69,36 @@ create policy "update rooms" on uno_rooms for update using (true);
 -- Optional: auto-delete rooms older than 24 hours
 -- (run manually or schedule via pg_cron if you have it)
 -- delete from uno_rooms where updated_at < now() - interval '24 hours';
+
+-- ─── Skribbl rooms table ──────────────────────────────────────────────────────
+
+create table if not exists skribbl_rooms (
+  id         uuid        default gen_random_uuid() primary key,
+  code       text        unique not null,
+  state      jsonb       not null,
+  updated_at timestamptz default now()
+);
+
+create or replace trigger skribbl_rooms_updated_at
+  before update on skribbl_rooms
+  for each row execute function update_updated_at();
+
+create or replace trigger skribbl_rooms_protect_immutable
+  before update on skribbl_rooms
+  for each row execute function protect_immutable_columns();
+
+alter publication supabase_realtime add table skribbl_rooms;
+
+alter table skribbl_rooms enable row level security;
+
+create policy "select skribbl rooms" on skribbl_rooms for select using (true);
+
+create policy "insert skribbl rooms" on skribbl_rooms
+  for insert with check (
+    code ~ '^[A-Z0-9]{4}$'
+    and state is not null
+  );
+
+create policy "update skribbl rooms" on skribbl_rooms for update using (true);
+
+-- delete from skribbl_rooms where updated_at < now() - interval '24 hours';


### PR DESCRIPTION
## Summary
- Add full online multiplayer Skribbl (Pictionary-style) game with real-time Supabase sync
- Pure state machine with 5 phases: lobby → word picking → drawing → round-end → finished
- Drawing canvas with pen/eraser, 16 colors, 4 brush sizes, undo/clear, and touch support
- Chat/guess panel, live scoreboard, countdown timer, time-based scoring system
- 120+ word list, 3 word choices per turn, 80-second turns, 3 rounds, 2-8 players
- Supabase `skribbl_rooms` table with RLS policies (migration already applied)
- 41 unit tests for all game logic

## Test plan
- [x] All 41 logic tests pass (`pnpm test -- src/games/skribbl/logic.test.ts`)
- [x] ESLint + Prettier pass (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual test: create room, join from second browser, play full game
- [ ] Verify drawing syncs in real-time across clients
- [ ] Verify scoring, timer, and round progression

🤖 Generated with [Claude Code](https://claude.com/claude-code)