### PR TITLE
fix: constrain Skribbl chat panel height to prevent expanding

### DIFF
--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -276,9 +276,9 @@ function ChatPanel({ messages, isDrawer, hasGuessed, onGuess }: ChatPanelProps) 
   const canGuess = !isDrawer && !hasGuessed
 
   return (
-    <div className="flex h-full flex-col rounded-xl border bg-background">
+    <div className="flex max-h-[400px] flex-col rounded-xl border bg-background">
       <div className="border-b px-3 py-2 text-xs font-semibold text-muted-foreground">Chat</div>
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-2" style={{ minHeight: 200 }}>
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto p-2">
         {messages.map((msg) => (
           <div
             key={msg.id}


### PR DESCRIPTION
## Summary
- Cap the chat panel at `max-h-[400px]` (matching the canvas height) so messages scroll within a fixed container instead of pushing the layout downward.

## Test plan
- [ ] Manual test: send many chat messages/guesses and verify the chat panel stays at a fixed height and scrolls internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)