### PR TITLE
feat(uno): add 1-second grace window before Catch button appears

### DIFF
--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -930,12 +930,14 @@ export function UnoGame() {
         gameState={gameState}
         playerId={playerId}
         onDispatch={(cardId, chosenColor) =>
-          dispatch({ type: 'PLAY_CARD', playerId, cardId, chosenColor })
+          dispatch({ type: 'PLAY_CARD', playerId, cardId, chosenColor, now: Date.now() })
         }
         onDraw={() => dispatch({ type: 'DRAW_CARD', playerId })}
         onPassAfterDraw={() => dispatch({ type: 'PASS_AFTER_DRAW', playerId })}
         onSayUno={() => dispatch({ type: 'SAY_UNO', playerId })}
-        onCatchUno={(targetId) => dispatch({ type: 'CATCH_UNO', playerId, targetId })}
+        onCatchUno={(targetId) =>
+          dispatch({ type: 'CATCH_UNO', playerId, targetId, now: Date.now() })
+        }
         onLeave={leaveRoom}
       />
     </>

--- a/src/games/uno/logic.test.ts
+++ b/src/games/uno/logic.test.ts
@@ -542,18 +542,28 @@ describe('applyAction – CATCH_UNO', () => {
   it('is a no-op while the grace window has not expired', () => {
     let state = makePlayingState()
     state = injectHand(state, 'p2', [{ id: 'only', color: 'red', value: 1 }])
-    // Simulate a grace window ending 10 seconds in the future
-    state = { ...state, unoWindow: { p2: Date.now() + 10_000 } }
-    const next = applyAction(state, { type: 'CATCH_UNO', playerId: 'p1', targetId: 'p2' })
+    state = { ...state, unoWindow: { p2: 2000 } }
+    // now=1000 is before the window (2000), so catch is rejected
+    const next = applyAction(state, {
+      type: 'CATCH_UNO',
+      playerId: 'p1',
+      targetId: 'p2',
+      now: 1000,
+    })
     expect(next).toBe(state)
   })
 
   it('allows catch once the grace window has expired', () => {
     let state = makePlayingState()
     state = injectHand(state, 'p2', [{ id: 'only', color: 'red', value: 1 }])
-    // Simulate a grace window that already expired
-    state = { ...state, unoWindow: { p2: Date.now() - 1_000 } }
-    const next = applyAction(state, { type: 'CATCH_UNO', playerId: 'p1', targetId: 'p2' })
+    state = { ...state, unoWindow: { p2: 2000 } }
+    // now=3000 is after the window (2000), so catch succeeds
+    const next = applyAction(state, {
+      type: 'CATCH_UNO',
+      playerId: 'p1',
+      targetId: 'p2',
+      now: 3000,
+    })
     expect(next.hands['p2']).toHaveLength(3) // 1 + 2 penalty
   })
 })
@@ -566,23 +576,19 @@ describe('applyAction – unoWindow on PLAY_CARD', () => {
     const card2: Card = { id: 'c2', color: topCard.color as 'red', value: 2 }
     state = injectHand(state, 'p1', [card1, card2])
     state = { ...state, currentColor: topCard.color as 'red' }
-    const before = Date.now()
-    const next = applyAction(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'c1' })
-    expect(next.unoWindow['p1']).toBeGreaterThanOrEqual(before + 1000)
+    // Pass a fixed now so the assertion is deterministic
+    const next = applyAction(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'c1', now: 5000 })
+    expect(next.unoWindow['p1']).toBe(6000) // now + 1000
   })
 
-  it('clears unoWindow when a player plays down from 2 to more cards (not 1)', () => {
+  it('clears unoWindow when playing leaves more than 1 card', () => {
     let state = makePlayingState()
     const topCard = getTopCard(state)!
     const card1: Card = { id: 'c1', color: topCard.color as 'red', value: 1 }
     const card2: Card = { id: 'c2', color: topCard.color as 'red', value: 2 }
     const card3: Card = { id: 'c3', color: topCard.color as 'red', value: 3 }
     state = injectHand(state, 'p1', [card1, card2, card3])
-    state = {
-      ...state,
-      currentColor: topCard.color as 'red',
-      unoWindow: { p1: Date.now() + 99999 },
-    }
+    state = { ...state, currentColor: topCard.color as 'red', unoWindow: { p1: 99999 } }
     const next = applyAction(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'c1' })
     // Playing leaves 2 cards — window should be cleared (set to 0)
     expect(next.unoWindow['p1'] ?? 0).toBe(0)

--- a/src/games/uno/logic.ts
+++ b/src/games/uno/logic.ts
@@ -58,11 +58,11 @@ export interface GameState {
 }
 
 export type GameAction =
-  | { type: 'PLAY_CARD'; playerId: string; cardId: string; chosenColor?: CardColor }
+  | { type: 'PLAY_CARD'; playerId: string; cardId: string; chosenColor?: CardColor; now?: number }
   | { type: 'DRAW_CARD'; playerId: string }
   | { type: 'PASS_AFTER_DRAW'; playerId: string }
   | { type: 'SAY_UNO'; playerId: string }
-  | { type: 'CATCH_UNO'; playerId: string; targetId: string }
+  | { type: 'CATCH_UNO'; playerId: string; targetId: string; now?: number }
   | { type: 'START_GAME'; playerId: string }
   | { type: 'PLAY_AGAIN'; playerId: string }
 
@@ -282,7 +282,8 @@ export function applyAction(state: GameState, action: GameAction): GameState {
     if (targetHand.length !== 1) return state
     if (state.calledUno.includes(action.targetId)) return state
     // Respect the grace window — give the player time to say UNO themselves
-    if (Date.now() < (state.unoWindow[action.targetId] ?? 0)) return state
+    const catchTs = action.now ?? Date.now()
+    if (catchTs < (state.unoWindow[action.targetId] ?? 0)) return state
 
     // Penalty: target draws 2 cards
     const s = reshuffleIfNeeded(state)
@@ -418,10 +419,10 @@ export function applyAction(state: GameState, action: GameAction): GameState {
         newHand.length !== 1
           ? state.calledUno.filter((id) => id !== action.playerId)
           : state.calledUno,
-      // Grant a 2-second grace window when a player plays down to 1 card
+      // Grant a 1-second grace window when a player plays down to 1 card
       unoWindow:
         newHand.length === 1
-          ? { ...state.unoWindow, [action.playerId]: Date.now() + 1000 }
+          ? { ...state.unoWindow, [action.playerId]: (action.now ?? Date.now()) + 1000 }
           : { ...state.unoWindow, [action.playerId]: 0 },
     }
 


### PR DESCRIPTION
## Summary

- Adds a `unoWindow: Record<string, number>` field to `GameState` that stores per-player timestamps after which catching is allowed
- When a player plays down to 1 card, `PLAY_CARD` sets `unoWindow[playerId] = Date.now() + 1000`, giving them 1 second to click "UNO!" before opponents see the "Catch!" button
- `CATCH_UNO` rejects actions that arrive before the window expires (enforced in the pure state machine)
- `UnoGame.tsx` hides the "Catch!" button client-side using a one-shot `setTimeout`, re-rendering when the earliest window expires

## Test plan

- [ ] Run `pnpm test` — all 70 tests pass including 6 new ones covering the grace window
- [ ] Play a game: after playing down to 1 card, verify "Catch!" is invisible for ~1 second, then appears
- [ ] Verify calling "UNO!" within the window prevents the "Catch!" button from ever appearing

https://claude.ai/code/session_01Rv5g7CV9H7mAFMporajJSL