### PR TITLE
feat(#68): shareable invite links for multiplayer games

### DIFF
--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -471,17 +471,23 @@ function Lobby({
   const [copied, setCopied] = useState<'code' | 'link' | null>(null)
 
   function copyCode() {
-    navigator.clipboard.writeText(roomCode).then(() => {
-      setCopied('code')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(roomCode).then(
+      () => {
+        setCopied('code')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   function copyInviteLink() {
-    navigator.clipboard.writeText(getInviteLink('agario', roomCode)).then(() => {
-      setCopied('link')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(getInviteLink('agario', roomCode)).then(
+      () => {
+        setCopied('link')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   return (

--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
+import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { useAgarioRoom } from './useAgarioRoom'
 import {
   MAP_WIDTH,
@@ -467,6 +468,21 @@ function Lobby({
   onStart: () => void
 }) {
   const isHost = gameState.hostId === playerId
+  const [copied, setCopied] = useState<'code' | 'link' | null>(null)
+
+  function copyCode() {
+    navigator.clipboard.writeText(roomCode).then(() => {
+      setCopied('code')
+      setTimeout(() => setCopied(null), 2000)
+    })
+  }
+
+  function copyInviteLink() {
+    navigator.clipboard.writeText(getInviteLink('agario', roomCode)).then(() => {
+      setCopied('link')
+      setTimeout(() => setCopied(null), 2000)
+    })
+  }
 
   return (
     <div className="flex flex-col items-center gap-6">
@@ -474,6 +490,20 @@ function Lobby({
         <p className="mb-1 text-sm text-muted-foreground">Room Code</p>
         <p className="font-mono text-4xl font-bold tracking-widest">{roomCode}</p>
         <p className="mt-1 text-sm text-muted-foreground">Share this code with friends</p>
+        <div className="mt-2 flex justify-center gap-2">
+          <button
+            onClick={copyCode}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'code' ? 'Copied!' : 'Copy code'}
+          </button>
+          <button
+            onClick={copyInviteLink}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'link' ? 'Copied!' : 'Copy invite link'}
+          </button>
+        </div>
       </div>
 
       <div className="w-full max-w-xs">
@@ -601,9 +631,10 @@ export function AgarioGame() {
     leaveRoom,
   } = useAgarioRoom()
 
+  const inviteCode = useInviteCode()
   const [nameInput, setNameInput] = useState(getSavedPlayerName)
-  const [codeInput, setCodeInput] = useState('')
-  const [mode, setMode] = useState<'menu' | 'create' | 'join'>('menu')
+  const [codeInput, setCodeInput] = useState(inviteCode ?? '')
+  const [mode, setMode] = useState<'menu' | 'create' | 'join'>(inviteCode ? 'join' : 'menu')
 
   // Game state refs
   const mySnakeRef = useRef<SnakeState | null>(null)

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -269,17 +269,23 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
   const [copied, setCopied] = useState<'code' | 'link' | null>(null)
 
   function copyCode() {
-    navigator.clipboard.writeText(roomCode).then(() => {
-      setCopied('code')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(roomCode).then(
+      () => {
+        setCopied('code')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   function copyInviteLink() {
-    navigator.clipboard.writeText(getInviteLink('cards-against-humanity', roomCode)).then(() => {
-      setCopied('link')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(getInviteLink('cards-against-humanity', roomCode)).then(
+      () => {
+        setCopied('link')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   return (

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
+import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { useCAHRoom } from './useCAHRoom'
 import {
   getCzar,
@@ -141,6 +142,7 @@ interface EntryScreenProps {
   savedSession: { roomCode: string; playerName: string } | null
   loading: boolean
   error: string | null
+  initialCode?: string | null
 }
 
 function EntryScreen({
@@ -150,10 +152,11 @@ function EntryScreen({
   savedSession,
   loading,
   error,
+  initialCode,
 }: EntryScreenProps) {
   const [name, setName] = useState(getSavedPlayerName)
-  const [joinCode, setJoinCode] = useState('')
-  const [mode, setMode] = useState<'choose' | 'create' | 'join'>('choose')
+  const [joinCode, setJoinCode] = useState(initialCode ?? '')
+  const [mode, setMode] = useState<'choose' | 'create' | 'join'>(initialCode ? 'join' : 'choose')
 
   if (mode === 'choose') {
     return (
@@ -263,12 +266,19 @@ interface LobbyScreenProps {
 
 function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyScreenProps) {
   const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
-  const [copied, setCopied] = useState(false)
+  const [copied, setCopied] = useState<'code' | 'link' | null>(null)
 
   function copyCode() {
     navigator.clipboard.writeText(roomCode).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      setCopied('code')
+      setTimeout(() => setCopied(null), 2000)
+    })
+  }
+
+  function copyInviteLink() {
+    navigator.clipboard.writeText(getInviteLink('cards-against-humanity', roomCode)).then(() => {
+      setCopied('link')
+      setTimeout(() => setCopied(null), 2000)
     })
   }
 
@@ -279,12 +289,20 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
           Room code &mdash; share with friends
         </p>
         <p className="mb-3 text-4xl font-black tracking-widest">{roomCode}</p>
-        <button
-          onClick={copyCode}
-          className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
-        >
-          {copied ? 'Copied!' : 'Copy code'}
-        </button>
+        <div className="flex justify-center gap-2">
+          <button
+            onClick={copyCode}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'code' ? 'Copied!' : 'Copy code'}
+          </button>
+          <button
+            onClick={copyInviteLink}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'link' ? 'Copied!' : 'Copy invite link'}
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">
@@ -744,6 +762,7 @@ function ConfettiEffect() {
 // ─── Main component ─────────────────────────────────────────────────────────
 
 export function CardsAgainstHumanityGame() {
+  const inviteCode = useInviteCode()
   const {
     gameState,
     playerId,
@@ -773,6 +792,7 @@ export function CardsAgainstHumanityGame() {
           savedSession={savedSession}
           loading={isLoading}
           error={error}
+          initialCode={inviteCode}
         />
       </>
     )

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
+import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { useSkribblRoom } from './useSkribblRoom'
 import {
   getCurrentDrawer,
@@ -459,6 +460,7 @@ interface EntryScreenProps {
   savedSession: { roomCode: string; playerName: string } | null
   loading: boolean
   error: string | null
+  initialCode?: string | null
 }
 
 function EntryScreen({
@@ -468,10 +470,11 @@ function EntryScreen({
   savedSession,
   loading,
   error,
+  initialCode,
 }: EntryScreenProps) {
   const [name, setName] = useState(getSavedPlayerName)
-  const [joinCode, setJoinCode] = useState('')
-  const [mode, setMode] = useState<'choose' | 'create' | 'join'>('choose')
+  const [joinCode, setJoinCode] = useState(initialCode ?? '')
+  const [mode, setMode] = useState<'choose' | 'create' | 'join'>(initialCode ? 'join' : 'choose')
 
   if (mode === 'choose') {
     return (
@@ -578,12 +581,19 @@ interface LobbyScreenProps {
 
 function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyScreenProps) {
   const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
-  const [copied, setCopied] = useState(false)
+  const [copied, setCopied] = useState<'code' | 'link' | null>(null)
 
   function copyCode() {
     navigator.clipboard.writeText(roomCode).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      setCopied('code')
+      setTimeout(() => setCopied(null), 2000)
+    })
+  }
+
+  function copyInviteLink() {
+    navigator.clipboard.writeText(getInviteLink('skribbl', roomCode)).then(() => {
+      setCopied('link')
+      setTimeout(() => setCopied(null), 2000)
     })
   }
 
@@ -594,12 +604,20 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
           Room code &mdash; share with friends
         </p>
         <p className="mb-3 text-4xl font-black tracking-widest">{roomCode}</p>
-        <button
-          onClick={copyCode}
-          className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
-        >
-          {copied ? 'Copied!' : 'Copy code'}
-        </button>
+        <div className="flex justify-center gap-2">
+          <button
+            onClick={copyCode}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'code' ? 'Copied!' : 'Copy code'}
+          </button>
+          <button
+            onClick={copyInviteLink}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'link' ? 'Copied!' : 'Copy invite link'}
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">
@@ -930,6 +948,7 @@ function GameBoardScreen({ gameState, playerId, dispatch, onLeave }: GameBoardPr
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 export function SkribblGame() {
+  const inviteCode = useInviteCode()
   const {
     gameState,
     playerId,
@@ -957,6 +976,7 @@ export function SkribblGame() {
         savedSession={savedSession}
         loading={isLoading}
         error={error}
+        initialCode={inviteCode}
       />
     )
   }

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -584,17 +584,23 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
   const [copied, setCopied] = useState<'code' | 'link' | null>(null)
 
   function copyCode() {
-    navigator.clipboard.writeText(roomCode).then(() => {
-      setCopied('code')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(roomCode).then(
+      () => {
+        setCopied('code')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   function copyInviteLink() {
-    navigator.clipboard.writeText(getInviteLink('skribbl', roomCode)).then(() => {
-      setCopied('link')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(getInviteLink('skribbl', roomCode)).then(
+      () => {
+        setCopied('link')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   return (

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -379,17 +379,23 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
   const [copied, setCopied] = useState<'code' | 'link' | null>(null)
 
   function copyCode() {
-    navigator.clipboard.writeText(roomCode).then(() => {
-      setCopied('code')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(roomCode).then(
+      () => {
+        setCopied('code')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   function copyInviteLink() {
-    navigator.clipboard.writeText(getInviteLink('uno', roomCode)).then(() => {
-      setCopied('link')
-      setTimeout(() => setCopied(null), 2000)
-    })
+    navigator.clipboard.writeText(getInviteLink('uno', roomCode)).then(
+      () => {
+        setCopied('link')
+        setTimeout(() => setCopied(null), 2000)
+      },
+      () => {}
+    )
   }
 
   return (

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
+import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { useUnoRoom } from './useUnoRoom'
 import {
   canPlayCard,
@@ -242,6 +243,7 @@ interface EntryScreenProps {
   savedSession: { roomCode: string; playerName: string } | null
   loading: boolean
   error: string | null
+  initialCode?: string | null
 }
 
 function EntryScreen({
@@ -251,10 +253,11 @@ function EntryScreen({
   savedSession,
   loading,
   error,
+  initialCode,
 }: EntryScreenProps) {
   const [name, setName] = useState(getSavedPlayerName)
-  const [joinCode, setJoinCode] = useState('')
-  const [mode, setMode] = useState<'choose' | 'create' | 'join'>('choose')
+  const [joinCode, setJoinCode] = useState(initialCode ?? '')
+  const [mode, setMode] = useState<'choose' | 'create' | 'join'>(initialCode ? 'join' : 'choose')
 
   if (mode === 'choose') {
     return (
@@ -373,12 +376,19 @@ interface LobbyScreenProps {
 
 function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyScreenProps) {
   const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
-  const [copied, setCopied] = useState(false)
+  const [copied, setCopied] = useState<'code' | 'link' | null>(null)
 
   function copyCode() {
     navigator.clipboard.writeText(roomCode).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      setCopied('code')
+      setTimeout(() => setCopied(null), 2000)
+    })
+  }
+
+  function copyInviteLink() {
+    navigator.clipboard.writeText(getInviteLink('uno', roomCode)).then(() => {
+      setCopied('link')
+      setTimeout(() => setCopied(null), 2000)
     })
   }
 
@@ -389,12 +399,20 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
           Room code &mdash; share with friends
         </p>
         <p className="mb-3 text-4xl font-black tracking-widest">{roomCode}</p>
-        <button
-          onClick={copyCode}
-          className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
-        >
-          {copied ? 'Copied!' : 'Copy code'}
-        </button>
+        <div className="flex justify-center gap-2">
+          <button
+            onClick={copyCode}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'code' ? 'Copied!' : 'Copy code'}
+          </button>
+          <button
+            onClick={copyInviteLink}
+            className="rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors hover:bg-background"
+          >
+            {copied === 'link' ? 'Copied!' : 'Copy invite link'}
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">
@@ -863,6 +881,7 @@ function ConfettiEffect() {
 // ─── Main component ──────────────────────────────────────────────────────────
 
 export function UnoGame() {
+  const inviteCode = useInviteCode()
   const {
     gameState,
     playerId,
@@ -899,6 +918,7 @@ export function UnoGame() {
           savedSession={savedSession}
           loading={isLoading}
           error={error}
+          initialCode={inviteCode}
         />
       </>
     )

--- a/src/hooks/useInviteCode.test.ts
+++ b/src/hooks/useInviteCode.test.ts
@@ -1,0 +1,57 @@
+import { getInviteLink } from './useInviteCode'
+import { renderHook } from '@testing-library/react'
+import { useInviteCode } from './useInviteCode'
+
+describe('getInviteLink', () => {
+  it('builds a correct invite URL', () => {
+    const link = getInviteLink('uno', 'ABC123')
+    expect(link).toBe('http://localhost/library-games/games/uno?code=ABC123')
+  })
+})
+
+describe('useInviteCode', () => {
+  const originalLocation = window.location
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    })
+  })
+
+  it('returns null when no code param is present', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '' },
+      writable: true,
+    })
+    const { result } = renderHook(() => useInviteCode())
+    expect(result.current).toBeNull()
+  })
+
+  it('returns uppercased code from URL', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '?code=abc123' },
+      writable: true,
+    })
+    const { result } = renderHook(() => useInviteCode())
+    expect(result.current).toBe('ABC123')
+  })
+
+  it('returns null for empty code param', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '?code=' },
+      writable: true,
+    })
+    const { result } = renderHook(() => useInviteCode())
+    expect(result.current).toBeNull()
+  })
+
+  it('trims whitespace from code', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '?code=%20xyz%20' },
+      writable: true,
+    })
+    const { result } = renderHook(() => useInviteCode())
+    expect(result.current).toBe('XYZ')
+  })
+})

--- a/src/hooks/useInviteCode.ts
+++ b/src/hooks/useInviteCode.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Reads `?code=XXXX` from the current URL on mount.
+ * Returns the uppercased code or null if absent.
+ */
+export function useInviteCode(): string | null {
+  const [code, setCode] = useState<string | null>(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const raw = params.get('code')
+    if (raw && raw.trim().length > 0) {
+      setCode(raw.trim().toUpperCase())
+    }
+  }, [])
+
+  return code
+}
+
+/**
+ * Build a full invite link for the given game slug and room code.
+ * Uses window.location.origin + basePath so it works in any environment.
+ */
+export function getInviteLink(slug: string, roomCode: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : ''
+  return `${origin}/library-games/games/${slug}?code=${roomCode}`
+}

--- a/src/hooks/useInviteCode.ts
+++ b/src/hooks/useInviteCode.ts
@@ -1,21 +1,18 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 /**
- * Reads `?code=XXXX` from the current URL on mount.
+ * Reads `?code=XXXX` from the current URL synchronously on first render.
  * Returns the uppercased code or null if absent.
  */
 export function useInviteCode(): string | null {
-  const [code, setCode] = useState<string | null>(null)
-
-  useEffect(() => {
+  const [code] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null
     const params = new URLSearchParams(window.location.search)
     const raw = params.get('code')
-    if (raw && raw.trim().length > 0) {
-      setCode(raw.trim().toUpperCase())
-    }
-  }, [])
+    return raw && raw.trim().length > 0 ? raw.trim().toUpperCase() : null
+  })
 
   return code
 }


### PR DESCRIPTION
## Summary
- Add `useInviteCode` hook and `getInviteLink` utility (`src/hooks/useInviteCode.ts`) to read `?code=` URL params and build invite URLs
- All 4 multiplayer games (Uno, Skribbl, Slither.io, Cards Against Humanity) now pre-fill the room code and auto-switch to "join" mode when opened via an invite link
- Lobby screens show a new "Copy invite link" button alongside the existing "Copy code" button

## Test plan
- [ ] Create a room in each multiplayer game, verify "Copy invite link" button appears in lobby
- [ ] Click "Copy invite link" and open the copied URL — verify the join form appears with the room code pre-filled
- [ ] Verify the user still needs to enter their name and click "Join" manually
- [ ] Verify the "Copy code" button still works independently
- [ ] Verify opening a game page without `?code=` param shows the normal choose screen

Closes #68

https://claude.ai/code/session_01EvMbKfVh32Zu66abRjUGzS