### PR TITLE
feat(slither): enhance UI, mobile controls, and multiplayer sync

### DIFF
--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -48,16 +48,28 @@ const BORDER_COLOR = '#FF073A'
 
 // ─── Game Canvas ──────────────────────────────────────────────────────────────
 
+interface KillFeedEntry {
+  id: number
+  killerName: string
+  killerColor: string
+  victimName: string
+  victimColor: string
+  isMe: boolean
+  at: number
+}
+
 interface GameCanvasProps {
   mySnake: SnakeState
   otherSnakes: Map<string, SnakeState>
   food: Food[]
   timeLeft: number
-  onMouseMove: (worldX: number, worldY: number) => void
+  respawnMs: number | null
+  onSteer: (worldX: number, worldY: number) => void
   onBoostStart: () => void
   onBoostEnd: () => void
   canvasWidth: number
   canvasHeight: number
+  isTouch: boolean
 }
 
 function GameCanvas({
@@ -65,11 +77,13 @@ function GameCanvas({
   otherSnakes,
   food,
   timeLeft,
-  onMouseMove,
+  respawnMs,
+  onSteer,
   onBoostStart,
   onBoostEnd,
   canvasWidth,
   canvasHeight,
+  isTouch,
 }: GameCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const vpRef = useRef({ x: 0, y: 0, scale: 1 })
@@ -79,44 +93,54 @@ function GameCanvas({
     const canvas = canvasRef.current
     if (!canvas) return
 
-    const toWorld = (clientX: number, clientY: number) => {
+    // Desktop/mouse: steer to cursor world position (absolute).
+    // Touch: steer relative to canvas center — project a target far ahead.
+    const steerFromEvent = (clientX: number, clientY: number, relative: boolean) => {
       const rect = canvas.getBoundingClientRect()
-      const sx = canvas.width / rect.width
-      const sy = canvas.height / rect.height
-      const cx = (clientX - rect.left) * sx
-      const cy = (clientY - rect.top) * sy
+      const cssX = clientX - rect.left
+      const cssY = clientY - rect.top
       const vp = vpRef.current
-      onMouseMove(vp.x + cx / vp.scale, vp.y + cy / vp.scale)
+      if (relative) {
+        const dx = cssX - rect.width / 2
+        const dy = cssY - rect.height / 2
+        const mag = Math.sqrt(dx * dx + dy * dy) || 1
+        // Project a far-away target in the indicated direction so the snake
+        // steers toward that heading regardless of canvas distance.
+        const head = mySnake.segments[0] ?? { x: MAP_WIDTH / 2, y: MAP_HEIGHT / 2 }
+        const FAR = 2000
+        onSteer(head.x + (dx / mag) * FAR, head.y + (dy / mag) * FAR)
+      } else {
+        onSteer(vp.x + cssX / vp.scale, vp.y + cssY / vp.scale)
+      }
     }
 
-    const onMouse = (e: MouseEvent) => toWorld(e.clientX, e.clientY)
-    const onTouch = (e: TouchEvent) => {
+    const onMouse = (e: MouseEvent) => steerFromEvent(e.clientX, e.clientY, false)
+    const onTouchMove = (e: TouchEvent) => {
       e.preventDefault()
-      if (e.touches[0]) toWorld(e.touches[0].clientX, e.touches[0].clientY)
+      if (e.touches[0]) steerFromEvent(e.touches[0].clientX, e.touches[0].clientY, true)
     }
     const onMouseDown = () => onBoostStart()
     const onMouseUp = () => onBoostEnd()
     const onTouchStart = (e: TouchEvent) => {
-      if (e.touches.length >= 2) onBoostStart()
+      // Immediately steer on first touch
+      if (e.touches[0]) {
+        steerFromEvent(e.touches[0].clientX, e.touches[0].clientY, true)
+      }
     }
-    const onTouchEnd = () => onBoostEnd()
-
     canvas.addEventListener('mousemove', onMouse)
     canvas.addEventListener('mousedown', onMouseDown)
     canvas.addEventListener('mouseup', onMouseUp)
-    canvas.addEventListener('touchmove', onTouch, { passive: false })
+    canvas.addEventListener('touchmove', onTouchMove, { passive: false })
     canvas.addEventListener('touchstart', onTouchStart, { passive: false })
-    canvas.addEventListener('touchend', onTouchEnd)
 
     return () => {
       canvas.removeEventListener('mousemove', onMouse)
       canvas.removeEventListener('mousedown', onMouseDown)
       canvas.removeEventListener('mouseup', onMouseUp)
-      canvas.removeEventListener('touchmove', onTouch)
+      canvas.removeEventListener('touchmove', onTouchMove)
       canvas.removeEventListener('touchstart', onTouchStart)
-      canvas.removeEventListener('touchend', onTouchEnd)
     }
-  }, [onMouseMove, onBoostStart, onBoostEnd])
+  }, [onSteer, onBoostStart, onBoostEnd, mySnake])
 
   // Keyboard boost
   useEffect(() => {
@@ -137,6 +161,17 @@ function GameCanvas({
     }
   }, [onBoostStart, onBoostEnd])
 
+  // DPI-aware canvas backing store sizing
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+    canvas.width = Math.round(canvasWidth * dpr)
+    canvas.height = Math.round(canvasHeight * dpr)
+    canvas.style.width = `${canvasWidth}px`
+    canvas.style.height = `${canvasHeight}px`
+  }, [canvasWidth, canvasHeight])
+
   // Render loop
   useEffect(() => {
     const canvas = canvasRef.current
@@ -147,7 +182,9 @@ function GameCanvas({
     let animId: number
 
     function draw() {
-      if (!ctx) return
+      if (!ctx || !canvas) return
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2)
 
       // Smooth camera
       const targetVp = getViewport(
@@ -160,8 +197,14 @@ function GameCanvas({
       vpRef.current = lerpViewport(vpRef.current, targetVp, 0.08)
       const vp = vpRef.current
 
+      // Reset transform and clear using raw canvas backing dimensions
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      // All subsequent draws operate in CSS pixels
+      ctx.scale(dpr, dpr)
+
       ctx.save()
-      ctx.clearRect(0, 0, canvasWidth, canvasHeight)
 
       // Dark background
       ctx.fillStyle = BG_COLOR
@@ -258,42 +301,101 @@ function GameCanvas({
         ctx.fill()
       }
 
-      // Timer
+      // Timer — top center pill
       const minutes = Math.floor(timeLeft / 60)
       const seconds = timeLeft % 60
+      const timerStr = `${minutes}:${seconds.toString().padStart(2, '0')}`
       ctx.font = 'bold 18px monospace'
       ctx.textAlign = 'center'
-      ctx.fillStyle = 'rgba(255,255,255,0.7)'
-      ctx.fillText(`${minutes}:${seconds.toString().padStart(2, '0')}`, canvasWidth / 2, 30)
+      const timerW = ctx.measureText(timerStr).width + 28
+      ctx.fillStyle = 'rgba(10, 10, 46, 0.7)'
+      ctx.strokeStyle = 'rgba(100, 100, 200, 0.4)'
+      ctx.lineWidth = 1
+      roundedRect(ctx, canvasWidth / 2 - timerW / 2, 12, timerW, 30, 15)
+      ctx.fill()
+      ctx.stroke()
+      ctx.fillStyle = timeLeft <= 10 ? '#FF073A' : 'rgba(255,255,255,0.9)'
+      ctx.fillText(timerStr, canvasWidth / 2, 33)
 
-      // Length counter
-      ctx.font = 'bold 16px sans-serif'
+      // Stat card — top left (length + score)
+      const cardPad = 10
+      const cardX = 10
+      const cardY = 12
+      const cardW = 140
+      const cardH = 58
+      ctx.fillStyle = 'rgba(10, 10, 46, 0.7)'
+      ctx.strokeStyle = 'rgba(100, 100, 200, 0.4)'
+      roundedRect(ctx, cardX, cardY, cardW, cardH, 8)
+      ctx.fill()
+      ctx.stroke()
       ctx.textAlign = 'left'
-      ctx.fillStyle = 'rgba(255,255,255,0.6)'
-      ctx.fillText(`Length: ${Math.floor(mySnake.targetLength)}`, 14, 28)
+      ctx.font = 'bold 11px sans-serif'
+      ctx.fillStyle = 'rgba(255,255,255,0.45)'
+      ctx.fillText('LENGTH', cardX + cardPad, cardY + 18)
+      ctx.fillText('SCORE', cardX + cardPad + 70, cardY + 18)
+      ctx.font = 'bold 18px sans-serif'
+      ctx.fillStyle = mySnake.color
+      ctx.fillText(`${Math.floor(mySnake.targetLength)}`, cardX + cardPad, cardY + 42)
+      ctx.fillStyle = '#fff'
+      ctx.fillText(`${mySnake.score}`, cardX + cardPad + 70, cardY + 42)
 
-      // Score
-      ctx.fillText(`Score: ${mySnake.score}`, 14, 50)
-
-      // Boost indicator
-      if (mySnake.boosting && mySnake.alive) {
-        ctx.font = 'bold 14px sans-serif'
-        ctx.textAlign = 'center'
-        ctx.fillStyle = 'rgba(255, 200, 0, 0.8)'
-        ctx.fillText('BOOST', canvasWidth / 2, canvasHeight - 20)
+      // Boost bar — bottom center
+      const barW = Math.min(240, canvasWidth * 0.45)
+      const barH = 10
+      const barX = canvasWidth / 2 - barW / 2
+      const barY = canvasHeight - 28
+      const boostFraction = Math.max(
+        0,
+        Math.min(1, (mySnake.targetLength - 15) / Math.max(1, mySnake.targetLength))
+      )
+      ctx.fillStyle = 'rgba(10, 10, 46, 0.7)'
+      ctx.strokeStyle = 'rgba(100, 100, 200, 0.4)'
+      roundedRect(ctx, barX - 2, barY - 2, barW + 4, barH + 4, 6)
+      ctx.fill()
+      ctx.stroke()
+      // fill
+      const boostFillW = barW * boostFraction
+      const canBoost = mySnake.targetLength > 15
+      ctx.fillStyle = mySnake.boosting
+        ? '#FFD700'
+        : canBoost
+          ? mySnake.color
+          : 'rgba(255,255,255,0.2)'
+      if (mySnake.boosting) {
+        ctx.shadowColor = '#FFD700'
+        ctx.shadowBlur = 10
       }
+      roundedRect(ctx, barX, barY, boostFillW, barH, 5)
+      ctx.fill()
+      ctx.shadowBlur = 0
+      // label
+      ctx.font = 'bold 10px sans-serif'
+      ctx.textAlign = 'center'
+      ctx.fillStyle = 'rgba(255,255,255,0.7)'
+      const boostLabel = isTouch ? 'BOOST — tap right button' : 'BOOST — click / space'
+      ctx.fillText(boostLabel, canvasWidth / 2, barY - 6)
 
-      // Death overlay
+      // Kill feed — top right below leaderboard (drawn via DOM in React; nothing here)
+
+      // Death overlay with countdown
       if (!mySnake.alive) {
-        ctx.fillStyle = 'rgba(0,0,0,0.6)'
+        ctx.fillStyle = 'rgba(0,0,0,0.65)'
         ctx.fillRect(0, 0, canvasWidth, canvasHeight)
         ctx.fillStyle = '#FF073A'
-        ctx.font = 'bold 28px sans-serif'
+        ctx.font = 'bold 34px sans-serif'
         ctx.textAlign = 'center'
-        ctx.fillText('You died!', canvasWidth / 2, canvasHeight / 2 - 10)
-        ctx.fillStyle = 'rgba(255,255,255,0.7)'
+        ctx.shadowColor = '#FF073A'
+        ctx.shadowBlur = 14
+        ctx.fillText('You died', canvasWidth / 2, canvasHeight / 2 - 10)
+        ctx.shadowBlur = 0
+        ctx.fillStyle = 'rgba(255,255,255,0.85)'
         ctx.font = '16px sans-serif'
-        ctx.fillText('Respawning...', canvasWidth / 2, canvasHeight / 2 + 20)
+        const secs = respawnMs != null ? Math.max(0, Math.ceil(respawnMs / 1000)) : 0
+        ctx.fillText(
+          respawnMs != null && respawnMs > 0 ? `Respawning in ${secs}…` : 'Respawning…',
+          canvasWidth / 2,
+          canvasHeight / 2 + 22
+        )
       }
 
       animId = requestAnimationFrame(draw)
@@ -301,17 +403,42 @@ function GameCanvas({
 
     animId = requestAnimationFrame(draw)
     return () => cancelAnimationFrame(animId)
-  }, [mySnake, otherSnakes, food, timeLeft, canvasWidth, canvasHeight])
+  }, [mySnake, otherSnakes, food, timeLeft, canvasWidth, canvasHeight, respawnMs, isTouch])
 
   return (
     <canvas
       ref={canvasRef}
-      width={canvasWidth}
-      height={canvasHeight}
-      className="h-full w-full"
-      style={{ touchAction: 'none', cursor: 'none' }}
+      className="block h-full w-full select-none"
+      style={{
+        touchAction: 'none',
+        cursor: isTouch ? 'default' : 'none',
+        WebkitUserSelect: 'none',
+        WebkitTapHighlightColor: 'transparent',
+      }}
     />
   )
+}
+
+function roundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number
+) {
+  const radius = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + radius, y)
+  ctx.lineTo(x + w - radius, y)
+  ctx.quadraticCurveTo(x + w, y, x + w, y + radius)
+  ctx.lineTo(x + w, y + h - radius)
+  ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h)
+  ctx.lineTo(x + radius, y + h)
+  ctx.quadraticCurveTo(x, y + h, x, y + h - radius)
+  ctx.lineTo(x, y + radius)
+  ctx.quadraticCurveTo(x, y, x + radius, y)
+  ctx.closePath()
 }
 
 function drawSnake(ctx: CanvasRenderingContext2D, snake: SnakeState, isMe: boolean) {
@@ -412,6 +539,91 @@ function darkenCSS(hex: string, amount: number): string {
   const g = Math.max(0, parseInt(hex.slice(3, 5), 16) - amount)
   const b = Math.max(0, parseInt(hex.slice(5, 7), 16) - amount)
   return `rgb(${r},${g},${b})`
+}
+
+// ─── Kill Feed ────────────────────────────────────────────────────────────────
+
+function KillFeed({ entries }: { entries: KillFeedEntry[] }) {
+  if (entries.length === 0) return null
+  return (
+    <div className="pointer-events-none absolute top-2 left-1/2 flex -translate-x-1/2 flex-col items-center gap-1">
+      {entries.slice(-5).map((e) => (
+        <div
+          key={e.id}
+          className={cn(
+            'animate-in fade-in slide-in-from-top-1 rounded-full border bg-[#0a0a2e]/80 px-3 py-1 text-xs backdrop-blur-sm duration-200',
+            e.isMe ? 'border-red-500/60' : 'border-white/10'
+          )}
+        >
+          <span className="font-semibold" style={{ color: e.killerColor }}>
+            {e.killerName}
+          </span>
+          <span className="mx-1.5 text-white/60">killed</span>
+          <span className="font-semibold" style={{ color: e.victimColor }}>
+            {e.victimName}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── Mobile Boost Button ──────────────────────────────────────────────────────
+
+function MobileBoostButton({
+  canBoost,
+  onStart,
+  onEnd,
+}: {
+  canBoost: boolean
+  onStart: () => void
+  onEnd: () => void
+}) {
+  const [pressed, setPressed] = useState(false)
+
+  return (
+    <button
+      type="button"
+      aria-label="Boost"
+      className={cn(
+        'pointer-events-auto absolute right-6 bottom-6 flex h-20 w-20 items-center justify-center rounded-full border-2 font-bold text-white transition-transform select-none',
+        pressed ? 'scale-95' : 'scale-100',
+        canBoost
+          ? 'border-yellow-300/80 bg-gradient-to-br from-orange-500/80 to-red-600/80 shadow-lg shadow-orange-500/40'
+          : 'border-white/20 bg-white/10'
+      )}
+      style={{ touchAction: 'none', WebkitTapHighlightColor: 'transparent' }}
+      onTouchStart={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setPressed(true)
+        onStart()
+      }}
+      onTouchEnd={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setPressed(false)
+        onEnd()
+      }}
+      onTouchCancel={() => {
+        setPressed(false)
+        onEnd()
+      }}
+      onPointerDown={(e) => {
+        // Fallback for devices that emit pointer before touch
+        if (e.pointerType === 'mouse') return
+        setPressed(true)
+        onStart()
+      }}
+      onPointerUp={(e) => {
+        if (e.pointerType === 'mouse') return
+        setPressed(false)
+        onEnd()
+      }}
+    >
+      <span className="text-xs tracking-widest">BOOST</span>
+    </button>
+  )
 }
 
 // ─── Leaderboard ──────────────────────────────────────────────────────────────
@@ -645,6 +857,9 @@ export function AgarioGame() {
   // Game state refs
   const mySnakeRef = useRef<SnakeState | null>(null)
   const otherSnakesRef = useRef<Map<string, SnakeState>>(new Map())
+  // Most-recently-received snake states from the network — rendered snakes are
+  // interpolated toward these each frame for smoother movement between broadcasts.
+  const otherSnakesTargetRef = useRef<Map<string, SnakeState>>(new Map())
   const foodRef = useRef<Food[]>([])
   const nextFoodIdRef = useRef(0)
   const targetRef = useRef<Position>({ x: MAP_WIDTH / 2, y: MAP_HEIGHT / 2 })
@@ -657,6 +872,7 @@ export function AgarioGame() {
   const lastFoodReplenishRef = useRef(0)
   const gameLoopRef = useRef<number | null>(null)
   const lastTickRef = useRef(0)
+  const nextKillFeedIdRef = useRef(1)
 
   // React state for rendering
   const [mySnakeState, setMySnakeState] = useState<SnakeState | null>(null)
@@ -667,17 +883,73 @@ export function AgarioGame() {
   const [isFinished, setIsFinished] = useState(false)
   const [finalScores, setFinalScores] = useState<SnakeState[]>([])
   const [canvasSize, setCanvasSize] = useState({ width: 800, height: 600 })
+  const [isTouch, setIsTouch] = useState(false)
+  const [killFeed, setKillFeed] = useState<KillFeedEntry[]>([])
+  const [respawnMs, setRespawnMs] = useState<number | null>(null)
 
+  // Detect touch device once (coarse pointer media query)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mq = window.matchMedia('(pointer: coarse)')
+    const update = () => setIsTouch(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+
+  // Responsive canvas sizing — fullscreen on mobile, bounded on desktop.
   useEffect(() => {
     function updateSize() {
-      const w = Math.min(window.innerWidth, 1200)
-      const h = Math.min(window.innerHeight - 120, 800)
-      setCanvasSize({ width: Math.max(400, w), height: Math.max(300, h) })
+      const vw = window.innerWidth
+      const vh = window.innerHeight
+      const mobile = vw < 768
+      // On mobile: full viewport minus a small header (~56px for back button).
+      // On desktop: bounded to 1200x800 with padding for the GameLayout chrome.
+      const w = mobile ? vw : Math.min(vw - 32, 1200)
+      const h = mobile ? vh - 64 : Math.min(vh - 140, 800)
+      setCanvasSize({ width: Math.max(320, w), height: Math.max(320, h) })
     }
     updateSize()
     window.addEventListener('resize', updateSize)
-    return () => window.removeEventListener('resize', updateSize)
+    window.addEventListener('orientationchange', updateSize)
+    return () => {
+      window.removeEventListener('resize', updateSize)
+      window.removeEventListener('orientationchange', updateSize)
+    }
   }, [])
+
+  // Prune old kill-feed entries (fade out after 5s)
+  useEffect(() => {
+    if (killFeed.length === 0) return
+    const timer = setTimeout(() => {
+      const cutoff = Date.now() - 5000
+      setKillFeed((prev) => prev.filter((k) => k.at > cutoff))
+    }, 1000)
+    return () => clearTimeout(timer)
+  }, [killFeed])
+
+  // Helper to push a kill-feed entry
+  const pushKill = useCallback(
+    (
+      killerName: string,
+      killerColor: string,
+      victimName: string,
+      victimColor: string,
+      isMe: boolean
+    ) => {
+      const entry: KillFeedEntry = {
+        id: nextKillFeedIdRef.current++,
+        killerName,
+        killerColor,
+        victimName,
+        victimColor,
+        isMe,
+        at: Date.now(),
+      }
+      setKillFeed((prev) => [...prev.slice(-5), entry])
+    },
+    []
+  )
 
   const isHost = gameState?.hostId === playerId
 
@@ -687,7 +959,12 @@ export function AgarioGame() {
       switch (msg.type) {
         case 'snake_update': {
           if (msg.snake.id === playerId) return
-          otherSnakesRef.current.set(msg.snake.id, msg.snake)
+          // Store the latest authoritative snake as the interpolation target.
+          // The currently-rendered snake is lerped toward this each tick.
+          otherSnakesTargetRef.current.set(msg.snake.id, msg.snake)
+          if (!otherSnakesRef.current.has(msg.snake.id)) {
+            otherSnakesRef.current.set(msg.snake.id, msg.snake)
+          }
           break
         }
         case 'food_sync': {
@@ -734,6 +1011,21 @@ export function AgarioGame() {
             killed.alive = false
             killed.deathTime = Date.now()
           }
+          otherSnakesTargetRef.current.delete(msg.killedId)
+
+          // Push kill-feed entry using best-known names/colors
+          const resolveMeta = (id: string) => {
+            if (id === playerId && mySnakeRef.current)
+              return { name: mySnakeRef.current.name, color: mySnakeRef.current.color }
+            const other = otherSnakesRef.current.get(id)
+            if (other) return { name: other.name, color: other.color }
+            const lobbyP = gameState?.players.find((p) => p.id === id)
+            if (lobbyP) return { name: lobbyP.name, color: lobbyP.color }
+            return { name: '???', color: '#888' }
+          }
+          const k = resolveMeta(msg.killerId)
+          const v = resolveMeta(msg.killedId)
+          pushKill(k.name, k.color, v.name, v.color, msg.killedId === playerId)
           break
         }
         case 'death_food': {
@@ -750,8 +1042,11 @@ export function AgarioGame() {
             if (me) {
               mySnakeRef.current = createSnakeState(me.id, me.name, me.color)
               otherSnakesRef.current.clear()
+              otherSnakesTargetRef.current.clear()
             }
           }
+          setKillFeed([])
+          setRespawnMs(null)
           setIsPlaying(true)
           setIsFinished(false)
           break
@@ -830,24 +1125,32 @@ export function AgarioGame() {
         return
       }
 
-      // Respawn
-      if (!me.alive && me.deathTime && now - me.deathTime > RESPAWN_DELAY) {
-        const pos = spawnPosition()
-        const angle = Math.random() * Math.PI * 2
-        const segments: Position[] = []
-        for (let i = 0; i < START_LENGTH; i++) {
-          segments.push({
-            x: pos.x - Math.cos(angle) * i * SEGMENT_SPACING,
-            y: pos.y - Math.sin(angle) * i * SEGMENT_SPACING,
-          })
+      // Respawn countdown + logic
+      if (!me.alive && me.deathTime) {
+        const remainingRespawn = RESPAWN_DELAY - (now - me.deathTime)
+        setRespawnMs(remainingRespawn)
+        if (remainingRespawn <= 0) {
+          const pos = spawnPosition()
+          const angle = Math.random() * Math.PI * 2
+          const segments: Position[] = []
+          for (let i = 0; i < START_LENGTH; i++) {
+            segments.push({
+              x: pos.x - Math.cos(angle) * i * SEGMENT_SPACING,
+              y: pos.y - Math.sin(angle) * i * SEGMENT_SPACING,
+            })
+          }
+          me.segments = segments
+          me.angle = angle
+          me.targetLength = START_LENGTH
+          me.alive = true
+          me.deathTime = null
+          me.boosting = false
+          me.foodEaten = 0
+          setRespawnMs(null)
         }
-        me.segments = segments
-        me.angle = angle
-        me.targetLength = START_LENGTH
-        me.alive = true
-        me.deathTime = null
-        me.boosting = false
-        me.foodEaten = 0
+      } else if (me.alive) {
+        // Use functional setter so this isn't a dependency of the tick effect.
+        setRespawnMs((prev) => (prev !== null ? null : prev))
       }
 
       if (me.alive && me.segments.length > 0) {
@@ -887,6 +1190,8 @@ export function AgarioGame() {
                 killedId: me.id,
               })
               broadcast({ type: 'death_food', food: deathFood })
+              // Show kill-feed entry locally (remote clients get it via broadcast)
+              pushKill(other.name, other.color, me.name, me.color, true)
               break
             }
           }
@@ -959,6 +1264,31 @@ export function AgarioGame() {
         lastFoodSyncRef.current = now
       }
 
+      // Interpolate other snakes toward their latest broadcast targets.
+      // Broadcasts arrive every ~100ms; lerping at a fixed per-frame rate
+      // produces a smooth visual at the cost of a small display lag.
+      const LERP_T = Math.min(1, dt * 12)
+      for (const [id, target] of otherSnakesTargetRef.current) {
+        const current = otherSnakesRef.current.get(id)
+        if (!current) {
+          otherSnakesRef.current.set(id, target)
+          continue
+        }
+        // Preserve identity/meta from target; interpolate segment positions.
+        const segs = target.segments.map((seg, i) => {
+          const curSeg = current.segments[i]
+          if (!curSeg) return seg
+          return {
+            x: curSeg.x + (seg.x - curSeg.x) * LERP_T,
+            y: curSeg.y + (seg.y - curSeg.y) * LERP_T,
+          }
+        })
+        otherSnakesRef.current.set(id, {
+          ...target,
+          segments: segs,
+        })
+      }
+
       // Update React state
       setMySnakeState({ ...me, segments: [...me.segments] })
       setOtherSnakesState(new Map(otherSnakesRef.current))
@@ -976,9 +1306,9 @@ export function AgarioGame() {
         gameLoopRef.current = null
       }
     }
-  }, [isPlaying, playerId, isHost, broadcast, dispatch])
+  }, [isPlaying, playerId, isHost, broadcast, dispatch, pushKill])
 
-  const handleMouseMove = useCallback((worldX: number, worldY: number) => {
+  const handleSteer = useCallback((worldX: number, worldY: number) => {
     targetRef.current = { x: worldX, y: worldY }
   }, [])
 
@@ -1018,13 +1348,23 @@ export function AgarioGame() {
             otherSnakes={otherSnakesState}
             food={foodState}
             timeLeft={timeLeft}
-            onMouseMove={handleMouseMove}
+            respawnMs={respawnMs}
+            onSteer={handleSteer}
             onBoostStart={handleBoostStart}
             onBoostEnd={handleBoostEnd}
             canvasWidth={canvasSize.width}
             canvasHeight={canvasSize.height}
+            isTouch={isTouch}
           />
           <Leaderboard mySnake={mySnakeState} otherSnakes={otherSnakesState} myId={playerId} />
+          <KillFeed entries={killFeed} />
+          {isTouch && mySnakeState.alive && (
+            <MobileBoostButton
+              canBoost={mySnakeState.targetLength > 15}
+              onStart={handleBoostStart}
+              onEnd={handleBoostEnd}
+            />
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
- Mobile controls: steer by dragging anywhere on screen (relative to
  center), plus a dedicated bottom-right BOOST button — the previous
  two-finger-touch boost was unintuitive on phones.
- Fullscreen layout on mobile (<768px) so the playfield uses the full
  viewport instead of being clamped to a 1200x800 box.
- DPI-aware canvas backing store — snakes and text render sharply on
  retina / high-DPR displays by sizing the canvas to CSS × devicePixelRatio.
- Interpolated remote snakes — each tick, other players' snakes are
  lerped toward their most-recently-received broadcast state, smoothing
  out the 100ms broadcast cadence.
- Revamped HUD: rounded timer pill, stat card (length + score), visual
  boost bar with dynamic color, respawn countdown in seconds, and a
  live kill feed (DOM overlay) that shows who killed whom.
- Cleaned up pointer handling and touch-action / tap-highlight styling
  to prevent unwanted scrolling and highlight flashes on touch devices.

https://claude.ai/code/session_011dLKp5dHCYKqDFp2izQwkQ