### PR TITLE
refactor: extract shared resume-session UI for multiplayer games

### DIFF
--- a/src/components/multiplayer/ResumeSessionButton.test.tsx
+++ b/src/components/multiplayer/ResumeSessionButton.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ResumeSessionButton } from './ResumeSessionButton'
+
+describe('ResumeSessionButton', () => {
+  it('renders the default title and session summary', () => {
+    render(
+      <ResumeSessionButton session={{ playerName: 'Roman', roomCode: 'AB12' }} onClick={() => {}} />
+    )
+
+    expect(screen.getByText('Resume session')).toBeInTheDocument()
+    expect(screen.getByText('Roman · Room AB12')).toBeInTheDocument()
+  })
+
+  it('uses custom title and html separator entities', () => {
+    render(
+      <ResumeSessionButton
+        session={{ playerName: 'Roman', roomCode: 'AB12' }}
+        onClick={() => {}}
+        title="Continue game"
+        separator=" &middot; "
+      />
+    )
+
+    expect(screen.getByText('Continue game')).toBeInTheDocument()
+    expect(screen.getByText('Roman · Room AB12')).toBeInTheDocument()
+  })
+
+  it('invokes onClick when tapped', () => {
+    const onClick = jest.fn()
+
+    render(
+      <ResumeSessionButton session={{ playerName: 'Roman', roomCode: 'AB12' }} onClick={onClick} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /resume session/i }))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/multiplayer/ResumeSessionButton.test.tsx
+++ b/src/components/multiplayer/ResumeSessionButton.test.tsx
@@ -11,18 +11,18 @@ describe('ResumeSessionButton', () => {
     expect(screen.getByText('Roman · Room AB12')).toBeInTheDocument()
   })
 
-  it('uses custom title and html separator entities', () => {
+  it('uses custom title and separator as-is', () => {
     render(
       <ResumeSessionButton
         session={{ playerName: 'Roman', roomCode: 'AB12' }}
         onClick={() => {}}
         title="Continue game"
-        separator=" &middot; "
+        separator=" | "
       />
     )
 
     expect(screen.getByText('Continue game')).toBeInTheDocument()
-    expect(screen.getByText('Roman · Room AB12')).toBeInTheDocument()
+    expect(screen.getByText('Roman | Room AB12')).toBeInTheDocument()
   })
 
   it('invokes onClick when tapped', () => {

--- a/src/components/multiplayer/ResumeSessionButton.tsx
+++ b/src/components/multiplayer/ResumeSessionButton.tsx
@@ -15,12 +15,8 @@ interface ResumeSessionButtonProps {
   detailsClassName?: string
 }
 
-function normalizeSeparator(separator: string): string {
-  return separator.replaceAll('&middot;', '·')
-}
-
 export function formatSessionSummary(session: SavedSessionSummary, separator = ' · '): string {
-  return `${session.playerName}${normalizeSeparator(separator)}Room ${session.roomCode}`
+  return `${session.playerName}${separator}Room ${session.roomCode}`
 }
 
 export function ResumeSessionButton({

--- a/src/components/multiplayer/ResumeSessionButton.tsx
+++ b/src/components/multiplayer/ResumeSessionButton.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@/lib/utils'
+
+export interface SavedSessionSummary {
+  roomCode: string
+  playerName: string
+}
+
+interface ResumeSessionButtonProps {
+  session: SavedSessionSummary
+  onClick: () => void
+  title?: string
+  separator?: string
+  className?: string
+  titleClassName?: string
+  detailsClassName?: string
+}
+
+function normalizeSeparator(separator: string): string {
+  return separator.replaceAll('&middot;', '·')
+}
+
+export function formatSessionSummary(session: SavedSessionSummary, separator = ' · '): string {
+  return `${session.playerName}${normalizeSeparator(separator)}Room ${session.roomCode}`
+}
+
+export function ResumeSessionButton({
+  session,
+  onClick,
+  title = 'Resume session',
+  separator = ' · ',
+  className,
+  titleClassName,
+  detailsClassName,
+}: ResumeSessionButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'border-primary/40 hover:bg-secondary w-64 rounded-xl border-2 border-dashed px-6 py-3 text-center text-sm transition-colors',
+        className
+      )}
+    >
+      <div className={cn('font-semibold', titleClassName)}>{title}</div>
+      <div className={cn('text-muted-foreground text-xs', detailsClassName)}>
+        {formatSessionSummary(session, separator)}
+      </div>
+    </button>
+  )
+}

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -297,9 +297,8 @@ function EntryScreen({
           <ResumeSessionButton
             session={savedSession}
             onClick={() => onRestore?.()}
-            className="border-primary/30 hover:border-primary/50 hover:bg-secondary/50 w-72 rounded-xl border-2 border-dashed px-6 py-3.5 text-center transition-all"
+            className="border-primary/30 hover:border-primary/50 hover:bg-secondary/50 w-72 py-3.5 transition-all"
             titleClassName="text-sm"
-            separator=" &middot; "
           />
         )}
 

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -5,6 +5,10 @@ import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
+import {
+  ResumeSessionButton,
+  type SavedSessionSummary,
+} from '@/components/multiplayer/ResumeSessionButton'
 import { useCAHRoom } from './useCAHRoom'
 import {
   getCzar,
@@ -250,7 +254,7 @@ interface EntryScreenProps {
   onCreate: (name: string) => void
   onJoin: (code: string, name: string) => void
   onRestore?: () => void
-  savedSession: { roomCode: string; playerName: string } | null
+  savedSession: SavedSessionSummary | null
   loading: boolean
   error: string | null
   initialCode?: string | null
@@ -290,15 +294,13 @@ function EntryScreen({
         </div>
 
         {savedSession && (
-          <button
-            onClick={onRestore}
+          <ResumeSessionButton
+            session={savedSession}
+            onClick={() => onRestore?.()}
             className="border-primary/30 hover:border-primary/50 hover:bg-secondary/50 w-72 rounded-xl border-2 border-dashed px-6 py-3.5 text-center transition-all"
-          >
-            <div className="text-sm font-semibold">Resume session</div>
-            <div className="text-muted-foreground text-xs">
-              {savedSession.playerName} &middot; Room {savedSession.roomCode}
-            </div>
-          </button>
+            titleClassName="text-sm"
+            separator=" &middot; "
+          />
         )}
 
         <div className="flex gap-4">

--- a/src/games/codenames/CodenamesGame.tsx
+++ b/src/games/codenames/CodenamesGame.tsx
@@ -5,6 +5,10 @@ import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
+import {
+  ResumeSessionButton,
+  type SavedSessionSummary,
+} from '@/components/multiplayer/ResumeSessionButton'
 import { useCodenamesRoom } from './useCodenamesRoom'
 import {
   canStartGame,
@@ -64,7 +68,7 @@ interface EntryScreenProps {
   onCreate: (name: string) => void
   onJoin: (code: string, name: string) => void
   onRestore?: () => void
-  savedSession: { roomCode: string; playerName: string } | null
+  savedSession: SavedSessionSummary | null
   loading: boolean
   error: string | null
   initialCode?: string | null
@@ -92,15 +96,11 @@ function EntryScreen({
           <p className="text-muted-foreground text-sm">4-10 players</p>
         </div>
         {savedSession && (
-          <button
-            onClick={onRestore}
-            className="border-primary/40 hover:bg-secondary w-64 rounded-xl border-2 border-dashed px-6 py-3 text-center text-sm transition-colors"
-          >
-            <div className="font-semibold">Resume session</div>
-            <div className="text-muted-foreground text-xs">
-              {savedSession.playerName} · Room {savedSession.roomCode}
-            </div>
-          </button>
+          <ResumeSessionButton
+            session={savedSession}
+            onClick={() => onRestore?.()}
+            className="w-64"
+          />
         )}
         <div className="flex gap-3">
           <button

--- a/src/games/mindmeld/MindmeldGame.tsx
+++ b/src/games/mindmeld/MindmeldGame.tsx
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
-import { getInviteLink, useInviteCode } from '@/hooks/useInviteCode'
+import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
+import {
+  ResumeSessionButton,
+  type SavedSessionSummary,
+} from '@/components/multiplayer/ResumeSessionButton'
 import { useMindmeldRoom } from './useMindmeldRoom'
 import {
   BULLSEYE_RADIUS,
@@ -67,7 +71,7 @@ interface EntryScreenProps {
   onCreate: (name: string) => void
   onJoin: (code: string, name: string) => void
   onRestore?: () => void
-  savedSession: { roomCode: string; playerName: string } | null
+  savedSession: SavedSessionSummary | null
   loading: boolean
   error: string | null
   initialCode?: string | null
@@ -132,15 +136,11 @@ function EntryScreen({
         </div>
 
         {savedSession && onRestore && (
-          <button
+          <ResumeSessionButton
+            session={savedSession}
             onClick={onRestore}
-            className="border-primary/40 hover:bg-secondary mx-auto w-full max-w-md rounded-2xl border-2 border-dashed px-6 py-4 text-center text-sm transition-colors"
-          >
-            <div className="font-semibold">Resume session</div>
-            <div className="text-muted-foreground text-xs">
-              {savedSession.playerName} · Room {savedSession.roomCode}
-            </div>
-          </button>
+            className="mx-auto w-full max-w-md rounded-2xl px-6 py-4"
+          />
         )}
       </div>
     )

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -514,7 +514,6 @@ function EntryScreen({
             session={savedSession}
             onClick={() => onRestore?.()}
             className="w-64"
-            separator=" &middot; "
           />
         )}
         <div className="flex gap-3">

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -5,6 +5,10 @@ import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
+import {
+  ResumeSessionButton,
+  type SavedSessionSummary,
+} from '@/components/multiplayer/ResumeSessionButton'
 import { useSkribblRoom } from './useSkribblRoom'
 import {
   getCurrentDrawer,
@@ -478,7 +482,7 @@ interface EntryScreenProps {
   onCreate: (name: string) => void
   onJoin: (code: string, name: string) => void
   onRestore?: () => void
-  savedSession: { roomCode: string; playerName: string } | null
+  savedSession: SavedSessionSummary | null
   loading: boolean
   error: string | null
   initialCode?: string | null
@@ -506,15 +510,12 @@ function EntryScreen({
           <p className="text-muted-foreground text-sm">2-8 players &middot; Draw & Guess</p>
         </div>
         {savedSession && (
-          <button
-            onClick={onRestore}
-            className="border-primary/40 hover:bg-secondary w-64 rounded-xl border-2 border-dashed px-6 py-3 text-center text-sm transition-colors"
-          >
-            <div className="font-semibold">Resume session</div>
-            <div className="text-muted-foreground text-xs">
-              {savedSession.playerName} &middot; Room {savedSession.roomCode}
-            </div>
-          </button>
+          <ResumeSessionButton
+            session={savedSession}
+            onClick={() => onRestore?.()}
+            className="w-64"
+            separator=" &middot; "
+          />
         )}
         <div className="flex gap-3">
           <button

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -5,6 +5,10 @@ import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
+import {
+  ResumeSessionButton,
+  type SavedSessionSummary,
+} from '@/components/multiplayer/ResumeSessionButton'
 import { useUnoRoom } from './useUnoRoom'
 import {
   canPlayCard,
@@ -240,7 +244,7 @@ interface EntryScreenProps {
   onCreate: (name: string) => void
   onJoin: (code: string, name: string) => void
   onRestore?: () => void
-  savedSession: { roomCode: string; playerName: string } | null
+  savedSession: SavedSessionSummary | null
   loading: boolean
   error: string | null
   initialCode?: string | null
@@ -280,15 +284,11 @@ function EntryScreen({
           <p className="text-muted-foreground text-sm">2-10 players</p>
         </div>
         {savedSession && (
-          <button
-            onClick={onRestore}
-            className="border-primary/40 hover:bg-secondary w-64 rounded-xl border-2 border-dashed px-6 py-3 text-center text-sm transition-colors"
-          >
-            <div className="font-semibold">Resume session</div>
-            <div className="text-muted-foreground text-xs">
-              {savedSession.playerName} · Room {savedSession.roomCode}
-            </div>
-          </button>
+          <ResumeSessionButton
+            session={savedSession}
+            onClick={() => onRestore?.()}
+            className="w-64"
+          />
         )}
         <div className="flex gap-3">
           <button


### PR DESCRIPTION
## Summary
- add `ResumeSessionButton` shared component under `src/components/multiplayer/`
- replace duplicated resume-session UI in UNO, Skribbl, Codenames, Cards Against Humanity, and Mindmeld entry screens
- centralize summary formatting and support both `·` and `&middot;` separators
- add unit tests for rendering and click behavior

## Why
These multiplayer game files are large and had repeated session-resume markup/typing. This refactor removes duplication and makes future UI changes in one place.

## Verification
- `pnpm lint`
- `pnpm test`
