### PR TITLE
feat: redesign home with Discover/Library tabs + fix Mindmeld dial rotation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { games } from '@/data/games'
-import { GameGrid } from '@/components/GameGrid'
+import { HomeExperience } from '@/components/home/HomeExperience'
 
 export default function HomePage() {
   const liveCount = games.filter((g) => g.status === 'live').length
@@ -12,7 +12,6 @@ export default function HomePage() {
 
   return (
     <div className="bg-background min-h-screen">
-      {/* Hero */}
       <header className="from-accent/60 to-background border-b bg-gradient-to-b">
         <div className="mx-auto max-w-5xl px-4 pt-16 pb-12 text-center">
           <div className="mb-4 text-6xl">🎮</div>
@@ -20,10 +19,9 @@ export default function HomePage() {
             Library Games
           </h1>
           <p className="text-muted-foreground mx-auto mt-4 max-w-xl text-lg">
-            A collection of classic and modern games — no downloads, no accounts, just play.
+            Discover what to play next, then jump into your library instantly.
           </p>
 
-          {/* Stats row */}
           <div className="mt-8 inline-flex flex-wrap justify-center gap-3">
             <div className="bg-card flex items-center gap-2 rounded-full border px-4 py-2 text-sm shadow-sm">
               <span className="text-foreground font-bold">{liveCount}</span>
@@ -43,8 +41,8 @@ export default function HomePage() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-5xl px-4 py-12">
-        <GameGrid games={games} />
+      <main className="mx-auto max-w-5xl px-4 py-10">
+        <HomeExperience games={games} />
       </main>
 
       <footer className="mt-20 border-t">

--- a/src/components/home/HomeExperience.tsx
+++ b/src/components/home/HomeExperience.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { type GameMeta } from '@/data/games'
+import { cn } from '@/lib/utils'
+import {
+  estimateMinutes,
+  matchesLibraryFilter,
+  sortLibraryGames,
+  type LibraryFilter,
+  type LibrarySort,
+} from './home-experience.logic'
+
+type HomeTab = 'discover' | 'library'
+
+interface HomeExperienceProps {
+  games: GameMeta[]
+}
+
+const LIBRARY_FILTERS: { value: LibraryFilter; label: string; emoji: string }[] = [
+  { value: 'all', label: 'All', emoji: '🎮' },
+  { value: 'single-player', label: 'Solo', emoji: '🧩' },
+  { value: 'online-multiplayer', label: 'Multiplayer', emoji: '👥' },
+  { value: 'party', label: 'Party', emoji: '🥳' },
+  { value: 'chill', label: 'Chill', emoji: '🫧' },
+]
+
+const LIBRARY_SORTS: { value: LibrarySort; label: string }[] = [
+  { value: 'popular', label: 'Popular' },
+  { value: 'a-z', label: 'A → Z' },
+  { value: 'quick', label: 'Quick games' },
+]
+
+function StoryCard({ game }: { game: GameMeta }) {
+  return (
+    <article className="from-card to-accent/40 rounded-3xl border bg-gradient-to-br p-6 shadow-sm">
+      <div className="mb-4 text-5xl">{game.emoji}</div>
+      <p className="text-muted-foreground mb-2 text-xs tracking-[0.16em] uppercase">Game story</p>
+      <h3 className="text-foreground text-2xl font-black">{game.title}</h3>
+      <p className="text-muted-foreground mt-2 text-sm">{game.description}</p>
+      <div className="mt-5 flex flex-wrap gap-2">
+        {game.tags.slice(0, 3).map((tag) => (
+          <span
+            key={tag}
+            className="bg-background rounded-full border px-2.5 py-1 text-xs capitalize"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+      <div className="mt-6 flex gap-2">
+        <Link
+          href={`/games/${game.slug}`}
+          className="bg-foreground text-background rounded-full px-4 py-2 text-sm font-semibold"
+        >
+          Play now
+        </Link>
+        <Link
+          href={`/games/${game.slug}`}
+          className="bg-background hover:bg-accent rounded-full border px-4 py-2 text-sm font-semibold transition-colors"
+        >
+          Details
+        </Link>
+      </div>
+    </article>
+  )
+}
+
+function DiscoverRow({ title, items }: { title: string; items: GameMeta[] }) {
+  if (items.length === 0) return null
+
+  return (
+    <section className="mt-8">
+      <h4 className="mb-3 text-sm font-bold tracking-tight">{title}</h4>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((game) => (
+          <Link
+            key={game.slug}
+            href={`/games/${game.slug}`}
+            className="bg-card hover:bg-accent/60 flex items-center justify-between rounded-2xl border px-4 py-3 transition-colors"
+          >
+            <div>
+              <p className="text-sm font-semibold">
+                {game.emoji} {game.title}
+              </p>
+              <p className="text-muted-foreground text-xs">~{estimateMinutes(game)} min</p>
+            </div>
+            <span className="text-muted-foreground text-xs">Open →</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function HomeExperience({ games }: HomeExperienceProps) {
+  const liveGames = useMemo(() => games.filter((game) => game.status === 'live'), [games])
+
+  const [activeTab, setActiveTab] = useState<HomeTab>('discover')
+  const [activeStoryIndex, setActiveStoryIndex] = useState(0)
+
+  const [query, setQuery] = useState('')
+  const [libraryFilter, setLibraryFilter] = useState<LibraryFilter>('all')
+  const [librarySort, setLibrarySort] = useState<LibrarySort>('popular')
+  const [favorites, setFavorites] = useState<string[]>([])
+
+  const discoverGames = useMemo(() => {
+    const prioritized = [...liveGames].sort((a, b) => {
+      if (a.category === b.category) return a.title.localeCompare(b.title)
+      return a.category === 'online-multiplayer' ? -1 : 1
+    })
+    return prioritized.slice(0, 7)
+  }, [liveGames])
+
+  const activeStory = discoverGames[activeStoryIndex] ?? discoverGames[0]
+
+  const quickGames = useMemo(
+    () => liveGames.filter((game) => estimateMinutes(game) <= 12).slice(0, 6),
+    [liveGames]
+  )
+
+  const multiplayerTonight = useMemo(
+    () => liveGames.filter((game) => game.category === 'online-multiplayer').slice(0, 6),
+    [liveGames]
+  )
+
+  const becauseYouPlayed = useMemo(() => {
+    const pool = [...liveGames]
+      .filter((game) => game.slug !== activeStory?.slug)
+      .sort((a, b) => estimateMinutes(a) - estimateMinutes(b))
+    return pool.slice(0, 6)
+  }, [activeStory?.slug, liveGames])
+
+  const libraryGames = useMemo(() => {
+    const byFilter = liveGames.filter((game) => matchesLibraryFilter(game, libraryFilter))
+    const byQuery = byFilter.filter((game) => {
+      if (!query.trim()) return true
+      const text = `${game.title} ${game.description} ${game.tags.join(' ')}`.toLowerCase()
+      return text.includes(query.trim().toLowerCase())
+    })
+    return sortLibraryGames(byQuery, librarySort)
+  }, [libraryFilter, librarySort, liveGames, query])
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-muted inline-flex rounded-full p-1">
+        <button
+          onClick={() => setActiveTab('discover')}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-semibold transition-colors',
+            activeTab === 'discover' ? 'bg-background border shadow-sm' : 'text-muted-foreground'
+          )}
+        >
+          ✨ Discover
+        </button>
+        <button
+          onClick={() => setActiveTab('library')}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-semibold transition-colors',
+            activeTab === 'library' ? 'bg-background border shadow-sm' : 'text-muted-foreground'
+          )}
+        >
+          📚 Library
+        </button>
+      </div>
+
+      {activeTab === 'discover' && activeStory && (
+        <section>
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="text-lg font-bold">Story mode</h3>
+            <div className="flex gap-2">
+              <button
+                onClick={() =>
+                  setActiveStoryIndex((prev) =>
+                    prev === 0 ? Math.max(discoverGames.length - 1, 0) : prev - 1
+                  )
+                }
+                className="bg-card hover:bg-accent rounded-full border px-3 py-1.5 text-sm"
+              >
+                ←
+              </button>
+              <button
+                onClick={() =>
+                  setActiveStoryIndex((prev) =>
+                    discoverGames.length === 0 ? 0 : (prev + 1) % discoverGames.length
+                  )
+                }
+                className="bg-card hover:bg-accent rounded-full border px-3 py-1.5 text-sm"
+              >
+                →
+              </button>
+            </div>
+          </div>
+
+          <StoryCard game={activeStory} />
+
+          <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
+            {discoverGames.map((game, index) => (
+              <button
+                key={game.slug}
+                onClick={() => setActiveStoryIndex(index)}
+                className={cn(
+                  'bg-card min-w-fit rounded-full border px-3 py-1.5 text-xs font-medium',
+                  index === activeStoryIndex && 'border-foreground'
+                )}
+              >
+                {game.emoji} {game.title}
+              </button>
+            ))}
+          </div>
+
+          <DiscoverRow title="Because you played puzzle games" items={becauseYouPlayed} />
+          <DiscoverRow title="Quick 10-min games" items={quickGames} />
+          <DiscoverRow title="Multiplayer tonight" items={multiplayerTonight} />
+        </section>
+      )}
+
+      {activeTab === 'library' && (
+        <section>
+          <div className="mb-4 grid gap-3 lg:grid-cols-[1.5fr,1fr]">
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search games, tags, vibes…"
+              className="bg-background rounded-xl border px-3 py-2 text-sm outline-none focus:ring-2"
+            />
+            <select
+              value={librarySort}
+              onChange={(event) => setLibrarySort(event.target.value as LibrarySort)}
+              className="bg-background rounded-xl border px-3 py-2 text-sm outline-none"
+            >
+              {LIBRARY_SORTS.map((sort) => (
+                <option key={sort.value} value={sort.value}>
+                  Sort: {sort.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="mb-4 flex flex-wrap gap-2">
+            {LIBRARY_FILTERS.map((filter) => (
+              <button
+                key={filter.value}
+                onClick={() => setLibraryFilter(filter.value)}
+                className={cn(
+                  'rounded-full border px-3 py-1.5 text-xs font-semibold',
+                  libraryFilter === filter.value
+                    ? 'bg-foreground text-background border-foreground'
+                    : 'bg-background hover:bg-accent'
+                )}
+              >
+                {filter.emoji} {filter.label}
+              </button>
+            ))}
+          </div>
+
+          {libraryGames.length === 0 ? (
+            <div className="text-muted-foreground rounded-2xl border border-dashed p-10 text-center text-sm">
+              No games match this filter yet.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {libraryGames.map((game) => {
+                const isFavorite = favorites.includes(game.slug)
+                return (
+                  <article key={game.slug} className="bg-card rounded-2xl border p-4">
+                    <div className="mb-2 flex items-start justify-between gap-3">
+                      <h4 className="text-sm font-bold">
+                        {game.emoji} {game.title}
+                      </h4>
+                      <button
+                        onClick={() =>
+                          setFavorites((prev) =>
+                            prev.includes(game.slug)
+                              ? prev.filter((slug) => slug !== game.slug)
+                              : [...prev, game.slug]
+                          )
+                        }
+                        className={cn(
+                          'rounded-full border px-2 py-0.5 text-xs',
+                          isFavorite ? 'border-amber-300 bg-amber-100' : 'bg-background'
+                        )}
+                      >
+                        {isFavorite ? '⭐' : '☆'}
+                      </button>
+                    </div>
+                    <p className="text-muted-foreground text-xs">{game.description}</p>
+                    <p className="text-muted-foreground mt-2 text-xs">
+                      {game.category === 'online-multiplayer' ? '👥 Multiplayer' : '🧩 Solo'} · ~
+                      {estimateMinutes(game)} min
+                    </p>
+                    <div className="mt-3 flex gap-2">
+                      <Link
+                        href={`/games/${game.slug}`}
+                        className="bg-foreground text-background rounded-full px-3 py-1.5 text-xs font-semibold"
+                      >
+                        Play
+                      </Link>
+                      <Link
+                        href={`/games/${game.slug}`}
+                        className="bg-background hover:bg-accent rounded-full border px-3 py-1.5 text-xs font-semibold"
+                      >
+                        Details
+                      </Link>
+                    </div>
+                  </article>
+                )
+              })}
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/components/home/home-experience.logic.test.ts
+++ b/src/components/home/home-experience.logic.test.ts
@@ -1,0 +1,47 @@
+import { games } from '@/data/games'
+import {
+  estimateMinutes,
+  matchesLibraryFilter,
+  sortLibraryGames,
+  type LibraryFilter,
+} from './home-experience.logic'
+
+describe('home-experience.logic', () => {
+  const wordle = games.find((game) => game.slug === 'wordle')
+  const mindmeld = games.find((game) => game.slug === 'mindmeld')
+  const cah = games.find((game) => game.slug === 'cards-against-humanity')
+
+  if (!wordle || !mindmeld || !cah) {
+    throw new Error('Fixture games missing from games.ts')
+  }
+
+  it('estimates longer sessions for multiplayer games', () => {
+    expect(estimateMinutes(wordle)).toBeLessThan(estimateMinutes(mindmeld))
+  })
+
+  it('matches party filter for party and drawing games', () => {
+    expect(matchesLibraryFilter(cah, 'party')).toBe(true)
+    expect(matchesLibraryFilter(mindmeld, 'party')).toBe(true)
+    expect(matchesLibraryFilter(wordle, 'party')).toBe(false)
+  })
+
+  it('supports category filters', () => {
+    const filters: LibraryFilter[] = ['single-player', 'online-multiplayer']
+
+    for (const filter of filters) {
+      const filtered = games.filter(
+        (game) => game.status === 'live' && matchesLibraryFilter(game, filter)
+      )
+      expect(filtered.every((game) => game.category === filter)).toBe(true)
+    }
+  })
+
+  it('sorts quick mode by estimated duration ascending', () => {
+    const sample = games.filter((game) => game.status === 'live').slice(0, 6)
+    const sorted = sortLibraryGames(sample, 'quick')
+
+    for (let i = 1; i < sorted.length; i += 1) {
+      expect(estimateMinutes(sorted[i - 1])).toBeLessThanOrEqual(estimateMinutes(sorted[i]))
+    }
+  })
+})

--- a/src/components/home/home-experience.logic.ts
+++ b/src/components/home/home-experience.logic.ts
@@ -1,0 +1,71 @@
+import { type GameMeta } from '@/data/games'
+
+export type LibraryFilter = 'all' | 'single-player' | 'online-multiplayer' | 'party' | 'chill'
+
+export type LibrarySort = 'popular' | 'a-z' | 'quick'
+
+const DURATION_BY_TAG: Record<string, number> = {
+  puzzle: 12,
+  word: 10,
+  arcade: 8,
+  classic: 10,
+  memory: 8,
+  cards: 20,
+  strategy: 25,
+  drawing: 18,
+  party: 20,
+  numbers: 12,
+  multiplayer: 20,
+}
+
+export function estimateMinutes(game: GameMeta): number {
+  if (game.category === 'online-multiplayer') return 20
+  const tagMinutes = game.tags
+    .map((tag) => DURATION_BY_TAG[tag])
+    .filter((value): value is number => typeof value === 'number')
+
+  if (tagMinutes.length === 0) return 12
+
+  const avg = tagMinutes.reduce((sum, value) => sum + value, 0) / tagMinutes.length
+  return Math.max(5, Math.round(avg))
+}
+
+export function matchesLibraryFilter(game: GameMeta, filter: LibraryFilter): boolean {
+  if (filter === 'all') return true
+  if (filter === 'single-player' || filter === 'online-multiplayer') return game.category === filter
+  if (filter === 'party') return game.tags.includes('party') || game.tags.includes('drawing')
+  if (filter === 'chill') {
+    return (
+      game.tags.includes('puzzle') ||
+      game.tags.includes('word') ||
+      game.tags.includes('memory') ||
+      game.tags.includes('classic')
+    )
+  }
+  return true
+}
+
+export function sortLibraryGames(games: GameMeta[], sort: LibrarySort): GameMeta[] {
+  const copy = [...games]
+
+  if (sort === 'a-z') {
+    return copy.sort((a, b) => a.title.localeCompare(b.title))
+  }
+
+  if (sort === 'quick') {
+    return copy.sort((a, b) => estimateMinutes(a) - estimateMinutes(b))
+  }
+
+  // popular
+  return copy.sort((a, b) => {
+    const multiplayerScoreA = a.category === 'online-multiplayer' ? 1 : 0
+    const multiplayerScoreB = b.category === 'online-multiplayer' ? 1 : 0
+    if (multiplayerScoreA !== multiplayerScoreB) return multiplayerScoreB - multiplayerScoreA
+
+    const partyScoreA = a.tags.includes('party') ? 1 : 0
+    const partyScoreB = b.tags.includes('party') ? 1 : 0
+    if (partyScoreA !== partyScoreB) return partyScoreB - partyScoreA
+
+    return a.title.localeCompare(b.title)
+  })
+}

--- a/src/games/mindmeld/MindmeldGame.tsx
+++ b/src/games/mindmeld/MindmeldGame.tsx
@@ -331,7 +331,9 @@ function clamp(value: number, min: number, max: number) {
 }
 
 function percentageToAngle(value: number) {
-  return 180 + value * 1.8
+  // Map 0..100 from left-to-right across the TOP arc of the dial.
+  // 0 -> 270° (left), 50 -> 360° (top), 100 -> 450° (right)
+  return 270 + value * 1.8
 }
 
 function polarToCartesian(cx: number, cy: number, radius: number, angle: number) {
@@ -419,14 +421,14 @@ function PsychicDial({
         </defs>
 
         <path
-          d={describeArc(centerX, centerY, radius, 180, 360)}
+          d={describeArc(centerX, centerY, radius, 270, 450)}
           fill="none"
           stroke="rgba(255,255,255,0.12)"
           strokeWidth="28"
           strokeLinecap="round"
         />
         <path
-          d={describeArc(centerX, centerY, radius, 180, 360)}
+          d={describeArc(centerX, centerY, radius, 270, 450)}
           fill="none"
           stroke="url(#mindmeld-track)"
           strokeOpacity="0.28"


### PR DESCRIPTION
## Summary
- replace homepage grid entry with a 2-tab experience: **Discover** + **Library**
- add story-mode hero in Discover with linked game rows
- add Library search, filters, sorting, favorites toggle, and direct game links
- add reusable home logic module with unit tests
- fix Mindmeld psychic dial orientation so left/center/right map correctly across the top arc

## Validation
- `pnpm lint`
- `pnpm test`

## Notes
- no Releases tab included (as requested)
- all navigation links route to existing game detail/play pages
