### PR TITLE
[codex] Redesign Skribbl multiplayer experience

### DIFF
--- a/src/app/games/skribbl/page.tsx
+++ b/src/app/games/skribbl/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { games } from '@/data/games'
-import { GameLayout } from '@/components/GameLayout'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { SkribblGame } from '@/games/skribbl/SkribblGame'
 
 const game = games.find((g) => g.slug === 'skribbl')!
@@ -12,8 +12,8 @@ export const metadata: Metadata = {
 
 export default function SkribblPage() {
   return (
-    <GameLayout title="Skribbl" slug="skribbl">
+    <ErrorBoundary>
       <SkribblGame />
-    </GameLayout>
+    </ErrorBoundary>
   )
 }

--- a/src/components/multiplayer/ArcadeAvatar.tsx
+++ b/src/components/multiplayer/ArcadeAvatar.tsx
@@ -1,0 +1,41 @@
+interface ArcadeAvatarProps {
+  index: number
+  size?: number
+}
+
+export function ArcadeAvatar({ index, size = 28 }: ArcadeAvatarProps) {
+  const hues = [130, 45, 200, 340, 95, 260, 20, 170]
+  const hue = hues[index % hues.length]
+  const mouthIndex = ((index % 4) + 4) % 4
+
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true">
+      <rect x="1" y="1" width="22" height="22" fill={`oklch(0.82 0.18 ${hue})`} />
+      {index % 4 === 0 && <rect x="4" y="2" width="16" height="4" fill="#1a1a1a" />}
+      {index % 4 === 1 && <path d="M 3 8 Q 12 3 21 8 L 20 10 L 4 10 Z" fill="#1a1a1a" />}
+      {index % 4 === 2 && <path d="M 6 6 L 18 6 L 16 3 L 8 3 Z" fill="#1a1a1a" />}
+      <circle cx="8" cy="12" r="1.6" fill="#1a1a1a" />
+      <circle cx="16" cy="12" r="1.6" fill="#1a1a1a" />
+      {mouthIndex === 0 && (
+        <path
+          d="M 8 17 Q 12 20 16 17"
+          stroke="#1a1a1a"
+          strokeWidth="1.4"
+          fill="none"
+          strokeLinecap="round"
+        />
+      )}
+      {mouthIndex === 1 && <path d="M 8 18 L 16 18" stroke="#1a1a1a" strokeWidth="1.4" />}
+      {mouthIndex === 2 && (
+        <path
+          d="M 9 18 Q 12 16 15 18"
+          stroke="#1a1a1a"
+          strokeWidth="1.4"
+          fill="none"
+          strokeLinecap="round"
+        />
+      )}
+      {mouthIndex === 3 && <circle cx="12" cy="18" r="1.4" fill="#1a1a1a" />}
+    </svg>
+  )
+}

--- a/src/components/multiplayer/ArcadeShell.module.css
+++ b/src/components/multiplayer/ArcadeShell.module.css
@@ -1,0 +1,355 @@
+.shell {
+  --arcade-bg: var(--bg);
+  --arcade-bg-2: var(--bg-2);
+  --arcade-bg-3: var(--bg-3);
+  --arcade-ink: var(--ink);
+  --arcade-ink-dim: var(--ink-dim);
+  --arcade-ink-mute: var(--ink-mute);
+  --arcade-line: var(--line);
+  --arcade-line-strong: var(--line-strong);
+  --arcade-accent: var(--acid);
+  --arcade-accent-ink: var(--acid-ink);
+  --arcade-amber: var(--amber);
+  --arcade-danger: var(--danger);
+  --arcade-success: oklch(0.72 0.18 145);
+  --arcade-highlight: oklch(0.58 0.2 330);
+  --arcade-highlight-soft: oklch(0.7 0.18 330);
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
+  background:
+    radial-gradient(
+      circle at top left,
+      color-mix(in oklch, var(--arcade-highlight-soft) 18%, transparent),
+      transparent 30%
+    ),
+    linear-gradient(180deg, color-mix(in oklch, #fff 90%, var(--arcade-bg)), var(--arcade-bg));
+  color: var(--arcade-ink);
+  font-family: var(--font-body);
+}
+
+.shell::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    linear-gradient(
+      to right,
+      color-mix(in oklch, var(--arcade-line) 80%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      color-mix(in oklch, var(--arcade-line) 80%, transparent) 1px,
+      transparent 1px
+    );
+  background-size: 48px 48px;
+  mask-image: radial-gradient(circle at center, black 30%, transparent 82%);
+  opacity: 0.35;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 16px 40px;
+  border-bottom: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, var(--arcade-bg) 88%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+.topbarSide {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.topbarSideStart {
+  justify-content: flex-start;
+}
+
+.topbarSideCenter {
+  justify-content: center;
+}
+
+.topbarSideRight {
+  justify-content: flex-end;
+}
+
+.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid var(--arcade-line-strong);
+  background: transparent;
+  padding: 0.45rem 0.8rem;
+  color: var(--arcade-ink-dim);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.back:hover {
+  color: var(--arcade-ink);
+  border-color: var(--arcade-ink);
+  background: var(--arcade-ink);
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 color-mix(in oklch, var(--arcade-highlight-soft) 25%, transparent);
+}
+
+.back:hover,
+.back:hover svg {
+  color: var(--arcade-bg);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+  color: var(--arcade-ink);
+  text-decoration: none;
+  font-family: var(--font-display);
+}
+
+.brandMark {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+  font-weight: 900;
+  font-size: 0.95rem;
+  transform: rotate(-4deg);
+  box-shadow: 3px 3px 0 var(--arcade-ink);
+}
+
+.brandText {
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.brandSuffix {
+  color: var(--arcade-ink-mute);
+  font-weight: 400;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+}
+
+.crumb {
+  min-width: 0;
+  color: var(--arcade-ink-mute);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  text-align: right;
+}
+
+.crumbAccent {
+  color: var(--arcade-highlight);
+}
+
+.stage {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: calc(100vh - 73px);
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.stageInner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 1120px;
+}
+
+.fullBleed {
+  position: relative;
+  z-index: 1;
+  min-height: calc(100vh - 73px);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 1px solid var(--arcade-ink);
+  background: var(--arcade-accent);
+  padding: 14px 26px;
+  color: var(--arcade-accent-ink);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    opacity 120ms ease,
+    background 150ms ease,
+    color 150ms ease;
+  box-shadow: 3px 3px 0 var(--arcade-ink);
+}
+
+.button:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 5px 0 var(--arcade-ink);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: none;
+  box-shadow: 3px 3px 0 var(--arcade-ink);
+}
+
+.buttonGhost {
+  background: transparent;
+  color: var(--arcade-ink);
+  border-color: var(--arcade-ink);
+  box-shadow: none;
+}
+
+.buttonGhost:hover {
+  transform: none;
+  box-shadow: none;
+  background: var(--arcade-ink);
+  color: var(--arcade-bg);
+}
+
+.buttonSmall {
+  padding: 8px 14px;
+  font-size: 11px;
+  box-shadow: 2px 2px 0 var(--arcade-ink);
+}
+
+.buttonSmall:hover {
+  box-shadow: 3px 3px 0 var(--arcade-ink);
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.panel {
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 82%, var(--arcade-bg-2));
+}
+
+.input {
+  width: 100%;
+  border: 1px solid var(--arcade-line-strong);
+  background: #fff;
+  padding: 0.9rem 1rem;
+  color: var(--arcade-ink);
+  font-family: var(--font-body);
+  outline: none;
+  transition: border-color 150ms ease;
+}
+
+.input:focus {
+  border-color: var(--arcade-accent);
+}
+
+@media (max-width: 960px) {
+  .topbar {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+      'back brand'
+      'crumb crumb';
+    align-items: center;
+    column-gap: 0.75rem;
+    row-gap: 0.75rem;
+    padding: 0.9rem 1rem;
+  }
+
+  .topbarSide {
+    min-width: 0;
+    width: auto;
+    flex: none;
+  }
+
+  .topbarSideStart {
+    grid-area: back;
+  }
+
+  .topbarSideCenter {
+    grid-area: brand;
+    justify-content: flex-end;
+  }
+
+  .topbarSideRight {
+    grid-area: crumb;
+    justify-content: flex-start;
+  }
+
+  .brand {
+    justify-content: flex-end;
+    max-width: 100%;
+    gap: 0.55rem;
+  }
+
+  .crumb {
+    text-align: left;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+  }
+
+  .stage {
+    padding-inline: 1rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .back {
+    padding: 0.4rem 0.65rem;
+  }
+
+  .brandText {
+    font-size: 0.95rem;
+  }
+
+  .brandSuffix {
+    display: none;
+  }
+
+  .crumb {
+    font-size: 0.58rem;
+    letter-spacing: 0.11em;
+  }
+}
+
+@media (max-width: 760px) and (max-height: 820px) {
+  .stage {
+    min-height: calc(100dvh - 73px);
+    align-items: flex-start;
+    padding: 0.9rem 0.85rem 1.1rem;
+  }
+}

--- a/src/components/multiplayer/ArcadeShell.tsx
+++ b/src/components/multiplayer/ArcadeShell.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import styles from './ArcadeShell.module.css'
+
+interface ArcadeShellProps {
+  title: string
+  crumb: React.ReactNode
+  children: React.ReactNode
+  centered?: boolean
+  backHref?: string
+}
+
+export function ArcadeShell({
+  title,
+  crumb,
+  children,
+  centered = true,
+  backHref = '/',
+}: ArcadeShellProps) {
+  return (
+    <div className={styles.shell}>
+      <header className={styles.topbar}>
+        <div className={cn(styles.topbarSide, styles.topbarSideStart)}>
+          <Link href={backHref} className={styles.back}>
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Library
+          </Link>
+        </div>
+
+        <div className={cn(styles.topbarSide, styles.topbarSideCenter, 'justify-center')}>
+          <Link href="/" className={styles.brand}>
+            <span className={styles.brandMark}>{title[0]}</span>
+            <span className={styles.brandText}>{title}</span>
+            <span className={styles.brandSuffix}>/ play</span>
+          </Link>
+        </div>
+
+        <div className={cn(styles.topbarSide, styles.topbarSideRight)}>
+          <div className={styles.crumb}>{crumb}</div>
+        </div>
+      </header>
+
+      {centered ? (
+        <main className={styles.stage}>
+          <div className={styles.stageInner}>{children}</div>
+        </main>
+      ) : (
+        <main className={styles.fullBleed}>{children}</main>
+      )}
+    </div>
+  )
+}
+
+export { styles as arcadeShellStyles }

--- a/src/games/skribbl/SkribblGame.module.css
+++ b/src/games/skribbl/SkribblGame.module.css
@@ -1,0 +1,1360 @@
+.hero {
+  display: grid;
+  grid-template-columns: 1.08fr 1fr;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.heroLeft {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tag {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--arcade-highlight);
+}
+
+.tag::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--arcade-accent);
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: clamp(3.1rem, 7vw, 5.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  font-weight: 800;
+}
+
+.heroTitleAccent {
+  display: inline-block;
+  padding-inline: 0.55rem;
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+  transform: rotate(-2deg);
+}
+
+.heroCopy {
+  max-width: 42rem;
+  margin: 0;
+  color: var(--arcade-ink-dim);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.heroMeta {
+  display: inline-flex;
+  align-items: center;
+  color: var(--arcade-ink-mute);
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.95rem;
+}
+
+.step {
+  display: flex;
+  min-height: 11rem;
+  flex-direction: column;
+  gap: 0.8rem;
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 75%, var(--arcade-bg-2));
+  padding: 1.2rem;
+}
+
+.stepAccent {
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+  border-color: var(--arcade-ink);
+}
+
+.stepNumber {
+  color: var(--arcade-ink-mute);
+}
+
+.stepAccent .stepNumber {
+  color: color-mix(in oklch, var(--arcade-accent-ink) 72%, transparent);
+}
+
+.stepIcon {
+  display: grid;
+  width: 3.1rem;
+  height: 3.1rem;
+  place-items: center;
+  border: 1px solid currentColor;
+  background: #fff;
+}
+
+.stepAccent .stepIcon {
+  background: color-mix(in oklch, #fff 72%, var(--arcade-accent));
+}
+
+.stepTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.stepDescription {
+  color: var(--arcade-ink-dim);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.stepAccent .stepDescription {
+  color: color-mix(in oklch, var(--arcade-accent-ink) 75%, transparent);
+}
+
+.entryShell {
+  width: 100%;
+  max-width: 36rem;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.entryHead {
+  text-align: center;
+}
+
+.entryHead h2,
+.pickerHead h2,
+.endTitle {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.entryHead p,
+.pickerHead p {
+  margin: 0.35rem 0 0;
+  color: var(--arcade-ink-dim);
+}
+
+.entryChoiceGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.entryCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  border: 1px solid var(--arcade-line);
+  background: #fff;
+  padding: 1.6rem;
+  color: inherit;
+  text-align: left;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    border-color 150ms ease;
+}
+
+.entryCard:hover {
+  transform: translate(-2px, -2px);
+  border-color: var(--arcade-ink);
+  box-shadow: 4px 4px 0 var(--arcade-ink);
+}
+
+.entryCardAccent {
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+  border-color: var(--arcade-ink);
+}
+
+.entryCardTitle {
+  font-size: 1.6rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.entryCardCopy {
+  color: var(--arcade-ink-dim);
+  font-size: 0.8rem;
+}
+
+.entryCardAccent .entryCardCopy {
+  color: color-mix(in oklch, var(--arcade-accent-ink) 72%, transparent);
+}
+
+.resumeCard,
+.entryForm {
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 75%, var(--arcade-bg-2));
+  padding: 1.6rem;
+}
+
+.resumeCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.resumeTitle {
+  font-weight: 700;
+}
+
+.resumeCopy {
+  color: var(--arcade-ink-dim);
+  font-size: 0.88rem;
+}
+
+.entryForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.label {
+  color: var(--arcade-ink-mute);
+}
+
+.codeInput {
+  text-align: center;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+}
+
+.avatarGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.avatarButton {
+  display: grid;
+  aspect-ratio: 1;
+  place-items: center;
+  border: 1px solid var(--arcade-line-strong);
+  background: #fff;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    transform 150ms ease;
+}
+
+.avatarButton:hover {
+  transform: translateY(-1px);
+  border-color: var(--arcade-ink);
+}
+
+.avatarButtonActive {
+  border-color: var(--arcade-accent);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--arcade-accent) 45%, transparent);
+}
+
+.entryActions,
+.endActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.error {
+  border: 1px solid color-mix(in oklch, var(--arcade-danger) 45%, transparent);
+  background: color-mix(in oklch, var(--arcade-danger) 12%, #fff);
+  padding: 0.85rem 1rem;
+  color: color-mix(in oklch, var(--arcade-danger) 78%, black);
+  font-size: 0.9rem;
+}
+
+.setup {
+  max-width: 36rem;
+  margin-inline: auto;
+  border: 1px solid var(--arcade-line);
+  background: #fff;
+  padding: 2rem;
+  text-align: center;
+}
+
+.setup p {
+  color: var(--arcade-ink-dim);
+}
+
+.setup pre {
+  overflow-x: auto;
+  border: 1px solid var(--arcade-line);
+  background: var(--arcade-bg-2);
+  padding: 1rem;
+  text-align: left;
+}
+
+.lobby {
+  display: grid;
+  grid-template-columns: 1.1fr 0.95fr;
+  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-areas:
+    'room side'
+    'room footer';
+  gap: 1.25rem;
+  min-height: min(43rem, calc(100dvh - 11rem));
+  max-height: calc(100dvh - 11rem);
+  align-items: stretch;
+}
+
+.roomCard {
+  grid-area: room;
+  position: relative;
+  display: flex;
+  height: 100%;
+  min-height: 23rem;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid var(--arcade-ink);
+  background: var(--arcade-ink);
+  padding: 2rem;
+  color: var(--arcade-bg);
+}
+
+.roomCard::before {
+  content: '';
+  position: absolute;
+  inset: 0.45rem;
+  border: 1px dashed color-mix(in oklch, #fff 30%, transparent);
+  pointer-events: none;
+}
+
+.roomLabel {
+  opacity: 0.65;
+}
+
+.roomCode {
+  font-size: clamp(4rem, 11vw, 6.2rem);
+  line-height: 1;
+  letter-spacing: 0.08em;
+  font-weight: 800;
+  color: var(--arcade-accent);
+  text-shadow: 4px 4px 0 color-mix(in oklch, #fff 18%, transparent);
+}
+
+.roomActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.roomAction {
+  display: inline-flex;
+  min-width: 10.75rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border: 1px solid color-mix(in oklch, #fff 40%, transparent);
+  background: transparent;
+  padding: 0.65rem 0.95rem;
+  color: #fff;
+  transition: background 150ms ease;
+}
+
+.roomAction:hover {
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+}
+
+.roomMeta {
+  margin-top: auto;
+  opacity: 0.55;
+}
+
+.lobbySide {
+  grid-area: side;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 1rem;
+  min-height: 0;
+}
+
+.playersPanel,
+.settingsPanel,
+.resultsTable,
+.scoreboard,
+.chat,
+.toolbar,
+.canvasSurface,
+.canvasMeta {
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 78%, var(--arcade-bg-2));
+}
+
+.playersPanel,
+.settingsPanel {
+  padding: 1.1rem 1.2rem;
+}
+
+.playersPanel {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.panelHead,
+.scoreHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-bottom: 0.8rem;
+  border-bottom: 1px solid var(--arcade-line);
+  color: var(--arcade-ink-mute);
+}
+
+.playerList {
+  margin-top: 0.9rem;
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.55rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.playerRow {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  border: 1px solid var(--arcade-line);
+  background: #fff;
+  padding: 0.75rem 0.85rem;
+}
+
+.playerRowYou {
+  border-color: var(--arcade-accent);
+}
+
+.playerAvatar {
+  display: grid;
+  width: 2.4rem;
+  height: 2.4rem;
+  place-items: center;
+  background: var(--arcade-bg-2);
+}
+
+.playerInfo {
+  min-width: 0;
+  flex: 1;
+}
+
+.playerName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.playerMeta {
+  margin-top: 0.15rem;
+  color: var(--arcade-ink-mute);
+  font-size: 0.76rem;
+}
+
+.playerTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.playerTag {
+  border: 1px solid var(--arcade-line);
+  padding: 0.2rem 0.35rem;
+  color: var(--arcade-ink-mute);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.playerTagHost {
+  border-color: var(--arcade-highlight);
+  color: var(--arcade-highlight);
+}
+
+.playerRemove {
+  background: transparent;
+  cursor: pointer;
+}
+
+.playerRemove:hover {
+  border-color: var(--arcade-danger);
+  color: var(--arcade-danger);
+}
+
+.settingsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.settingsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.pillGroup {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  align-self: flex-start;
+  border: 1px solid var(--arcade-line);
+  background: #fff;
+}
+
+.pill {
+  border: 0;
+  background: transparent;
+  padding: 0.55rem 0.8rem;
+  color: var(--arcade-ink-dim);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 0.7rem;
+}
+
+.pillActive {
+  background: var(--arcade-ink);
+  color: var(--arcade-bg);
+}
+
+.lobbyFooter {
+  grid-area: footer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 78%, var(--arcade-bg-2));
+  padding: 1rem 1.2rem;
+}
+
+.waiting {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--arcade-ink-mute);
+}
+
+.waiting::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--arcade-accent);
+  animation: pulse 1.2s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.35;
+    transform: scale(0.7);
+  }
+}
+
+.pickerShell,
+.endShell {
+  width: 100%;
+  max-width: 58rem;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.4rem;
+}
+
+.pickerHead,
+.endShell {
+  text-align: center;
+}
+
+.pickerTimer {
+  width: 100%;
+  max-width: 32rem;
+  height: 0.3rem;
+  background: var(--arcade-line);
+  overflow: hidden;
+}
+
+.pickerTimerBar {
+  height: 100%;
+  background: var(--arcade-accent);
+  transition: width 120ms linear;
+}
+
+.pickerGrid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.wordCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+  border: 1px solid var(--arcade-line);
+  background: #fff;
+  padding: 1.8rem 1rem;
+  text-align: center;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    border-color 150ms ease,
+    background 150ms ease;
+}
+
+.wordCard:hover {
+  transform: translate(-3px, -3px);
+  box-shadow: 6px 6px 0 var(--arcade-ink);
+  border-color: var(--arcade-ink);
+}
+
+.wordCard:nth-child(2):hover {
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+}
+
+.wordIndex {
+  color: var(--arcade-ink-mute);
+}
+
+.wordDifficulty {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  gap: 0.2rem;
+}
+
+.wordDot {
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+
+.wordDotActive {
+  background: currentColor;
+}
+
+.wordText {
+  font-size: 1.9rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  text-wrap: balance;
+}
+
+.wordHint {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.wordHintBox {
+  width: 0.9rem;
+  height: 1.1rem;
+  border-bottom: 2px solid currentColor;
+}
+
+.wordHintSpace {
+  width: 0.45rem;
+}
+
+.skeletonGrid {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.skeletonCard {
+  display: grid;
+  height: 11rem;
+  place-items: center;
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 75%, var(--arcade-bg-2));
+}
+
+.skeletonBar {
+  width: 2.8rem;
+  height: 0.35rem;
+  background: var(--arcade-line-strong);
+  animation: pulse 1.2s infinite;
+}
+
+.board {
+  display: grid;
+  height: calc(100dvh - 73px);
+  min-height: calc(100dvh - 73px);
+  max-height: calc(100dvh - 73px);
+  grid-template-columns: 16rem minmax(0, 1fr) 19rem;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.hud {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 16rem minmax(0, 1fr) 19rem;
+  align-items: stretch;
+  border-bottom: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 78%, var(--arcade-bg-2));
+}
+
+.hudSection {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+}
+
+.hudSectionCenter {
+  justify-content: center;
+  border-inline: 1px solid var(--arcade-line);
+}
+
+.hudSectionRight {
+  justify-content: flex-end;
+}
+
+.roundBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.roundLabel {
+  color: var(--arcade-ink-mute);
+}
+
+.roundValue {
+  font-size: 1.15rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.hintDrawer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.hintLabel {
+  color: var(--arcade-ink-mute);
+}
+
+.hintWord {
+  padding: 0.2rem 0.8rem;
+  background: var(--arcade-ink);
+  color: var(--arcade-accent);
+  font-size: 1.7rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.hintMask {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: clamp(1.25rem, 2.4vw, 1.9rem);
+  letter-spacing: 0.3em;
+}
+
+.timer {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.timerNumber {
+  min-width: 2.4ch;
+  text-align: right;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.timerWarn {
+  color: var(--arcade-amber);
+}
+
+.timerCrit {
+  color: var(--arcade-danger);
+  animation: flash 0.7s infinite;
+}
+
+@keyframes flash {
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.timerRing {
+  width: 2.8rem;
+  height: 2.8rem;
+}
+
+.scoreboard {
+  min-height: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--arcade-line);
+}
+
+.scoreHead {
+  padding: 0.9rem 1rem;
+}
+
+.scoreRows {
+  display: flex;
+  flex-direction: column;
+}
+
+.scoreRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1.2rem 2.2rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  border-bottom: 1px solid var(--arcade-line);
+  padding: 0.8rem 0.95rem;
+  background: color-mix(in oklch, #fff 90%, var(--arcade-bg-2));
+}
+
+.scoreRowYou {
+  background: color-mix(in oklch, var(--arcade-accent) 13%, #fff);
+}
+
+.scoreRowDrawer::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 0.18rem;
+  background: var(--arcade-accent);
+}
+
+.scoreRowGuessed .scoreName {
+  color: oklch(0.45 0.18 145);
+}
+
+.scoreRank {
+  color: var(--arcade-ink-mute);
+  text-align: center;
+}
+
+.scoreName {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.scoreBadge {
+  border: 1px solid var(--arcade-line);
+  padding: 0.1rem 0.25rem;
+  color: var(--arcade-ink-mute);
+  font-size: 0.56rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.scoreValue {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  font-weight: 700;
+}
+
+.scoreDelta {
+  position: absolute;
+  top: -0.15rem;
+  right: 0.85rem;
+  color: var(--arcade-highlight);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.canvasColumn {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+.canvasSurface {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  box-shadow: 6px 6px 0 var(--arcade-ink);
+  background: #fff;
+}
+
+.canvasSurface canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  touch-action: none;
+}
+
+.canvasReadOnly canvas {
+  cursor: default;
+}
+
+.canvasWatermark {
+  position: absolute;
+  right: 0.9rem;
+  bottom: 0.7rem;
+  color: oklch(0.75 0 0);
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.8rem 1rem;
+}
+
+.toolGroup {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding-right: 0.9rem;
+  border-right: 1px solid var(--arcade-line);
+}
+
+.toolGroup:last-child {
+  border-right: 0;
+  padding-right: 0;
+}
+
+.toolLabel {
+  color: var(--arcade-ink-mute);
+}
+
+.colorButton {
+  width: 1.45rem;
+  height: 1.45rem;
+  border: 1px solid color-mix(in oklch, var(--arcade-ink) 22%, transparent);
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.colorButton:hover {
+  transform: scale(1.08);
+}
+
+.colorButtonActive {
+  box-shadow:
+    0 0 0 2px #fff,
+    0 0 0 3px var(--arcade-ink);
+  transform: scale(1.08);
+}
+
+.sizeButton,
+.toolButton {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: 1px solid var(--arcade-line);
+  background: #fff;
+  color: var(--arcade-ink-dim);
+}
+
+.sizeButtonActive {
+  border-color: var(--arcade-accent);
+  box-shadow: 0 0 0 1px var(--arcade-accent);
+}
+
+.sizeDot {
+  border-radius: 999px;
+  background: var(--arcade-ink);
+}
+
+.toolButton:hover,
+.sizeButton:hover {
+  border-color: var(--arcade-ink);
+  color: var(--arcade-ink);
+}
+
+.toolButtonActive {
+  background: var(--arcade-ink);
+  color: #fff;
+  border-color: var(--arcade-ink);
+}
+
+.toolButtonDanger:hover {
+  color: var(--arcade-danger);
+  border-color: var(--arcade-danger);
+}
+
+.toolbarInfo {
+  justify-content: center;
+  color: var(--arcade-ink-mute);
+}
+
+.chat {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  border-left: 1px solid var(--arcade-line);
+}
+
+.chatLog {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.message {
+  border-left: 2px solid transparent;
+  padding: 0.45rem 0.65rem;
+  line-height: 1.4;
+  word-break: break-word;
+  font-size: 0.86rem;
+}
+
+.messageName {
+  margin-right: 0.35rem;
+  font-weight: 700;
+}
+
+.messageSystem {
+  border-left-color: var(--arcade-line);
+  color: var(--arcade-ink-mute);
+}
+
+.messageCorrect {
+  border-left-color: var(--arcade-accent);
+  background: color-mix(in oklch, var(--arcade-accent) 12%, #fff);
+  font-weight: 600;
+}
+
+.messageClose {
+  border-left-color: var(--arcade-amber);
+  background: color-mix(in oklch, var(--arcade-amber) 15%, #fff);
+}
+
+.chatForm {
+  display: flex;
+  gap: 0.45rem;
+  border-top: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 75%, var(--arcade-bg-2));
+  padding: 0.7rem;
+}
+
+.chatInput {
+  flex: 1;
+  border: 1px solid var(--arcade-line-strong);
+  background: #fff;
+  padding: 0.7rem 0.85rem;
+  outline: none;
+}
+
+.chatInput:focus {
+  border-color: var(--arcade-accent);
+}
+
+.chatInput:disabled {
+  opacity: 0.5;
+}
+
+.chatSend {
+  border: 1px solid var(--arcade-ink);
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+  padding: 0 0.95rem;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.chatSend:disabled {
+  opacity: 0.45;
+}
+
+.endMeta {
+  color: var(--arcade-ink-mute);
+}
+
+.endWord {
+  color: var(--arcade-ink-dim);
+}
+
+.endWordAccent {
+  display: inline-block;
+  margin-left: 0.45rem;
+  background: var(--arcade-ink);
+  padding: 0.15rem 0.55rem;
+  color: var(--arcade-accent);
+  font-size: 1.2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.resultsTable {
+  width: 100%;
+}
+
+.resultRow {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.9rem;
+  border-bottom: 1px solid var(--arcade-line);
+  padding: 0.95rem 1.15rem;
+}
+
+.resultRow:last-child {
+  border-bottom: 0;
+}
+
+.resultRowWinner {
+  background: var(--arcade-accent);
+  color: var(--arcade-accent-ink);
+}
+
+.resultPlayer {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+  font-weight: 700;
+}
+
+.resultPlayer span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resultDelta,
+.resultTotal {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+}
+
+.resultTotal {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.endCountdown {
+  color: var(--arcade-ink-mute);
+}
+
+@media (max-width: 1100px) {
+  .hero,
+  .lobby {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-template-areas:
+      'room'
+      'side'
+      'footer';
+    min-height: auto;
+    max-height: none;
+  }
+
+  .board,
+  .hud {
+    grid-template-columns: 1fr;
+  }
+
+  .hudSectionCenter {
+    border-inline: 0;
+    border-top: 1px solid var(--arcade-line);
+    border-bottom: 1px solid var(--arcade-line);
+  }
+
+  .scoreboard {
+    border-right: 0;
+    border-bottom: 1px solid var(--arcade-line);
+    max-height: 16rem;
+  }
+
+  .chat {
+    border-left: 0;
+    border-top: 1px solid var(--arcade-line);
+    max-height: 20rem;
+  }
+
+  .lobbySide,
+  .playersPanel,
+  .playerList {
+    min-height: auto;
+  }
+
+  .playerList {
+    overflow: visible;
+    padding-right: 0;
+  }
+}
+
+@media (max-width: 760px) {
+  .entryShell {
+    gap: 0.9rem;
+  }
+
+  .entryHead h2 {
+    font-size: clamp(1.6rem, 7vw, 2.1rem);
+  }
+
+  .entryHead p {
+    margin-top: 0.2rem;
+    font-size: 0.9rem;
+  }
+
+  .steps,
+  .entryChoiceGrid,
+  .pickerGrid,
+  .skeletonGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .avatarGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.45rem;
+  }
+
+  .lobbyFooter,
+  .resumeCard,
+  .settingsRow,
+  .entryActions,
+  .endActions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .roomCard {
+    min-height: auto;
+  }
+
+  .resultRow {
+    grid-template-columns: 1.5rem minmax(0, 1fr) auto;
+  }
+
+  .resultDelta {
+    display: none;
+  }
+
+  .entryCard {
+    padding: 1.15rem;
+    gap: 0.65rem;
+  }
+
+  .entryCardTitle {
+    font-size: 1.25rem;
+  }
+
+  .resumeCard,
+  .entryForm {
+    padding: 1rem;
+  }
+
+  .entryForm {
+    gap: 0.75rem;
+  }
+
+  .field {
+    gap: 0.35rem;
+  }
+
+  .codeInput {
+    font-size: 1.15rem;
+    letter-spacing: 0.24em;
+  }
+
+  .avatarButton {
+    min-height: 3.25rem;
+  }
+}
+
+@media (max-width: 760px) and (max-height: 820px) {
+  .entryShell {
+    max-width: 32rem;
+    gap: 0.75rem;
+  }
+
+  .entryHead h2 {
+    font-size: 1.45rem;
+  }
+
+  .entryHead p {
+    font-size: 0.82rem;
+  }
+
+  .entryCard {
+    padding: 0.95rem 1rem;
+  }
+
+  .entryCardCopy {
+    font-size: 0.72rem;
+  }
+
+  .resumeCard,
+  .entryForm {
+    padding: 0.85rem;
+  }
+
+  .entryForm {
+    gap: 0.6rem;
+  }
+
+  .avatarGrid {
+    gap: 0.35rem;
+  }
+
+  .avatarButton {
+    min-height: 2.75rem;
+  }
+
+  .entryActions {
+    gap: 0.55rem;
+  }
+}

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -1,162 +1,308 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
-import { cn } from '@/lib/utils'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Copy, Eraser, Link2, PencilLine, Trash2, Undo2 } from 'lucide-react'
+import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
-import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
+import { cn } from '@/lib/utils'
+import { ArcadeAvatar } from '@/components/multiplayer/ArcadeAvatar'
+import { ArcadeShell, arcadeShellStyles } from '@/components/multiplayer/ArcadeShell'
+import { useSkribblRoom, type UseSkribblRoomReturn } from './useSkribblRoom'
 import {
-  ResumeSessionButton,
-  type SavedSessionSummary,
-} from '@/components/multiplayer/ResumeSessionButton'
-import { useSkribblRoom } from './useSkribblRoom'
-import {
-  getCurrentDrawer,
   decodeWord,
-  type DrawStroke,
+  getCurrentDrawer,
   type DrawPoint,
+  type DrawStroke,
+  type GameAction,
   type GameState,
 } from './logic'
-
-// ─── Drawing Canvas ───────────────────────────────────────────────────────────
+import styles from './SkribblGame.module.css'
 
 const COLORS = [
   '#000000',
-  '#FFFFFF',
-  '#808080',
-  '#C0C0C0',
-  '#800000',
-  '#FF0000',
-  '#FF6600',
-  '#FFCC00',
-  '#FFFF00',
-  '#00FF00',
-  '#008000',
-  '#00FFFF',
-  '#0000FF',
-  '#800080',
-  '#FF00FF',
-  '#FF69B4',
+  '#555555',
+  '#888888',
+  '#c5c5c5',
+  '#ffffff',
+  '#7a1b1b',
+  '#e53935',
+  '#fb8c00',
+  '#fdd835',
+  '#ffee58',
+  '#2e7d32',
+  '#66bb6a',
+  '#00acc1',
+  '#1e88e5',
+  '#3949ab',
+  '#8e24aa',
+  '#d81b60',
+  '#f06292',
+  '#8d6e63',
+  '#5d4037',
 ]
 
-const BRUSH_SIZES = [3, 6, 12, 24]
+const BRUSH_SIZES = [3, 6, 12, 22]
+const WORD_PICKER_SECONDS = 15
+const ROUND_END_DELAY = 5
+const AVATAR_STORAGE_KEY = 'library-games:skribbl-avatar'
 
-interface CanvasProps {
-  strokes: DrawStroke[]
-  isDrawer: boolean
-  onStrokeComplete: (stroke: DrawStroke) => void
-  onClear: () => void
-  onUndo: () => void
+function getSavedAvatar(): number {
+  if (typeof window === 'undefined') return 0
+  try {
+    const raw = Number(localStorage.getItem(AVATAR_STORAGE_KEY) ?? '0')
+    if (Number.isInteger(raw) && raw >= 0 && raw <= 7) return raw
+  } catch {}
+  return 0
 }
 
-function DrawingCanvas({ strokes, isDrawer, onStrokeComplete, onClear, onUndo }: CanvasProps) {
+function saveAvatar(index: number) {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(AVATAR_STORAGE_KEY, String(index))
+  } catch {}
+}
+
+function makeCrumb(
+  gameState: GameState | null,
+  roomCode: string | null,
+  playerId: string | null,
+  inviteCode: string | null | undefined
+) {
+  if (!gameState) {
+    return (
+      <>
+        /{' '}
+        <span className={arcadeShellStyles.crumbAccent}>
+          {inviteCode === undefined ? 'Loading' : inviteCode ? 'Join a game' : 'How to play'}
+        </span>
+      </>
+    )
+  }
+
+  const drawer = getCurrentDrawer(gameState)
+  const isMyTurn = drawer?.id === playerId
+
+  if (gameState.phase === 'lobby') {
+    return (
+      <>
+        / Lobby · <span className={arcadeShellStyles.crumbAccent}>{roomCode}</span>
+      </>
+    )
+  }
+
+  if (gameState.phase === 'picking') {
+    return (
+      <>
+        / Round {gameState.round} ·{' '}
+        <span className={arcadeShellStyles.crumbAccent}>
+          {isMyTurn ? 'Your turn' : `${drawer?.name ?? 'Player'} picking`}
+        </span>
+      </>
+    )
+  }
+
+  if (gameState.phase === 'drawing') {
+    return (
+      <>
+        / Round {gameState.round} · <span className={arcadeShellStyles.crumbAccent}>Drawing</span>
+      </>
+    )
+  }
+
+  if (gameState.phase === 'round-end') {
+    return (
+      <>
+        / Round {gameState.round} · <span className={arcadeShellStyles.crumbAccent}>Reveal</span>
+      </>
+    )
+  }
+
+  return (
+    <>
+      / <span className={arcadeShellStyles.crumbAccent}>Game over</span>
+    </>
+  )
+}
+
+function TimerRing({
+  startTime,
+  duration,
+  onTimeUp,
+}: {
+  startTime: number
+  duration: number
+  onTimeUp: () => void
+}) {
+  const [remaining, setRemaining] = useState(duration)
+  const firedRef = useRef(false)
+
+  useEffect(() => {
+    firedRef.current = false
+
+    const tick = () => {
+      const left = Math.max(0, duration - (Date.now() - startTime) / 1000)
+      setRemaining(Math.ceil(left))
+      if (left <= 0 && !firedRef.current) {
+        firedRef.current = true
+        onTimeUp()
+      }
+    }
+
+    tick()
+    const interval = window.setInterval(tick, 250)
+    return () => window.clearInterval(interval)
+  }, [duration, onTimeUp, startTime])
+
+  const progress = Math.max(0, Math.min(1, remaining / duration))
+  const circumference = 2 * Math.PI * 18
+  const dashOffset = circumference * (1 - progress)
+  const numberClassName = cn(
+    styles.timerNumber,
+    remaining <= 10 && styles.timerCrit,
+    remaining > 10 && remaining <= 25 && styles.timerWarn
+  )
+  const strokeColor =
+    remaining <= 10
+      ? 'var(--arcade-danger)'
+      : remaining <= 25
+        ? 'var(--arcade-amber)'
+        : 'var(--arcade-accent)'
+
+  return (
+    <div className={styles.timer}>
+      <svg viewBox="0 0 44 44" className={styles.timerRing}>
+        <circle cx="22" cy="22" r="18" fill="none" stroke="var(--arcade-line)" strokeWidth="3" />
+        <circle
+          cx="22"
+          cy="22"
+          r="18"
+          fill="none"
+          stroke={strokeColor}
+          strokeWidth="3"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          transform="rotate(-90 22 22)"
+          strokeLinecap="round"
+          style={{ transition: 'stroke-dashoffset 250ms linear' }}
+        />
+      </svg>
+      <span className={numberClassName}>{remaining}</span>
+      <span className={arcadeShellStyles.mono}>s</span>
+    </div>
+  )
+}
+
+function DrawingCanvas({
+  strokes,
+  isDrawer,
+  color,
+  size,
+  tool,
+  onStrokeComplete,
+}: {
+  strokes: DrawStroke[]
+  isDrawer: boolean
+  color: string
+  size: number
+  tool: 'pen' | 'eraser'
+  onStrokeComplete: (stroke: DrawStroke) => void
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [color, setColor] = useState('#000000')
-  const [brushSize, setBrushSize] = useState(6)
-  const [tool, setTool] = useState<'pen' | 'eraser'>('pen')
-  const [isDrawing, setIsDrawing] = useState(false)
+  const drawingRef = useRef(false)
   const currentStrokeRef = useRef<DrawPoint[]>([])
 
-  const drawAll = useCallback(
-    (ctx: CanvasRenderingContext2D, allStrokes: DrawStroke[], currentPoints?: DrawPoint[]) => {
-      ctx.fillStyle = '#FFFFFF'
-      ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+  const redraw = useCallback(
+    (preview?: DrawPoint[]) => {
+      const canvas = canvasRef.current
+      if (!canvas) return
 
-      const toDraw = [...allStrokes]
-      if (currentPoints && currentPoints.length > 0) {
-        toDraw.push({ points: currentPoints })
-      }
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
 
-      for (const stroke of toDraw) {
+      ctx.fillStyle = '#ffffff'
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      const allStrokes = preview && preview.length > 0 ? [...strokes, { points: preview }] : strokes
+
+      for (const stroke of allStrokes) {
         if (stroke.points.length === 0) continue
+
         ctx.beginPath()
         ctx.lineCap = 'round'
         ctx.lineJoin = 'round'
 
         const first = stroke.points[0]
-        ctx.strokeStyle = first.tool === 'eraser' ? '#FFFFFF' : first.color
+        ctx.strokeStyle = first.tool === 'eraser' ? '#ffffff' : first.color
         ctx.lineWidth = first.size
-
         ctx.moveTo(first.x, first.y)
-        for (let i = 1; i < stroke.points.length; i++) {
-          ctx.lineTo(stroke.points[i].x, stroke.points[i].y)
+
+        for (let index = 1; index < stroke.points.length; index += 1) {
+          ctx.lineTo(stroke.points[index].x, stroke.points[index].y)
         }
+
         if (stroke.points.length === 1) {
           ctx.lineTo(first.x + 0.1, first.y + 0.1)
         }
+
         ctx.stroke()
       }
     },
-    []
+    [strokes]
   )
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-    drawAll(ctx, strokes)
-  }, [strokes, drawAll])
+    redraw()
+  }, [redraw])
 
-  function getPos(e: React.MouseEvent | React.TouchEvent): { x: number; y: number } | null {
+  function getPosition(
+    event: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
+  ) {
     const canvas = canvasRef.current
     if (!canvas) return null
+
     const rect = canvas.getBoundingClientRect()
     const scaleX = canvas.width / rect.width
     const scaleY = canvas.height / rect.height
-    if ('touches' in e) {
-      const touch = e.touches[0] || e.changedTouches[0]
-      return {
-        x: (touch.clientX - rect.left) * scaleX,
-        y: (touch.clientY - rect.top) * scaleY,
-      }
-    }
+    const point = 'touches' in event ? event.touches[0] || event.changedTouches[0] : event
+
     return {
-      x: (e.clientX - rect.left) * scaleX,
-      y: (e.clientY - rect.top) * scaleY,
+      x: (point.clientX - rect.left) * scaleX,
+      y: (point.clientY - rect.top) * scaleY,
     }
   }
 
-  function handleStart(e: React.MouseEvent | React.TouchEvent) {
+  function startStroke(
+    event: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
+  ) {
     if (!isDrawer) return
-    e.preventDefault()
-    const pos = getPos(e)
-    if (!pos) return
-    setIsDrawing(true)
-    const point: DrawPoint = {
-      x: pos.x,
-      y: pos.y,
-      color: tool === 'eraser' ? '#FFFFFF' : color,
-      size: brushSize,
-      tool,
-    }
-    currentStrokeRef.current = [point]
+    event.preventDefault()
 
-    const ctx = canvasRef.current?.getContext('2d')
-    if (ctx) drawAll(ctx, strokes, currentStrokeRef.current)
+    const position = getPosition(event)
+    if (!position) return
+
+    drawingRef.current = true
+    currentStrokeRef.current = [{ ...position, color, size, tool }]
+    redraw(currentStrokeRef.current)
   }
 
-  function handleMove(e: React.MouseEvent | React.TouchEvent) {
-    if (!isDrawing || !isDrawer) return
-    e.preventDefault()
-    const pos = getPos(e)
-    if (!pos) return
-    const point: DrawPoint = {
-      x: pos.x,
-      y: pos.y,
-      color: tool === 'eraser' ? '#FFFFFF' : color,
-      size: brushSize,
-      tool,
-    }
-    currentStrokeRef.current.push(point)
+  function moveStroke(
+    event: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
+  ) {
+    if (!isDrawer || !drawingRef.current) return
+    event.preventDefault()
 
-    const ctx = canvasRef.current?.getContext('2d')
-    if (ctx) drawAll(ctx, strokes, currentStrokeRef.current)
+    const position = getPosition(event)
+    if (!position) return
+
+    currentStrokeRef.current.push({ ...position, color, size, tool })
+    redraw(currentStrokeRef.current)
   }
 
-  function handleEnd() {
-    if (!isDrawing || !isDrawer) return
-    setIsDrawing(false)
+  function endStroke() {
+    if (!isDrawer || !drawingRef.current) return
+
+    drawingRef.current = false
     if (currentStrokeRef.current.length > 0) {
       onStrokeComplete({ points: currentStrokeRef.current })
       currentStrokeRef.current = []
@@ -164,186 +310,24 @@ function DrawingCanvas({ strokes, isDrawer, onStrokeComplete, onClear, onUndo }:
   }
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="border-border overflow-hidden rounded-xl border-2 bg-white shadow-inner">
-        <canvas
-          ref={canvasRef}
-          width={600}
-          height={400}
-          className={cn(
-            'h-auto w-full touch-none',
-            isDrawer ? 'cursor-crosshair' : 'cursor-default'
-          )}
-          onMouseDown={handleStart}
-          onMouseMove={handleMove}
-          onMouseUp={handleEnd}
-          onMouseLeave={handleEnd}
-          onTouchStart={handleStart}
-          onTouchMove={handleMove}
-          onTouchEnd={handleEnd}
-        />
-      </div>
-
-      {isDrawer && (
-        <div className="bg-secondary/60 flex flex-wrap items-center justify-center gap-2 rounded-xl p-2">
-          {/* Colors */}
-          <div className="flex flex-wrap gap-1">
-            {COLORS.map((c) => (
-              <button
-                key={c}
-                onClick={() => {
-                  setColor(c)
-                  setTool('pen')
-                }}
-                className={cn(
-                  'h-6 w-6 rounded-full border-2 transition-transform hover:scale-110',
-                  color === c && tool === 'pen'
-                    ? 'border-foreground scale-110'
-                    : 'border-transparent'
-                )}
-                style={{ backgroundColor: c }}
-                title={c}
-              />
-            ))}
-          </div>
-
-          <div className="bg-border mx-1 h-6 w-px" />
-
-          {/* Brush sizes */}
-          <div className="flex items-center gap-1">
-            {BRUSH_SIZES.map((s) => (
-              <button
-                key={s}
-                onClick={() => setBrushSize(s)}
-                className={cn(
-                  'flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
-                  brushSize === s ? 'bg-foreground/20' : 'hover:bg-foreground/10'
-                )}
-                title={`Size ${s}`}
-              >
-                <div
-                  className="bg-foreground rounded-full"
-                  style={{ width: Math.min(s, 20), height: Math.min(s, 20) }}
-                />
-              </button>
-            ))}
-          </div>
-
-          <div className="bg-border mx-1 h-6 w-px" />
-
-          {/* Tools */}
-          <button
-            onClick={() => setTool(tool === 'eraser' ? 'pen' : 'eraser')}
-            className={cn(
-              'rounded-lg px-2 py-1 text-xs font-medium transition-colors',
-              tool === 'eraser' ? 'bg-foreground/20 text-foreground' : 'hover:bg-foreground/10'
-            )}
-          >
-            {tool === 'eraser' ? 'Eraser' : 'Eraser'}
-          </button>
-          <button
-            onClick={onUndo}
-            className="hover:bg-foreground/10 rounded-lg px-2 py-1 text-xs font-medium"
-          >
-            Undo
-          </button>
-          <button
-            onClick={onClear}
-            className="rounded-lg px-2 py-1 text-xs font-medium text-red-500 hover:bg-red-500/10"
-          >
-            Clear
-          </button>
-        </div>
-      )}
+    <div className={cn(styles.canvasSurface, !isDrawer && styles.canvasReadOnly)}>
+      <canvas
+        ref={canvasRef}
+        width={800}
+        height={560}
+        onMouseDown={startStroke}
+        onMouseMove={moveStroke}
+        onMouseUp={endStroke}
+        onMouseLeave={endStroke}
+        onTouchStart={startStroke}
+        onTouchMove={moveStroke}
+        onTouchEnd={endStroke}
+      />
+      <span className={cn(styles.canvasWatermark, arcadeShellStyles.mono)}>
+        Library Games · Skribbl
+      </span>
     </div>
   )
-}
-
-// ─── Chat / Guess Panel ───────────────────────────────────────────────────────
-
-interface ChatPanelProps {
-  messages: GameState['messages']
-  isDrawer: boolean
-  hasGuessed: boolean
-  onGuess: (text: string) => void
-}
-
-function ChatPanel({ messages, isDrawer, hasGuessed, onGuess }: ChatPanelProps) {
-  const [input, setInput] = useState('')
-  const scrollRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-    }
-  }, [messages.length])
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!input.trim()) return
-    onGuess(input)
-    setInput('')
-  }
-
-  const canGuess = !isDrawer && !hasGuessed
-
-  return (
-    <div className="bg-background flex max-h-[400px] flex-col rounded-xl border">
-      <div className="text-muted-foreground border-b px-3 py-2 text-xs font-semibold">Chat</div>
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto p-2">
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className={cn(
-              'mb-1 rounded-lg px-2 py-1 text-xs',
-              msg.isCorrect &&
-                'bg-emerald-100 font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-              msg.isSystem && !msg.isCorrect && 'text-muted-foreground italic'
-            )}
-          >
-            {!msg.isSystem && <span className="mr-1 font-semibold">{msg.playerName}:</span>}
-            {msg.text}
-          </div>
-        ))}
-        {messages.length === 0 && (
-          <p className="text-muted-foreground py-4 text-center text-xs">
-            {isDrawer ? 'Players will guess here' : 'Type your guesses below'}
-          </p>
-        )}
-      </div>
-      <form onSubmit={handleSubmit} className="border-t p-2">
-        <div className="flex gap-1">
-          <input
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder={
-              isDrawer ? "You're drawing!" : hasGuessed ? 'Already guessed!' : 'Type your guess...'
-            }
-            disabled={!canGuess}
-            maxLength={50}
-            className="bg-background focus:ring-primary/40 flex-1 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-2 disabled:opacity-50"
-          />
-          <button
-            type="submit"
-            disabled={!canGuess || !input.trim()}
-            className="bg-primary text-primary-foreground rounded-lg px-3 py-1.5 text-xs font-semibold disabled:opacity-50"
-          >
-            Send
-          </button>
-        </div>
-      </form>
-    </div>
-  )
-}
-
-// ─── Scoreboard ───────────────────────────────────────────────────────────────
-
-interface ScoreboardProps {
-  players: GameState['players']
-  currentDrawerId: string | null
-  guessedPlayers: string[]
-  playerId: string
-  onlinePlayerIds?: string[]
 }
 
 function Scoreboard({
@@ -352,782 +336,1272 @@ function Scoreboard({
   guessedPlayers,
   playerId,
   onlinePlayerIds,
-}: ScoreboardProps) {
-  const sorted = [...players].sort((a, b) => b.score - a.score)
+  scoreDeltas,
+}: {
+  players: GameState['players']
+  currentDrawerId: string | null
+  guessedPlayers: string[]
+  playerId: string
+  onlinePlayerIds: string[]
+  scoreDeltas: GameState['scoreDeltas']
+}) {
+  const sortedPlayers = [...players].sort((left, right) => right.score - left.score)
+
   return (
-    <div className="bg-background rounded-xl border">
-      <div className="text-muted-foreground border-b px-3 py-2 text-xs font-semibold">
-        Scoreboard
+    <aside className={styles.scoreboard}>
+      <div className={cn(styles.scoreHead, arcadeShellStyles.mono)}>
+        <span>Scoreboard</span>
+        <span>{players.length} players</span>
       </div>
-      <div className="p-2">
-        {sorted.map((p, i) => {
-          const isOnline = !onlinePlayerIds || onlinePlayerIds.includes(p.id)
+      <div className={styles.scoreRows}>
+        {sortedPlayers.map((player, index) => {
+          const isDrawer = player.id === currentDrawerId
+          const hasGuessed = guessedPlayers.includes(player.id)
+          const isYou = player.id === playerId
+          const isOnline = onlinePlayerIds.includes(player.id)
+          const delta = scoreDeltas[player.id]
+
           return (
             <div
-              key={p.id}
+              key={player.id}
               className={cn(
-                'flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs',
-                p.id === playerId && 'bg-primary/10'
+                styles.scoreRow,
+                isYou && styles.scoreRowYou,
+                isDrawer && styles.scoreRowDrawer,
+                hasGuessed && styles.scoreRowGuessed
               )}
             >
-              <span className="text-muted-foreground w-4 text-center font-bold">{i + 1}</span>
-              <span
-                className={cn(
-                  'h-2 w-2 rounded-full',
-                  p.id === currentDrawerId
-                    ? 'bg-amber-400'
-                    : guessedPlayers.includes(p.id)
-                      ? 'bg-emerald-400'
-                      : isOnline
-                        ? 'bg-green-400'
-                        : 'bg-gray-300 opacity-50'
-                )}
-                title={
-                  p.id === currentDrawerId
-                    ? 'Drawing'
-                    : guessedPlayers.includes(p.id)
-                      ? 'Guessed'
-                      : isOnline
-                        ? 'Online'
-                        : 'Offline'
-                }
-              />
-              <span className={cn('flex-1 truncate font-medium', !isOnline && 'opacity-60')}>
-                {p.name}
-                {p.id === playerId && <span className="text-muted-foreground ml-1">(you)</span>}
-              </span>
-              {p.id === currentDrawerId && (
-                <span className="text-[10px] text-amber-600 dark:text-amber-400">drawing</span>
+              <span className={cn(styles.scoreRank, arcadeShellStyles.mono)}>{index + 1}</span>
+              <div className={styles.playerAvatar}>
+                <ArcadeAvatar index={player.avatar} size={24} />
+              </div>
+              <div className={styles.scoreName}>
+                <span>{player.name}</span>
+                {player.isHost && <span className={styles.scoreBadge}>host</span>}
+                {isDrawer && <span className={styles.scoreBadge}>draw</span>}
+                {hasGuessed && !isDrawer && <span className={styles.scoreBadge}>guessed</span>}
+                {!isOnline && <span className={styles.scoreBadge}>away</span>}
+              </div>
+              <span className={styles.scoreValue}>{player.score}</span>
+              {typeof delta === 'number' && delta > 0 && (
+                <span className={styles.scoreDelta}>+{delta}</span>
               )}
-              <span className="font-bold tabular-nums">{p.score}</span>
             </div>
           )
         })}
       </div>
-    </div>
+    </aside>
   )
 }
 
-// ─── Timer ────────────────────────────────────────────────────────────────────
-
-interface TimerProps {
-  startTime: number
-  duration: number
-  onTimeUp: () => void
-}
-
-function Timer({ startTime, duration, onTimeUp }: TimerProps) {
-  const [remaining, setRemaining] = useState(duration)
-  const calledRef = useRef(false)
+function ChatPanel({
+  messages,
+  isDrawer,
+  hasGuessed,
+  onGuess,
+}: {
+  messages: GameState['messages']
+  isDrawer: boolean
+  hasGuessed: boolean
+  onGuess: (text: string) => void
+}) {
+  const [input, setInput] = useState('')
+  const logRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    calledRef.current = false
-    const interval = setInterval(() => {
-      const elapsed = (Date.now() - startTime) / 1000
-      const left = Math.max(0, duration - elapsed)
-      setRemaining(Math.ceil(left))
-      if (left <= 0 && !calledRef.current) {
-        calledRef.current = true
-        onTimeUp()
-      }
-    }, 250)
-    return () => clearInterval(interval)
-  }, [startTime, duration, onTimeUp])
+    if (!logRef.current) return
+    logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [messages.length])
 
-  const pct = (remaining / duration) * 100
+  const canGuess = !isDrawer && !hasGuessed
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!canGuess || !input.trim()) return
+    onGuess(input.trim())
+    setInput('')
+  }
 
   return (
-    <div className="flex items-center gap-2">
-      <div className="bg-secondary h-2 flex-1 overflow-hidden rounded-full">
-        <div
-          className={cn(
-            'h-full rounded-full transition-all duration-300',
-            pct > 50 ? 'bg-emerald-500' : pct > 20 ? 'bg-amber-500' : 'bg-red-500'
-          )}
-          style={{ width: `${pct}%` }}
-        />
+    <section className={styles.chat}>
+      <div className={cn(styles.scoreHead, arcadeShellStyles.mono)}>
+        <span>Guesses</span>
+        <span>live</span>
       </div>
-      <span
-        className={cn(
-          'min-w-[2rem] text-center text-sm font-bold tabular-nums',
-          remaining <= 10 && 'text-red-500'
+
+      <div ref={logRef} className={styles.chatLog}>
+        {messages.length === 0 && (
+          <div className={cn(styles.message, styles.messageSystem)}>
+            {isDrawer ? 'Players will guess here' : 'Type your guess below'}
+          </div>
         )}
-      >
-        {remaining}s
-      </span>
-    </div>
+
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={cn(
+              styles.message,
+              message.isSystem && styles.messageSystem,
+              message.isCorrect && styles.messageCorrect,
+              message.isClose && !message.isSystem && styles.messageClose
+            )}
+          >
+            {!message.isSystem && <span className={styles.messageName}>{message.playerName}:</span>}
+            <span>{message.text}</span>
+          </div>
+        ))}
+      </div>
+
+      <form className={styles.chatForm} onSubmit={handleSubmit}>
+        <input
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          disabled={!canGuess}
+          maxLength={50}
+          placeholder={
+            isDrawer ? "You're drawing!" : hasGuessed ? 'Already guessed ✓' : 'Your guess...'
+          }
+          className={styles.chatInput}
+        />
+        <button type="submit" disabled={!canGuess || !input.trim()} className={styles.chatSend}>
+          Send
+        </button>
+      </form>
+    </section>
   )
 }
-
-// ─── Screens ──────────────────────────────────────────────────────────────────
 
 function SetupRequired() {
   return (
-    <div className="bg-secondary/40 mx-auto max-w-md rounded-2xl border p-6 text-center">
-      <div className="mb-3 text-4xl">🔧</div>
-      <h2 className="mb-2 text-lg font-bold">Supabase setup required</h2>
-      <p className="text-muted-foreground mb-4 text-sm">
-        Online multiplayer requires a Supabase project. Create a free project at{' '}
-        <span className="text-foreground font-medium">supabase.com</span>, run the schema from{' '}
-        <code className="bg-secondary rounded px-1 text-xs">supabase-schema.sql</code>, then set:
+    <div className={styles.setup}>
+      <div className="mb-4 text-5xl">🔧</div>
+      <h2 className="text-3xl font-extrabold tracking-tight">Supabase setup required</h2>
+      <p className="mt-3">
+        Online multiplayer rooms still run through Supabase. The redesign is ready, but the game
+        needs the same backend wiring as before.
       </p>
-      <pre className="bg-secondary rounded-lg p-3 text-left text-xs">
-        {`NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co\nNEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...`}
-      </pre>
+      <pre>{`NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co\nNEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...`}</pre>
     </div>
   )
 }
 
-interface EntryScreenProps {
-  onCreate: (name: string) => void
-  onJoin: (code: string, name: string) => void
-  onRestore?: () => void
-  savedSession: SavedSessionSummary | null
-  loading: boolean
-  error: string | null
-  initialCode?: string | null
-}
-
-function EntryScreen({
-  onCreate,
-  onJoin,
-  onRestore,
-  savedSession,
-  loading,
-  error,
-  initialCode,
-}: EntryScreenProps) {
-  const [name, setName] = useState(getSavedPlayerName)
-  const [joinCode, setJoinCode] = useState(initialCode ?? '')
-  const [mode, setMode] = useState<'choose' | 'create' | 'join'>(initialCode ? 'join' : 'choose')
-
-  if (mode === 'choose') {
-    return (
-      <div className="flex flex-col items-center gap-6">
-        <div className="text-center">
-          <div className="mb-3 text-5xl">🎨</div>
-          <h2 className="text-xl font-black tracking-tight">Skribbl Online</h2>
-          <p className="text-muted-foreground text-sm">2-8 players &middot; Draw & Guess</p>
-        </div>
-        {savedSession && (
-          <ResumeSessionButton
-            session={savedSession}
-            onClick={() => onRestore?.()}
-            className="w-64"
-          />
-        )}
-        <div className="flex gap-3">
-          <button
-            onClick={() => setMode('create')}
-            className="bg-secondary hover:bg-secondary/70 flex w-36 flex-col items-center gap-2 rounded-2xl px-6 py-5 text-center font-semibold transition-all hover:shadow-lg active:scale-95"
-          >
-            <div className="bg-primary/10 flex h-12 w-12 items-center justify-center rounded-full">
-              <span className="text-2xl">+</span>
-            </div>
-            <span>Create Room</span>
-            <span className="text-muted-foreground text-xs font-normal">Host a game</span>
-          </button>
-          <button
-            onClick={() => setMode('join')}
-            className="bg-secondary hover:bg-secondary/70 flex w-36 flex-col items-center gap-2 rounded-2xl px-6 py-5 text-center font-semibold transition-all hover:shadow-lg active:scale-95"
-          >
-            <div className="bg-primary/10 flex h-12 w-12 items-center justify-center rounded-full">
-              <span className="text-2xl">&rarr;</span>
-            </div>
-            <span>Join Room</span>
-            <span className="text-muted-foreground text-xs font-normal">Enter a code</span>
-          </button>
-        </div>
-      </div>
-    )
-  }
-
-  const isCreate = mode === 'create'
+function InviteResolvingScreen() {
   return (
-    <div className="flex w-72 flex-col gap-4">
-      <button
-        onClick={() => setMode('choose')}
-        className="text-muted-foreground hover:text-foreground self-start text-sm"
-      >
-        &larr; Back
-      </button>
-      <h2 className="text-lg font-bold">{isCreate ? 'Create Room' : 'Join Room'}</h2>
-      {error && (
-        <p className="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm">{error}</p>
-      )}
-      <label className="flex flex-col gap-1">
-        <span className="text-muted-foreground text-xs font-medium">Your name</span>
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Enter your name"
-          maxLength={16}
-          className="bg-background focus:ring-primary/40 rounded-lg border px-3 py-2 text-sm outline-none focus:ring-2"
-        />
-      </label>
-      {!isCreate && (
-        <label className="flex flex-col gap-1">
-          <span className="text-muted-foreground text-xs font-medium">Room code</span>
-          <input
-            value={joinCode}
-            onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
-            placeholder="e.g. AB12"
-            maxLength={4}
-            className="bg-background focus:ring-primary/40 rounded-lg border px-3 py-2 text-sm tracking-widest uppercase outline-none focus:ring-2"
-          />
-        </label>
-      )}
-      <button
-        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
-        onClick={() => {
-          savePlayerName(name.trim())
-          if (isCreate) onCreate(name.trim())
-          else onJoin(joinCode, name.trim())
-        }}
-        className="bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-semibold transition-opacity disabled:opacity-50"
-      >
-        {loading ? 'Connecting\u2026' : isCreate ? 'Create Room' : 'Join Room'}
-      </button>
-    </div>
-  )
-}
-
-interface LobbyScreenProps {
-  gameState: GameState
-  playerId: string
-  roomCode: string
-  onlinePlayerIds: string[]
-  onStart: () => void
-  onLeave: () => void
-}
-
-function LobbyScreen({
-  gameState,
-  playerId,
-  roomCode,
-  onlinePlayerIds,
-  onStart,
-  onLeave,
-}: LobbyScreenProps) {
-  const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
-  const [copied, setCopied] = useState<'code' | 'link' | null>(null)
-
-  function copyCode() {
-    navigator.clipboard.writeText(roomCode).then(
-      () => {
-        setCopied('code')
-        setTimeout(() => setCopied(null), 2000)
-      },
-      () => {}
-    )
-  }
-
-  function copyInviteLink() {
-    navigator.clipboard.writeText(getInviteLink('skribbl', roomCode)).then(
-      () => {
-        setCopied('link')
-        setTimeout(() => setCopied(null), 2000)
-      },
-      () => {}
-    )
-  }
-
-  return (
-    <div className="flex w-80 flex-col gap-5">
-      <div className="bg-secondary rounded-2xl p-5 text-center">
-        <p className="text-muted-foreground mb-1 text-xs font-medium">
-          Room code &mdash; share with friends
-        </p>
-        <p className="mb-3 text-4xl font-black tracking-widest">{roomCode}</p>
-        <div className="flex justify-center gap-2">
-          <button
-            onClick={copyCode}
-            className="hover:bg-background rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors"
-          >
-            {copied === 'code' ? 'Copied!' : 'Copy code'}
-          </button>
-          <button
-            onClick={copyInviteLink}
-            className="hover:bg-background rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors"
-          >
-            {copied === 'link' ? 'Copied!' : 'Copy invite link'}
-          </button>
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <p className="text-muted-foreground text-xs font-medium">
-          Players ({gameState.players.length}/8)
-        </p>
-        {gameState.players.map((p, i) => {
-          const isOnline = onlinePlayerIds.includes(p.id)
-          return (
-            <div
-              key={p.id}
-              className="bg-secondary flex items-center gap-2 rounded-lg px-3 py-2 text-sm"
-              style={{ animationDelay: `${i * 50}ms` }}
-            >
-              <span
-                className={cn(
-                  'h-2 w-2 rounded-full',
-                  isOnline ? 'bg-green-400' : 'bg-gray-400 opacity-50'
-                )}
-                title={isOnline ? 'Online' : 'Offline'}
-              />
-              <span className={cn('font-medium', !isOnline && 'opacity-60')}>{p.name}</span>
-              {p.isHost && <span className="text-muted-foreground ml-auto text-xs">host</span>}
-              {p.id === playerId && !p.isHost && (
-                <span className="text-muted-foreground ml-auto text-xs">you</span>
-              )}
-            </div>
-          )
-        })}
-      </div>
-
-      {isHost && gameState.players.length < 2 && (
-        <p className="text-muted-foreground text-center text-xs">
-          Waiting for at least one more player&hellip;
-        </p>
-      )}
-
-      <div className="flex gap-3">
-        {isHost && (
-          <button
-            disabled={gameState.players.length < 2}
-            onClick={onStart}
-            className="bg-primary text-primary-foreground flex-1 rounded-lg px-4 py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
-          >
-            Start Game
-          </button>
-        )}
-        {!isHost && (
-          <p className="text-muted-foreground flex-1 text-center text-sm">
-            Waiting for host to start&hellip;
-          </p>
-        )}
-        <button
-          onClick={onLeave}
-          className="hover:bg-secondary rounded-lg border px-4 py-2.5 text-sm font-semibold"
-        >
-          Leave
-        </button>
+    <div className={styles.entryShell}>
+      <div className={styles.entryHead}>
+        <h2>Loading room…</h2>
+        <p>Checking your invite link and preparing the right entry screen.</p>
       </div>
     </div>
   )
 }
 
-// ─── Word Picker ──────────────────────────────────────────────────────────────
-
-interface WordPickerProps {
-  words: string[]
-  onPick: (word: string) => void
-}
-
-function WordPicker({ words, onPick }: WordPickerProps) {
+function HowToScreen({ onStart }: { onStart: () => void }) {
   return (
-    <div className="flex flex-col items-center gap-4">
-      <div className="text-center">
-        <h2 className="text-lg font-bold">Choose a word to draw</h2>
-        <p className="text-muted-foreground text-sm">Pick one of the three options</p>
-      </div>
-      <div className="flex gap-3">
-        {words.map((word) => (
-          <button
-            key={word}
-            onClick={() => onPick(word)}
-            className="bg-secondary hover:bg-primary hover:text-primary-foreground rounded-xl px-6 py-4 text-sm font-bold transition-all hover:shadow-lg active:scale-95"
-          >
-            {decodeWord(word)}
+    <div className={styles.hero}>
+      <div className={styles.heroLeft}>
+        <span className={cn(styles.tag, arcadeShellStyles.mono)}>Multiplayer · 2-8 players</span>
+        <h1 className={styles.heroTitle}>
+          Draw it.
+          <br />
+          Guess it.
+          <br />
+          <span className={styles.heroTitleAccent}>Lose it.</span>
+        </h1>
+        <p className={styles.heroCopy}>
+          One player sketches a word against the clock while everyone else races to guess it in
+          chat. Faster guesses, more points. Three rounds, one winner.
+        </p>
+        <div className={styles.heroActions}>
+          <button type="button" onClick={onStart} className={arcadeShellStyles.button}>
+            Play now →
           </button>
+          <span className={cn(styles.heroMeta, arcadeShellStyles.mono)}>
+            80s · 3 rounds · avg game ~8 min
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.steps}>
+        {[
+          {
+            number: '01 · Join',
+            title: 'Grab a room',
+            copy: 'Host a private room or drop into an invite code from a friend.',
+            icon: (
+              <svg
+                viewBox="0 0 32 32"
+                width="24"
+                height="24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="4" y="8" width="24" height="18" rx="1" />
+                <path d="M 10 4 L 10 12 M 22 4 L 22 12" />
+              </svg>
+            ),
+          },
+          {
+            number: '02 · Draw',
+            title: 'Pick & sketch',
+            copy: 'Choose from three words. You get 80 seconds. No letters, no numbers.',
+            accent: true,
+            icon: (
+              <svg
+                viewBox="0 0 32 32"
+                width="24"
+                height="24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M 4 26 L 10 24 L 24 10 L 22 8 L 8 22 Z" />
+                <path d="M 18 12 L 20 14" />
+              </svg>
+            ),
+          },
+          {
+            number: '03 · Guess',
+            title: 'Type in chat',
+            copy: 'Early guesses score more. Hints reveal as the clock drops.',
+            icon: (
+              <svg
+                viewBox="0 0 32 32"
+                width="24"
+                height="24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M 6 10 L 26 10 L 24 22 L 12 22 L 6 26 Z" />
+              </svg>
+            ),
+          },
+          {
+            number: '04 · Win',
+            title: 'Rack up points',
+            copy: 'After 3 rounds, top scorer takes the crown. Drawers earn on every guess too.',
+            icon: (
+              <svg
+                viewBox="0 0 32 32"
+                width="24"
+                height="24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M 10 6 L 22 6 L 22 14 Q 22 20 16 20 Q 10 20 10 14 Z" />
+                <path d="M 13 22 L 19 22 L 20 26 L 12 26 Z" />
+                <path d="M 10 8 L 6 8 L 6 12 Q 6 14 10 14 M 22 8 L 26 8 L 26 12 Q 26 14 22 14" />
+              </svg>
+            ),
+          },
+        ].map((step) => (
+          <article key={step.number} className={cn(styles.step, step.accent && styles.stepAccent)}>
+            <span className={cn(styles.stepNumber, arcadeShellStyles.mono)}>{step.number}</span>
+            <div className={styles.stepIcon}>{step.icon}</div>
+            <div className={styles.stepTitle}>{step.title}</div>
+            <div className={styles.stepDescription}>{step.copy}</div>
+          </article>
         ))}
       </div>
     </div>
   )
 }
 
-// ─── Round End Screen ─────────────────────────────────────────────────────────
-
-const ROUND_END_DELAY = 5
-
-interface RoundEndProps {
-  gameState: GameState
-  playerId: string
-  onNext: () => void
-  onLeave: () => void
-}
-
-function RoundEndScreen({ gameState, playerId, onNext, onLeave }: RoundEndProps) {
-  const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
-  const drawer = getCurrentDrawer(gameState)
-  const [countdown, setCountdown] = useState(ROUND_END_DELAY)
-  const advancedRef = useRef(false)
+function EntryScreen({
+  error,
+  initialCode,
+  loading,
+  onBackToHowTo,
+  onCreate,
+  onJoin,
+  onRestore,
+  savedSession,
+}: {
+  error: string | null
+  initialCode: string | null
+  loading: boolean
+  onBackToHowTo?: () => void
+  onCreate: (name: string, avatar: number) => void
+  onJoin: (code: string, name: string, avatar: number) => void
+  onRestore: () => void
+  savedSession: UseSkribblRoomReturn['savedSession']
+}) {
+  const [mode, setMode] = useState<'choose' | 'create' | 'join'>(initialCode ? 'join' : 'choose')
+  const [name, setName] = useState(getSavedPlayerName)
+  const [avatar, setAvatar] = useState(getSavedAvatar)
+  const [code, setCode] = useState(initialCode ?? '')
 
   useEffect(() => {
-    advancedRef.current = false
-    setCountdown(ROUND_END_DELAY)
-    const interval = setInterval(() => {
-      setCountdown((prev) => {
-        const next = prev - 1
-        if (next <= 0 && isHost && !advancedRef.current) {
-          advancedRef.current = true
-          onNext()
-        }
-        return Math.max(0, next)
-      })
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [isHost, onNext])
+    if (!initialCode) return
+    setMode('join')
+    setCode(initialCode)
+  }, [initialCode])
 
-  const allGuessed =
-    gameState.guessedPlayers.length >= gameState.players.length - 1 && gameState.players.length > 1
+  const canSubmit = name.trim().length >= 2 && (mode === 'create' || code.trim().length >= 4)
+
+  function submit() {
+    if (!canSubmit) return
+
+    const trimmedName = name.trim()
+    savePlayerName(trimmedName)
+    saveAvatar(avatar)
+
+    if (mode === 'create') {
+      onCreate(trimmedName, avatar)
+      return
+    }
+
+    onJoin(code.trim().toUpperCase(), trimmedName, avatar)
+  }
+
+  if (mode === 'choose') {
+    return (
+      <div className={styles.entryShell}>
+        <div className={styles.entryHead}>
+          <h2>Ready to play?</h2>
+          <p>Host a new room or jump into a friend&apos;s game with a code.</p>
+        </div>
+
+        {savedSession && (
+          <div className={styles.resumeCard}>
+            <div>
+              <div className={styles.resumeTitle}>Resume your last room</div>
+              <div className={styles.resumeCopy}>
+                Room {savedSession.roomCode} as {savedSession.playerName}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onRestore}
+              className={cn(arcadeShellStyles.button, arcadeShellStyles.buttonSmall)}
+            >
+              Resume →
+            </button>
+          </div>
+        )}
+
+        <div className={styles.entryChoiceGrid}>
+          <button
+            type="button"
+            className={cn(styles.entryCard, styles.entryCardAccent)}
+            onClick={() => setMode('create')}
+          >
+            <div className={styles.entryCardTitle}>Create Room</div>
+            <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
+              Host a private game
+            </div>
+          </button>
+
+          <button type="button" className={styles.entryCard} onClick={() => setMode('join')}>
+            <div className={styles.entryCardTitle}>Join Room</div>
+            <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
+              Enter a 4-char code
+            </div>
+          </button>
+        </div>
+
+        {onBackToHowTo && (
+          <div className={styles.entryActions}>
+            <button
+              type="button"
+              className={cn(
+                arcadeShellStyles.button,
+                arcadeShellStyles.buttonGhost,
+                arcadeShellStyles.buttonSmall
+              )}
+              onClick={onBackToHowTo}
+            >
+              ← Back to how it works
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
 
   return (
-    <div className="flex flex-col items-center gap-5">
-      <div className="text-center">
-        <h2 className="text-xl font-bold">
-          {allGuessed ? 'Everyone guessed it!' : 'Time\u2019s up!'}
-        </h2>
-        <p className="text-muted-foreground mt-1 text-sm">
-          The word was:{' '}
-          <span className="text-foreground font-bold">{decodeWord(gameState.word ?? '')}</span>
-        </p>
-        <p className="text-muted-foreground text-xs">
-          {drawer?.name} was drawing &middot; Round {gameState.round}/{gameState.totalRounds}
-        </p>
+    <div className={styles.entryShell}>
+      <div className={styles.entryHead}>
+        <h2>{mode === 'create' ? 'Create a room' : 'Join a room'}</h2>
+        <p>{mode === 'create' ? "You'll be the host." : 'Ask the host for the room code.'}</p>
       </div>
 
-      <Scoreboard
-        players={gameState.players}
-        currentDrawerId={null}
-        guessedPlayers={[]}
-        playerId={playerId}
-      />
+      <div className={styles.entryForm}>
+        {error && <div className={styles.error}>{error}</div>}
 
-      <div className="flex flex-col items-center gap-2">
-        <div className="flex gap-3">
-          {isHost ? (
+        <label className={styles.field}>
+          <span className={cn(styles.label, arcadeShellStyles.mono)}>Your name</span>
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            maxLength={16}
+            placeholder="e.g. Marble"
+            className={arcadeShellStyles.input}
+          />
+        </label>
+
+        <div className={styles.field}>
+          <span className={cn(styles.label, arcadeShellStyles.mono)}>Pick an avatar</span>
+          <div className={styles.avatarGrid}>
+            {Array.from({ length: 8 }, (_, index) => (
+              <button
+                key={index}
+                type="button"
+                onClick={() => setAvatar(index)}
+                className={cn(styles.avatarButton, avatar === index && styles.avatarButtonActive)}
+              >
+                <ArcadeAvatar index={index} size={42} />
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {mode === 'join' && (
+          <label className={styles.field}>
+            <span className={cn(styles.label, arcadeShellStyles.mono)}>Room code</span>
+            <input
+              value={code}
+              onChange={(event) =>
+                setCode(event.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))
+              }
+              maxLength={4}
+              placeholder="AB23"
+              className={cn(arcadeShellStyles.input, styles.codeInput)}
+            />
+          </label>
+        )}
+
+        <div className={styles.entryActions}>
+          <button
+            type="button"
+            className={cn(
+              arcadeShellStyles.button,
+              arcadeShellStyles.buttonGhost,
+              arcadeShellStyles.buttonSmall
+            )}
+            onClick={() => setMode('choose')}
+          >
+            ← Back
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={loading || !canSubmit}
+            className={arcadeShellStyles.button}
+          >
+            {loading ? 'Connecting...' : mode === 'create' ? 'Create room' : 'Join room'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function LobbyScreen({
+  gameState,
+  onlinePlayerIds,
+  playerId,
+  roomCode,
+  onLeave,
+  onRemovePlayer,
+  onStart,
+  onUpdateSettings,
+}: {
+  gameState: GameState
+  onlinePlayerIds: string[]
+  playerId: string
+  roomCode: string
+  onLeave: () => void
+  onRemovePlayer: (targetPlayerId: string) => void
+  onStart: () => void
+  onUpdateSettings: (settings: { totalRounds?: number; turnDuration?: number }) => void
+}) {
+  const isHost = gameState.players.find((player) => player.id === playerId)?.isHost ?? false
+  const [copied, setCopied] = useState<'code' | 'link' | null>(null)
+
+  function copyValue(value: string, kind: 'code' | 'link') {
+    navigator.clipboard?.writeText(value).then(
+      () => {
+        setCopied(kind)
+        window.setTimeout(() => setCopied(null), 1800)
+      },
+      () => {}
+    )
+  }
+
+  return (
+    <div className={styles.lobby}>
+      <section className={styles.roomCard}>
+        <span className={cn(styles.roomLabel, arcadeShellStyles.mono)}>Room · share this code</span>
+        <div className={styles.roomCode}>{roomCode}</div>
+        <div className={styles.roomActions}>
+          <button
+            type="button"
+            className={cn(styles.roomAction, arcadeShellStyles.mono)}
+            onClick={() => copyValue(roomCode, 'code')}
+          >
+            <Copy className="h-3.5 w-3.5" />
+            {copied === 'code' ? 'Copied' : 'Copy code'}
+          </button>
+          <button
+            type="button"
+            className={cn(styles.roomAction, arcadeShellStyles.mono)}
+            onClick={() => copyValue(getInviteLink('skribbl', roomCode), 'link')}
+          >
+            <Link2 className="h-3.5 w-3.5" />
+            {copied === 'link' ? 'Copied' : 'Copy link'}
+          </button>
+        </div>
+        <div className={cn(styles.roomMeta, arcadeShellStyles.mono)}>
+          / lobby · waiting for players
+        </div>
+      </section>
+
+      <div className={styles.lobbySide}>
+        <section className={styles.playersPanel}>
+          <div className={cn(styles.panelHead, arcadeShellStyles.mono)}>
+            <span>Players</span>
+            <span>{gameState.players.length} / 8</span>
+          </div>
+
+          <div className={styles.playerList}>
+            {gameState.players.map((player) => {
+              const isOnline = onlinePlayerIds.includes(player.id)
+              const canRemove = isHost && !isOnline && !player.isHost && player.id !== playerId
+
+              return (
+                <div
+                  key={player.id}
+                  className={cn(styles.playerRow, player.id === playerId && styles.playerRowYou)}
+                >
+                  <div className={styles.playerAvatar}>
+                    <ArcadeAvatar index={player.avatar} size={30} />
+                  </div>
+
+                  <div className={styles.playerInfo}>
+                    <div className={styles.playerName}>{player.name}</div>
+                    <div className={styles.playerMeta}>
+                      {player.id === playerId ? 'you' : isOnline ? 'online' : 'offline'}
+                    </div>
+                  </div>
+
+                  <div className={styles.playerTags}>
+                    {player.isHost && (
+                      <span className={cn(styles.playerTag, styles.playerTagHost)}>host</span>
+                    )}
+                    {!isOnline && <span className={styles.playerTag}>away</span>}
+                    {canRemove && (
+                      <button
+                        type="button"
+                        onClick={() => onRemovePlayer(player.id)}
+                        className={cn(styles.playerTag, styles.playerRemove)}
+                      >
+                        remove
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+
+        <section className={styles.settingsPanel}>
+          <div className={styles.settingsRow}>
+            <span className={cn(styles.label, arcadeShellStyles.mono)}>Rounds</span>
+            <div className={styles.pillGroup}>
+              {[2, 3, 5].map((roundCount) => (
+                <button
+                  key={roundCount}
+                  type="button"
+                  disabled={!isHost}
+                  onClick={() => onUpdateSettings({ totalRounds: roundCount })}
+                  className={cn(
+                    styles.pill,
+                    gameState.totalRounds === roundCount && styles.pillActive
+                  )}
+                >
+                  {roundCount}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.settingsRow}>
+            <span className={cn(styles.label, arcadeShellStyles.mono)}>Turn</span>
+            <div className={styles.pillGroup}>
+              {[60, 80, 120].map((turnDuration) => (
+                <button
+                  key={turnDuration}
+                  type="button"
+                  disabled={!isHost}
+                  onClick={() => onUpdateSettings({ turnDuration })}
+                  className={cn(
+                    styles.pill,
+                    gameState.turnDuration === turnDuration && styles.pillActive
+                  )}
+                >
+                  {turnDuration}s
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <footer className={styles.lobbyFooter}>
+        <span className={cn(styles.waiting, arcadeShellStyles.mono)}>
+          {isHost ? "You're the host" : 'Waiting for host to start'}
+        </span>
+        <div className={styles.entryActions}>
+          <button
+            type="button"
+            onClick={onLeave}
+            className={cn(
+              arcadeShellStyles.button,
+              arcadeShellStyles.buttonGhost,
+              arcadeShellStyles.buttonSmall
+            )}
+          >
+            Leave
+          </button>
+          {isHost && (
             <button
-              onClick={() => {
-                if (!advancedRef.current) {
-                  advancedRef.current = true
-                  onNext()
-                }
-              }}
-              className="bg-primary text-primary-foreground rounded-lg px-5 py-2.5 text-sm font-semibold active:scale-95"
+              type="button"
+              disabled={gameState.players.length < 2}
+              onClick={onStart}
+              className={arcadeShellStyles.button}
             >
-              Next Turn ({countdown}s)
+              Start game →
             </button>
+          )}
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function WordPickerScreen({ words, onPick }: { words: string[]; onPick: (word: string) => void }) {
+  const [remaining, setRemaining] = useState(WORD_PICKER_SECONDS)
+  const firedRef = useRef(false)
+
+  useEffect(() => {
+    firedRef.current = false
+    const startedAt = Date.now()
+
+    const interval = window.setInterval(() => {
+      const left = Math.max(0, WORD_PICKER_SECONDS - (Date.now() - startedAt) / 1000)
+      setRemaining(Math.ceil(left))
+
+      if (left <= 0 && !firedRef.current) {
+        firedRef.current = true
+        const randomWord = words[Math.floor(Math.random() * words.length)]
+        onPick(randomWord)
+      }
+    }, 120)
+
+    return () => window.clearInterval(interval)
+  }, [onPick, words])
+
+  const progress = Math.max(0, (remaining / WORD_PICKER_SECONDS) * 100)
+
+  return (
+    <div className={styles.pickerShell}>
+      <div className={styles.pickerHead}>
+        <p className={cn(styles.label, arcadeShellStyles.mono)}>Your turn · choose a word</p>
+        <h2>Pick your poison</h2>
+        <p className={cn(styles.label, arcadeShellStyles.mono)}>Auto-picks in {remaining}s</p>
+      </div>
+
+      <div className={styles.pickerTimer}>
+        <div className={styles.pickerTimerBar} style={{ width: `${progress}%` }} />
+      </div>
+
+      <div className={styles.pickerGrid}>
+        {words.map((word, index) => {
+          const plainWord = decodeWord(word)
+          const difficulty = index + 1
+          return (
+            <button
+              key={word}
+              type="button"
+              className={styles.wordCard}
+              onClick={() => onPick(word)}
+            >
+              <span className={cn(styles.wordIndex, arcadeShellStyles.mono)}>
+                0{index + 1} / 03
+              </span>
+              <span className={styles.wordDifficulty}>
+                {[1, 2, 3].map((value) => (
+                  <span
+                    key={value}
+                    className={cn(styles.wordDot, value <= difficulty && styles.wordDotActive)}
+                  />
+                ))}
+              </span>
+              <span className={styles.wordText}>{plainWord}</span>
+              <span className={styles.wordHint}>
+                {plainWord
+                  .split('')
+                  .map((character, characterIndex) =>
+                    character === ' ' ? (
+                      <span key={characterIndex} className={styles.wordHintSpace} />
+                    ) : (
+                      <span key={characterIndex} className={styles.wordHintBox} />
+                    )
+                  )}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function WaitingPickerScreen({ drawerName }: { drawerName: string }) {
+  return (
+    <div className={styles.pickerShell}>
+      <div className={styles.pickerHead}>
+        <p className={cn(styles.label, arcadeShellStyles.mono)}>{drawerName} is choosing</p>
+        <h2>Hang tight...</h2>
+        <p>A word is being picked for the next sketch.</p>
+      </div>
+      <div className={styles.skeletonGrid}>
+        {Array.from({ length: 3 }, (_, index) => (
+          <div key={index} className={styles.skeletonCard}>
+            <div className={styles.skeletonBar} style={{ animationDelay: `${index * 180}ms` }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RoundEndScreen({
+  gameState,
+  playerId,
+  onLeave,
+  onNext,
+}: {
+  gameState: GameState
+  playerId: string
+  onLeave: () => void
+  onNext: () => void
+}) {
+  const isHost = gameState.players.find((player) => player.id === playerId)?.isHost ?? false
+  const [countdown, setCountdown] = useState(ROUND_END_DELAY)
+  const firedRef = useRef(false)
+  const drawer = getCurrentDrawer(gameState)
+  const allGuessed =
+    gameState.players.length > 1 && gameState.guessedPlayers.length >= gameState.players.length - 1
+  const sortedPlayers = [...gameState.players].sort((left, right) => right.score - left.score)
+
+  useEffect(() => {
+    firedRef.current = false
+    setCountdown(ROUND_END_DELAY)
+
+    const interval = window.setInterval(() => {
+      setCountdown((current) => {
+        const nextValue = Math.max(0, current - 1)
+        if (nextValue === 0 && isHost && !firedRef.current) {
+          firedRef.current = true
+          onNext()
+        }
+        return nextValue
+      })
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [isHost, onNext])
+
+  return (
+    <div className={styles.endShell}>
+      <p className={cn(styles.endMeta, arcadeShellStyles.mono)}>
+        Round {gameState.round} of {gameState.totalRounds} · {drawer?.name ?? 'Player'} was drawing
+      </p>
+      <h2 className={styles.endTitle}>{allGuessed ? 'Everyone got it!' : "Time's up"}</h2>
+      <p className={styles.endWord}>
+        The word was{' '}
+        <span className={styles.endWordAccent}>{decodeWord(gameState.word ?? '')}</span>
+      </p>
+
+      <div className={styles.resultsTable}>
+        {sortedPlayers.map((player, index) => (
+          <div key={player.id} className={styles.resultRow}>
+            <span className={cn(styles.resultTotal, arcadeShellStyles.mono)}>{index + 1}</span>
+            <div className={styles.resultPlayer}>
+              <ArcadeAvatar index={player.avatar} size={26} />
+              <span>{player.name}</span>
+            </div>
+            <span className={styles.resultDelta}>
+              {gameState.scoreDeltas[player.id] ? `+${gameState.scoreDeltas[player.id]}` : '—'}
+            </span>
+            <span className={styles.resultTotal}>{player.score}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.endActions}>
+        <button
+          type="button"
+          onClick={onLeave}
+          className={cn(
+            arcadeShellStyles.button,
+            arcadeShellStyles.buttonGhost,
+            arcadeShellStyles.buttonSmall
+          )}
+        >
+          Leave
+        </button>
+        {isHost ? (
+          <button type="button" onClick={onNext} className={arcadeShellStyles.button}>
+            Next turn →
+          </button>
+        ) : null}
+        <span className={cn(styles.endCountdown, arcadeShellStyles.mono)}>
+          auto in {countdown}s
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function FinishedScreen({
+  gameState,
+  playerId,
+  onLeave,
+  onPlayAgain,
+}: {
+  gameState: GameState
+  playerId: string
+  onLeave: () => void
+  onPlayAgain: () => void
+}) {
+  const isHost = gameState.players.find((player) => player.id === playerId)?.isHost ?? false
+  const sortedPlayers = [...gameState.players].sort((left, right) => right.score - left.score)
+  const winner = sortedPlayers[0]
+  const isWinner = winner?.id === playerId
+
+  return (
+    <div className={styles.endShell}>
+      <p className={cn(styles.endMeta, arcadeShellStyles.mono)}>Game over · final standings</p>
+      <h2 className={styles.endTitle}>
+        {isWinner ? 'You win' : `${winner?.name ?? 'Winner'} wins`}
+      </h2>
+      <p className={styles.endWord}>
+        with <span className={styles.endWordAccent}>{winner?.score ?? 0}</span> points
+      </p>
+
+      <div className={styles.resultsTable}>
+        {sortedPlayers.map((player, index) => (
+          <div
+            key={player.id}
+            className={cn(styles.resultRow, index === 0 && styles.resultRowWinner)}
+          >
+            <span className={cn(styles.resultTotal, arcadeShellStyles.mono)}>
+              {index === 0 ? '👑' : index + 1}
+            </span>
+            <div className={styles.resultPlayer}>
+              <ArcadeAvatar index={player.avatar} size={26} />
+              <span>{player.name}</span>
+            </div>
+            <span className={styles.resultDelta}>{index === 0 ? 'Winner' : ''}</span>
+            <span className={styles.resultTotal}>{player.score}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.endActions}>
+        <button
+          type="button"
+          onClick={onLeave}
+          className={cn(
+            arcadeShellStyles.button,
+            arcadeShellStyles.buttonGhost,
+            arcadeShellStyles.buttonSmall
+          )}
+        >
+          Back to library
+        </button>
+        {isHost ? (
+          <button type="button" onClick={onPlayAgain} className={arcadeShellStyles.button}>
+            Play again
+          </button>
+        ) : (
+          <span className={cn(styles.endCountdown, arcadeShellStyles.mono)}>waiting for host</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function GameBoardScreen({
+  gameState,
+  onlinePlayerIds,
+  playerId,
+  onAction,
+  onLeave,
+}: {
+  gameState: GameState
+  onlinePlayerIds: string[]
+  playerId: string
+  onAction: (action: GameAction) => void
+  onLeave: () => void
+}) {
+  const [color, setColor] = useState('#000000')
+  const [size, setSize] = useState(6)
+  const [tool, setTool] = useState<'pen' | 'eraser'>('pen')
+
+  const drawer = getCurrentDrawer(gameState)
+  const isDrawer = drawer?.id === playerId
+  const hasGuessed = gameState.guessedPlayers.includes(playerId)
+  const plainWord = decodeWord(gameState.word ?? '')
+
+  useEffect(() => {
+    if (!isDrawer || gameState.phase !== 'drawing' || !gameState.drawStartTime) return
+
+    const elapsed = Date.now() - gameState.drawStartTime
+    const halfDelay = gameState.turnDuration * 1000 * 0.5 - elapsed
+    const lateDelay = gameState.turnDuration * 1000 * 0.75 - elapsed
+    const timers: number[] = []
+
+    if (halfDelay > 0) {
+      timers.push(
+        window.setTimeout(() => {
+          onAction({ type: 'REVEAL_HINT', playerId, ratio: 0.5 })
+        }, halfDelay)
+      )
+    }
+
+    if (lateDelay > 0) {
+      timers.push(
+        window.setTimeout(() => {
+          onAction({ type: 'REVEAL_HINT', playerId, ratio: 0.75 })
+        }, lateDelay)
+      )
+    }
+
+    return () => {
+      timers.forEach((timer) => window.clearTimeout(timer))
+    }
+  }, [
+    gameState.drawStartTime,
+    gameState.phase,
+    gameState.turnDuration,
+    isDrawer,
+    onAction,
+    playerId,
+  ])
+
+  return (
+    <div className={styles.board}>
+      <div className={styles.hud}>
+        <div className={styles.hudSection}>
+          <div className={styles.roundBlock}>
+            <span className={cn(styles.roundLabel, arcadeShellStyles.mono)}>Round</span>
+            <span className={styles.roundValue}>
+              {gameState.round}
+              <span className="text-sm font-normal text-[var(--arcade-ink-mute)]">
+                {' '}
+                / {gameState.totalRounds}
+              </span>
+            </span>
+          </div>
+          <div className={styles.roundBlock}>
+            <span className={cn(styles.roundLabel, arcadeShellStyles.mono)}>Drawer</span>
+            <span className={styles.roundValue}>{drawer?.name}</span>
+          </div>
+        </div>
+
+        <div className={cn(styles.hudSection, styles.hudSectionCenter)}>
+          {isDrawer ? (
+            <div className={styles.hintDrawer}>
+              <span className={cn(styles.hintLabel, arcadeShellStyles.mono)}>Draw this</span>
+              <span className={styles.hintWord}>{plainWord}</span>
+            </div>
           ) : (
-            <p className="text-muted-foreground text-sm">Next turn in {countdown}s&hellip;</p>
+            <div className={styles.hintDrawer}>
+              <span className={cn(styles.hintLabel, arcadeShellStyles.mono)}>
+                {plainWord.length} letters · {plainWord.replace(/ /g, '').length} chars
+              </span>
+              <span className={styles.hintMask}>{gameState.hint}</span>
+            </div>
+          )}
+        </div>
+
+        <div className={cn(styles.hudSection, styles.hudSectionRight)}>
+          {gameState.drawStartTime && (
+            <TimerRing
+              startTime={gameState.drawStartTime}
+              duration={gameState.turnDuration}
+              onTimeUp={() => onAction({ type: 'END_TURN', playerId })}
+            />
           )}
           <button
+            type="button"
             onClick={onLeave}
-            className="hover:bg-secondary rounded-lg border px-5 py-2.5 text-sm font-semibold"
+            className={cn(
+              arcadeShellStyles.button,
+              arcadeShellStyles.buttonGhost,
+              arcadeShellStyles.buttonSmall
+            )}
           >
             Leave
           </button>
         </div>
       </div>
-    </div>
-  )
-}
 
-// ─── Finished Screen ──────────────────────────────────────────────────────────
+      <Scoreboard
+        players={gameState.players}
+        currentDrawerId={drawer?.id ?? null}
+        guessedPlayers={gameState.guessedPlayers}
+        playerId={playerId}
+        onlinePlayerIds={onlinePlayerIds}
+        scoreDeltas={gameState.scoreDeltas}
+      />
 
-interface FinishedScreenProps {
-  gameState: GameState
-  playerId: string
-  onPlayAgain: () => void
-  onLeave: () => void
-}
-
-function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedScreenProps) {
-  const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
-  const sorted = [...gameState.players].sort((a, b) => b.score - a.score)
-  const winner = sorted[0]
-  const isWinner = winner?.id === playerId
-
-  return (
-    <div className="flex flex-col items-center gap-6">
-      <div className="text-6xl">{isWinner ? '\uD83C\uDFC6' : '\uD83C\uDFAE'}</div>
-      <div className="text-center">
-        <h2 className="text-2xl font-black">
-          {isWinner ? 'You win!' : `${winner?.name ?? '?'} wins!`}
-        </h2>
-        <p className="text-muted-foreground text-sm">Final score: {winner?.score ?? 0} points</p>
-      </div>
-
-      <div className="w-72">
-        <Scoreboard
-          players={gameState.players}
-          currentDrawerId={null}
-          guessedPlayers={[]}
-          playerId={playerId}
+      <div className={styles.canvasColumn}>
+        <DrawingCanvas
+          strokes={gameState.strokes}
+          isDrawer={isDrawer}
+          color={tool === 'eraser' ? '#ffffff' : color}
+          size={size}
+          tool={tool}
+          onStrokeComplete={(stroke) => onAction({ type: 'ADD_STROKE', playerId, stroke })}
         />
-      </div>
 
-      <div className="flex gap-3">
-        {isHost ? (
-          <button
-            onClick={onPlayAgain}
-            className="bg-primary text-primary-foreground rounded-lg px-5 py-2.5 text-sm font-semibold active:scale-95"
-          >
-            Play Again
-          </button>
+        {isDrawer ? (
+          <div className={styles.toolbar}>
+            <div className={styles.toolGroup}>
+              <span className={cn(styles.toolLabel, arcadeShellStyles.mono)}>Colors</span>
+              {COLORS.map((swatch) => (
+                <button
+                  key={swatch}
+                  type="button"
+                  title={swatch}
+                  onClick={() => {
+                    setTool('pen')
+                    setColor(swatch)
+                  }}
+                  className={cn(
+                    styles.colorButton,
+                    color === swatch && tool === 'pen' && styles.colorButtonActive
+                  )}
+                  style={{ background: swatch }}
+                />
+              ))}
+            </div>
+
+            <div className={styles.toolGroup}>
+              <span className={cn(styles.toolLabel, arcadeShellStyles.mono)}>Size</span>
+              {BRUSH_SIZES.map((brushSize) => (
+                <button
+                  key={brushSize}
+                  type="button"
+                  onClick={() => setSize(brushSize)}
+                  className={cn(styles.sizeButton, size === brushSize && styles.sizeButtonActive)}
+                >
+                  <span
+                    className={styles.sizeDot}
+                    style={{
+                      width: Math.min(brushSize, 18),
+                      height: Math.min(brushSize, 18),
+                    }}
+                  />
+                </button>
+              ))}
+            </div>
+
+            <div className={styles.toolGroup}>
+              <span className={cn(styles.toolLabel, arcadeShellStyles.mono)}>Tools</span>
+              <button
+                type="button"
+                title="Pen"
+                onClick={() => setTool('pen')}
+                className={cn(styles.toolButton, tool === 'pen' && styles.toolButtonActive)}
+              >
+                <PencilLine className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                title="Eraser"
+                onClick={() => setTool('eraser')}
+                className={cn(styles.toolButton, tool === 'eraser' && styles.toolButtonActive)}
+              >
+                <Eraser className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                title="Undo"
+                onClick={() => onAction({ type: 'UNDO_STROKE', playerId })}
+                className={styles.toolButton}
+              >
+                <Undo2 className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                title="Clear all"
+                onClick={() => onAction({ type: 'CLEAR_CANVAS', playerId })}
+                className={cn(styles.toolButton, styles.toolButtonDanger)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
         ) : (
-          <p className="text-muted-foreground text-sm">Waiting for host&hellip;</p>
-        )}
-        <button
-          onClick={onLeave}
-          className="hover:bg-secondary rounded-lg border px-5 py-2.5 text-sm font-semibold"
-        >
-          Leave
-        </button>
-      </div>
-    </div>
-  )
-}
-
-// ─── Game Board (drawing phase) ───────────────────────────────────────────────
-
-interface GameBoardProps {
-  gameState: GameState
-  playerId: string
-  onlinePlayerIds: string[]
-  dispatch: (action: Parameters<ReturnType<typeof useSkribblRoom>['dispatch']>[0]) => void
-  onLeave: () => void
-}
-
-function GameBoardScreen({
-  gameState,
-  playerId,
-  onlinePlayerIds,
-  dispatch,
-  onLeave,
-}: GameBoardProps) {
-  const drawer = getCurrentDrawer(gameState)
-  const isDrawer = drawer?.id === playerId
-  const hasGuessed = gameState.guessedPlayers.includes(playerId)
-
-  const handleTimeUp = useCallback(() => {
-    dispatch({ type: 'END_TURN', playerId })
-  }, [dispatch, playerId])
-
-  // Drawer dispatches hint reveals at 50% and 75% of turn time
-  useEffect(() => {
-    if (!isDrawer || gameState.phase !== 'drawing' || !gameState.drawStartTime) return
-    const turnMs = gameState.turnDuration * 1000
-    const elapsed = Date.now() - gameState.drawStartTime
-    const halfTime = turnMs * 0.5 - elapsed
-    const threeQuarterTime = turnMs * 0.75 - elapsed
-    const timers: ReturnType<typeof setTimeout>[] = []
-    if (halfTime > 0) {
-      timers.push(
-        setTimeout(() => dispatch({ type: 'REVEAL_HINT', playerId, ratio: 0.5 }), halfTime)
-      )
-    }
-    if (threeQuarterTime > 0) {
-      timers.push(
-        setTimeout(() => dispatch({ type: 'REVEAL_HINT', playerId, ratio: 0.75 }), threeQuarterTime)
-      )
-    }
-    return () => timers.forEach(clearTimeout)
-  }, [
-    isDrawer,
-    gameState.phase,
-    gameState.drawStartTime,
-    gameState.turnDuration,
-    dispatch,
-    playerId,
-  ])
-
-  return (
-    <div className="flex w-full max-w-5xl flex-col gap-3 px-2">
-      {/* Top bar: round, hint/word, timer */}
-      <div className="bg-secondary/60 flex items-center gap-3 rounded-xl px-4 py-2">
-        <span className="text-muted-foreground text-xs font-semibold">
-          Round {gameState.round}/{gameState.totalRounds}
-        </span>
-        <div className="flex-1 text-center">
-          {isDrawer ? (
-            <span className="text-sm font-bold">
-              Draw: <span className="text-primary">{decodeWord(gameState.word ?? '')}</span>
+          <div className={cn(styles.toolbar, styles.toolbarInfo)}>
+            <span className={arcadeShellStyles.mono}>
+              {hasGuessed ? '✓ You got it — waiting on the others' : 'Keep guessing in chat →'}
             </span>
-          ) : (
-            <span className="text-lg font-bold tracking-[0.3em]">{gameState.hint}</span>
-          )}
-        </div>
-        <div className="w-32">
-          {gameState.drawStartTime && (
-            <Timer
-              startTime={gameState.drawStartTime}
-              duration={gameState.turnDuration}
-              onTimeUp={handleTimeUp}
-            />
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
-      {/* Main layout: scoreboard | canvas | chat */}
-      <div className="flex flex-col gap-3 lg:flex-row">
-        {/* Scoreboard */}
-        <div className="w-full shrink-0 lg:w-44">
-          <Scoreboard
-            players={gameState.players}
-            currentDrawerId={drawer?.id ?? null}
-            guessedPlayers={gameState.guessedPlayers}
-            playerId={playerId}
-            onlinePlayerIds={onlinePlayerIds}
-          />
-        </div>
-
-        {/* Canvas */}
-        <div className="flex-1">
-          <DrawingCanvas
-            strokes={gameState.strokes}
-            isDrawer={isDrawer}
-            onStrokeComplete={(stroke) => dispatch({ type: 'ADD_STROKE', playerId, stroke })}
-            onClear={() => dispatch({ type: 'CLEAR_CANVAS', playerId })}
-            onUndo={() => dispatch({ type: 'UNDO_STROKE', playerId })}
-          />
-        </div>
-
-        {/* Chat */}
-        <div className="w-full shrink-0 lg:w-56">
-          <ChatPanel
-            messages={gameState.messages}
-            isDrawer={isDrawer}
-            hasGuessed={hasGuessed}
-            onGuess={(text) => dispatch({ type: 'GUESS', playerId, text })}
-          />
-        </div>
-      </div>
-
-      {/* Status + leave */}
-      <div className="flex items-center justify-between">
-        <p className="text-muted-foreground text-xs">
-          {isDrawer
-            ? "You're drawing!"
-            : hasGuessed
-              ? 'You guessed it! Waiting for others...'
-              : `${drawer?.name} is drawing`}
-        </p>
-        <button
-          onClick={onLeave}
-          className="hover:bg-secondary rounded-lg border px-3 py-1.5 text-xs"
-        >
-          Leave
-        </button>
-      </div>
+      <ChatPanel
+        messages={gameState.messages}
+        isDrawer={isDrawer}
+        hasGuessed={hasGuessed}
+        onGuess={(text) => onAction({ type: 'GUESS', playerId, text })}
+      />
     </div>
   )
 }
-
-// ─── Main Component ───────────────────────────────────────────────────────────
 
 export function SkribblGame() {
   const inviteCode = useInviteCode()
+  const inviteCodeResolved = inviteCode !== undefined
+  const [entryMode, setEntryMode] = useState<'howto' | 'entry'>('howto')
   const {
-    gameState,
-    playerId,
-    roomCode,
-    status,
-    error,
-    savedSession,
-    onlinePlayerIds,
     createRoom,
-    joinRoom,
-    restoreSession,
     dispatch,
+    error,
+    gameState,
+    joinRoom,
     leaveRoom,
+    onlinePlayerIds,
+    playerId,
+    restoreSession,
+    roomCode,
+    savedSession,
+    status,
   } = useSkribblRoom()
 
-  if (!isSupabaseConfigured) return <SetupRequired />
-
-  const isLoading = status === 'creating' || status === 'joining' || status === 'restoring'
-
-  if (!gameState || !playerId || !roomCode) {
-    return (
-      <EntryScreen
-        onCreate={createRoom}
-        onJoin={joinRoom}
-        onRestore={savedSession ? restoreSession : undefined}
-        savedSession={savedSession}
-        loading={isLoading}
-        error={error}
-        initialCode={inviteCode}
-      />
-    )
-  }
-
-  if (gameState.phase === 'lobby') {
-    return (
-      <LobbyScreen
-        gameState={gameState}
-        playerId={playerId}
-        roomCode={roomCode}
-        onlinePlayerIds={onlinePlayerIds}
-        onStart={() => dispatch({ type: 'START_GAME', playerId })}
-        onLeave={leaveRoom}
-      />
-    )
-  }
-
-  if (gameState.phase === 'picking') {
-    const drawer = getCurrentDrawer(gameState)
-    const isDrawer = drawer?.id === playerId
-
-    if (isDrawer) {
-      return (
-        <WordPicker
-          words={gameState.wordChoices}
-          onPick={(word) => dispatch({ type: 'PICK_WORD', playerId, word })}
-        />
-      )
+  useEffect(() => {
+    if (inviteCode) {
+      setEntryMode('entry')
     }
+  }, [inviteCode])
 
-    return (
-      <div className="flex flex-col items-center gap-4">
-        <div className="text-5xl">🎨</div>
-        <h2 className="text-lg font-bold">{drawer?.name} is picking a word...</h2>
-        <p className="text-muted-foreground text-sm">Get ready to guess!</p>
-      </div>
-    )
-  }
+  const crumb = makeCrumb(gameState, roomCode, playerId, inviteCode)
+  const handleAction = useCallback(
+    (action: GameAction) => {
+      void dispatch(action)
+    },
+    [dispatch]
+  )
 
-  if (gameState.phase === 'drawing') {
-    return (
-      <GameBoardScreen
-        gameState={gameState}
-        playerId={playerId}
-        onlinePlayerIds={onlinePlayerIds}
-        dispatch={dispatch}
-        onLeave={leaveRoom}
-      />
-    )
-  }
+  const handleCreate = useCallback(
+    (name: string, avatar: number) => {
+      void createRoom(name, { avatar })
+    },
+    [createRoom]
+  )
 
-  if (gameState.phase === 'round-end') {
-    return (
-      <RoundEndScreen
-        gameState={gameState}
-        playerId={playerId}
-        onNext={() => dispatch({ type: 'NEXT_TURN', playerId })}
-        onLeave={leaveRoom}
-      />
-    )
-  }
+  const handleJoin = useCallback(
+    (code: string, name: string, avatar: number) => {
+      void joinRoom(code, name, { avatar })
+    },
+    [joinRoom]
+  )
 
-  if (gameState.phase === 'finished') {
-    return (
-      <FinishedScreen
-        gameState={gameState}
-        playerId={playerId}
-        onPlayAgain={() => dispatch({ type: 'PLAY_AGAIN', playerId })}
-        onLeave={leaveRoom}
-      />
-    )
-  }
+  const handleLeave = useCallback(() => {
+    void leaveRoom()
+  }, [leaveRoom])
 
-  return null
+  const centered = gameState?.phase !== 'drawing'
+  const isEntryState = !gameState || !playerId || !roomCode
+  const isResolvingInvite = isEntryState && !inviteCodeResolved
+
+  return (
+    <ArcadeShell title="Skribbl" crumb={crumb} centered={centered}>
+      {!isSupabaseConfigured ? (
+        <SetupRequired />
+      ) : isResolvingInvite ? (
+        <InviteResolvingScreen />
+      ) : isEntryState ? (
+        entryMode === 'howto' ? (
+          <HowToScreen onStart={() => setEntryMode('entry')} />
+        ) : (
+          <EntryScreen
+            error={error}
+            initialCode={inviteCode ?? null}
+            loading={status === 'creating' || status === 'joining' || status === 'restoring'}
+            onBackToHowTo={!inviteCode ? () => setEntryMode('howto') : undefined}
+            onCreate={handleCreate}
+            onJoin={handleJoin}
+            onRestore={() => void restoreSession()}
+            savedSession={savedSession}
+          />
+        )
+      ) : gameState.phase === 'lobby' ? (
+        <LobbyScreen
+          gameState={gameState}
+          onlinePlayerIds={onlinePlayerIds}
+          playerId={playerId}
+          roomCode={roomCode}
+          onLeave={handleLeave}
+          onRemovePlayer={(targetPlayerId) =>
+            handleAction({
+              type: 'REMOVE_PLAYER',
+              playerId,
+              targetPlayerId,
+            })
+          }
+          onStart={() => handleAction({ type: 'START_GAME', playerId })}
+          onUpdateSettings={(settings) =>
+            handleAction({
+              type: 'UPDATE_SETTINGS',
+              playerId,
+              ...settings,
+            })
+          }
+        />
+      ) : gameState.phase === 'picking' ? (
+        getCurrentDrawer(gameState)?.id === playerId ? (
+          <WordPickerScreen
+            words={gameState.wordChoices}
+            onPick={(word) => handleAction({ type: 'PICK_WORD', playerId, word })}
+          />
+        ) : (
+          <WaitingPickerScreen drawerName={getCurrentDrawer(gameState)?.name ?? 'Player'} />
+        )
+      ) : gameState.phase === 'drawing' ? (
+        <GameBoardScreen
+          gameState={gameState}
+          onlinePlayerIds={onlinePlayerIds}
+          playerId={playerId}
+          onAction={handleAction}
+          onLeave={handleLeave}
+        />
+      ) : gameState.phase === 'round-end' ? (
+        <RoundEndScreen
+          gameState={gameState}
+          playerId={playerId}
+          onLeave={handleLeave}
+          onNext={() => handleAction({ type: 'NEXT_TURN', playerId })}
+        />
+      ) : (
+        <FinishedScreen
+          gameState={gameState}
+          playerId={playerId}
+          onLeave={handleLeave}
+          onPlayAgain={() => handleAction({ type: 'PLAY_AGAIN', playerId })}
+        />
+      )}
+    </ArcadeShell>
+  )
 }

--- a/src/games/skribbl/logic.test.ts
+++ b/src/games/skribbl/logic.test.ts
@@ -16,11 +16,11 @@ import {
 } from './logic'
 
 function makeHost(): Player {
-  return { id: 'host', name: 'Host', isHost: true, score: 0 }
+  return { id: 'host', name: 'Host', isHost: true, score: 0, avatar: 0 }
 }
 
 function makePlayer(id: string, name: string): Player {
-  return { id, name, isHost: false, score: 0 }
+  return { id, name, isHost: false, score: 0, avatar: 1 }
 }
 
 function lobbyWithPlayers(): GameState {
@@ -121,6 +121,67 @@ describe('START_GAME', () => {
     state = { ...state, players: state.players.map((p) => ({ ...p, score: 100 })) }
     const next = applyAction(state, { type: 'START_GAME', playerId: 'host' })
     expect(next.players.every((p) => p.score === 0)).toBe(true)
+  })
+})
+
+describe('UPDATE_SETTINGS', () => {
+  it('lets the host change rounds and turn duration in lobby', () => {
+    const state = lobbyWithPlayers()
+    const next = applyAction(state, {
+      type: 'UPDATE_SETTINGS',
+      playerId: 'host',
+      totalRounds: 5,
+      turnDuration: 120,
+    })
+
+    expect(next.totalRounds).toBe(5)
+    expect(next.turnDuration).toBe(120)
+  })
+
+  it('ignores non-host updates', () => {
+    const state = lobbyWithPlayers()
+    const next = applyAction(state, {
+      type: 'UPDATE_SETTINGS',
+      playerId: 'p2',
+      totalRounds: 5,
+    })
+
+    expect(next.totalRounds).toBe(3)
+  })
+})
+
+describe('REMOVE_PLAYER', () => {
+  it('lets the host remove another player in lobby', () => {
+    const state = lobbyWithPlayers()
+    const next = applyAction(state, {
+      type: 'REMOVE_PLAYER',
+      playerId: 'host',
+      targetPlayerId: 'p2',
+    })
+
+    expect(next.players.map((player) => player.id)).toEqual(['host', 'p3'])
+  })
+
+  it('does not let non-host remove a player', () => {
+    const state = lobbyWithPlayers()
+    const next = applyAction(state, {
+      type: 'REMOVE_PLAYER',
+      playerId: 'p2',
+      targetPlayerId: 'p3',
+    })
+
+    expect(next.players).toHaveLength(3)
+  })
+
+  it('does not let host remove self', () => {
+    const state = lobbyWithPlayers()
+    const next = applyAction(state, {
+      type: 'REMOVE_PLAYER',
+      playerId: 'host',
+      targetPlayerId: 'host',
+    })
+
+    expect(next.players).toHaveLength(3)
   })
 })
 
@@ -226,6 +287,8 @@ describe('GUESS', () => {
     expect(next.guessedPlayers).toContain('p2')
     expect(next.players.find((p) => p.id === 'p2')!.score).toBeGreaterThan(0)
     expect(next.messages.some((m) => m.isCorrect)).toBe(true)
+    expect(next.scoreDeltas.p2).toBeGreaterThan(0)
+    expect(next.scoreDeltas.host).toBeGreaterThanOrEqual(0)
   })
 
   it('wrong guess adds chat message', () => {
@@ -234,6 +297,14 @@ describe('GUESS', () => {
     expect(next.guessedPlayers).not.toContain('p2')
     expect(next.messages).toHaveLength(1)
     expect(next.messages[0].text).toBe('wrongguess')
+  })
+
+  it('marks close guesses for richer chat UI', () => {
+    const state = drawingState()
+    const word = decodeWord(state.word!)
+    const almost = word.slice(0, Math.max(3, word.length - 1))
+    const next = applyAction(state, { type: 'GUESS', playerId: 'p2', text: almost })
+    expect(next.messages[0].isClose).toBe(true)
   })
 
   it('drawer cannot guess', () => {

--- a/src/games/skribbl/logic.ts
+++ b/src/games/skribbl/logic.ts
@@ -18,6 +18,7 @@ export interface Player {
   name: string
   isHost: boolean
   score: number
+  avatar: number
 }
 
 export interface ChatMessage {
@@ -27,6 +28,7 @@ export interface ChatMessage {
   text: string
   isCorrect?: boolean
   isSystem?: boolean
+  isClose?: boolean
 }
 
 export interface DrawPoint {
@@ -43,6 +45,8 @@ export interface DrawStroke {
 
 export type GameAction =
   | { type: 'START_GAME'; playerId: string }
+  | { type: 'UPDATE_SETTINGS'; playerId: string; totalRounds?: number; turnDuration?: number }
+  | { type: 'REMOVE_PLAYER'; playerId: string; targetPlayerId: string }
   | { type: 'PICK_WORD'; playerId: string; word: string }
   | { type: 'ADD_STROKE'; playerId: string; stroke: DrawStroke }
   | { type: 'CLEAR_CANVAS'; playerId: string }
@@ -141,6 +145,29 @@ export function calculateDrawerScore(guessedCount: number, totalGuessers: number
   return Math.round(100 * (guessedCount / totalGuessers))
 }
 
+export function isCloseGuess(guess: string, answer: string): boolean {
+  const normalizedGuess = guess.trim().toLowerCase()
+  const normalizedAnswer = answer.trim().toLowerCase()
+
+  if (!normalizedGuess || normalizedGuess === normalizedAnswer) return false
+  if (normalizedGuess.length < 3) return false
+
+  if (normalizedAnswer.includes(normalizedGuess) || normalizedGuess.includes(normalizedAnswer)) {
+    return true
+  }
+
+  if (Math.abs(normalizedGuess.length - normalizedAnswer.length) > 1) return false
+
+  let diff = 0
+  const maxLength = Math.max(normalizedGuess.length, normalizedAnswer.length)
+  for (let i = 0; i < maxLength; i++) {
+    if (normalizedGuess[i] !== normalizedAnswer[i]) diff++
+    if (diff > 2) return false
+  }
+
+  return diff <= 2
+}
+
 // ─── State helpers ────────────────────────────────────────────────────────────
 
 export function createLobbyState(host: Player): GameState {
@@ -159,6 +186,7 @@ export function createLobbyState(host: Player): GameState {
     drawStartTime: null,
     turnDuration: 80,
     turnEndTime: null,
+    scoreDeltas: {},
   }
 }
 
@@ -192,9 +220,11 @@ function startPickingPhase(state: GameState): GameState {
     word: null,
     hint: '',
     strokes: [],
+    messages: [],
     guessedPlayers: [],
     drawStartTime: null,
     turnEndTime: null,
+    scoreDeltas: {},
   }
 }
 
@@ -232,6 +262,7 @@ export function applyAction(state: GameState, action: GameAction): GameState {
       round: 1,
       currentDrawerIndex: 0,
       messages: [],
+      scoreDeltas: {},
     })
   }
 
@@ -244,7 +275,39 @@ export function applyAction(state: GameState, action: GameAction): GameState {
       round: 1,
       currentDrawerIndex: 0,
       messages: [],
+      scoreDeltas: {},
     })
+  }
+
+  if (action.type === 'UPDATE_SETTINGS') {
+    if (state.phase !== 'lobby') return state
+    if (host?.id !== action.playerId) return state
+
+    const nextTotalRounds =
+      action.totalRounds && [2, 3, 5].includes(action.totalRounds) ? action.totalRounds : undefined
+    const nextTurnDuration =
+      action.turnDuration && [60, 80, 120].includes(action.turnDuration)
+        ? action.turnDuration
+        : undefined
+
+    if (nextTotalRounds === undefined && nextTurnDuration === undefined) return state
+
+    return {
+      ...state,
+      totalRounds: nextTotalRounds ?? state.totalRounds,
+      turnDuration: nextTurnDuration ?? state.turnDuration,
+    }
+  }
+
+  if (action.type === 'REMOVE_PLAYER') {
+    if (state.phase !== 'lobby') return state
+    if (host?.id !== action.playerId) return state
+    if (action.targetPlayerId === action.playerId) return state
+
+    const target = state.players.find((player) => player.id === action.targetPlayerId)
+    if (!target || target.isHost) return state
+
+    return removePlayer(state, action.targetPlayerId)
   }
 
   if (action.type === 'PICK_WORD') {
@@ -337,6 +400,11 @@ export function applyAction(state: GameState, action: GameAction): GameState {
         players,
         guessedPlayers: newGuessedPlayers,
         messages: [...state.messages, msg],
+        scoreDeltas: {
+          ...state.scoreDeltas,
+          [action.playerId]: guessScore,
+          ...(drawer ? { [drawer.id]: drawerBonus } : {}),
+        },
       }
 
       if (allGuessed) {
@@ -356,6 +424,7 @@ export function applyAction(state: GameState, action: GameAction): GameState {
       playerId: action.playerId,
       playerName: player.name,
       text: action.text.trim(),
+      isClose: isCloseGuess(guess, answer),
     }
     return { ...state, messages: [...state.messages, msg] }
   }

--- a/src/games/skribbl/schema.test.ts
+++ b/src/games/skribbl/schema.test.ts
@@ -2,7 +2,7 @@ import { GameStateSchema } from './schema'
 
 const validGameState = {
   phase: 'lobby' as const,
-  players: [{ id: 'p1', name: 'Alice', isHost: true, score: 0 }],
+  players: [{ id: 'p1', name: 'Alice', isHost: true, score: 0, avatar: 0 }],
   currentDrawerIndex: 0,
   round: 0,
   totalRounds: 3,
@@ -15,6 +15,7 @@ const validGameState = {
   drawStartTime: null,
   turnDuration: 80,
   turnEndTime: null,
+  scoreDeltas: {},
 }
 
 describe('skribbl GameStateSchema', () => {
@@ -37,6 +38,7 @@ describe('skribbl GameStateSchema', () => {
           playerName: 'Alice',
           text: 'a guess',
           isCorrect: false,
+          isClose: true,
         },
       ],
     }

--- a/src/games/skribbl/schema.ts
+++ b/src/games/skribbl/schema.ts
@@ -5,6 +5,7 @@ const PlayerSchema = z.object({
   name: z.string(),
   isHost: z.boolean(),
   score: z.number(),
+  avatar: z.number().int().min(0).max(7).default(0),
 })
 
 const DrawPointSchema = z.object({
@@ -26,6 +27,7 @@ const ChatMessageSchema = z.object({
   text: z.string(),
   isCorrect: z.boolean().optional(),
   isSystem: z.boolean().optional(),
+  isClose: z.boolean().optional(),
 })
 
 export const GameStateSchema = z.object({
@@ -43,6 +45,7 @@ export const GameStateSchema = z.object({
   drawStartTime: z.number().nullable(),
   turnDuration: z.number(),
   turnEndTime: z.number().nullable(),
+  scoreDeltas: z.record(z.string(), z.number()).default({}),
 })
 
 export type GameState = z.infer<typeof GameStateSchema>

--- a/src/games/skribbl/useSkribblRoom.ts
+++ b/src/games/skribbl/useSkribblRoom.ts
@@ -18,6 +18,14 @@ export type UseSkribblRoomReturn = Omit<
   'broadcast' | 'onBroadcast'
 >
 
+function resolveAvatar(extras?: Record<string, unknown>, playerIndex = 0): number {
+  const avatar = extras?.avatar
+  if (typeof avatar === 'number' && Number.isInteger(avatar) && avatar >= 0 && avatar <= 7) {
+    return avatar
+  }
+  return playerIndex % 8
+}
+
 export function useSkribblRoom(): UseSkribblRoomReturn {
   return useGameRoom<GameState, GameAction>({
     tableName: 'skribbl_rooms',
@@ -26,7 +34,14 @@ export function useSkribblRoom(): UseSkribblRoomReturn {
     stateSchema: GameStateSchema,
     applyAction,
     createLobbyState: (host) => createLobbyState({ ...host, score: 0 } as Player),
-    createPlayer: ({ id, name, isHost }) => ({ id, name, isHost, score: 0 }) as Player,
+    createPlayer: ({ id, name, isHost, playerIndex, extras }) =>
+      ({
+        id,
+        name,
+        isHost,
+        score: 0,
+        avatar: resolveAvatar(extras, playerIndex),
+      }) as Player,
     addPlayer,
   })
 }

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -60,12 +60,13 @@ export interface GameRoomConfig<TState extends BaseGameState, TAction, TBroadcas
   sessionKey: string
   stateSchema: ZodType<TState>
   applyAction: (state: TState, action: TAction) => TState
-  createLobbyState: (host: { id: string; name: string; isHost: true }) => TState
+  createLobbyState: (host: TState['players'][number]) => TState
   createPlayer: (info: {
     id: string
     name: string
     isHost: boolean
     playerIndex: number
+    extras?: Record<string, unknown>
   }) => TState['players'][number]
   addPlayer: (state: TState, player: TState['players'][number]) => TState
   broadcast?: BroadcastConfig<TBroadcast>
@@ -87,8 +88,8 @@ export interface UseGameRoomReturn<TState, TAction, TBroadcast = never> {
   error: string | null
   savedSession: Session | null
   onlinePlayerIds: string[]
-  createRoom: (playerName: string) => Promise<void>
-  joinRoom: (code: string, playerName: string) => Promise<void>
+  createRoom: (playerName: string, extras?: Record<string, unknown>) => Promise<void>
+  joinRoom: (code: string, playerName: string, extras?: Record<string, unknown>) => Promise<void>
   restoreSession: () => Promise<void>
   dispatch: (action: TAction) => Promise<void>
   leaveRoom: () => Promise<void>
@@ -216,7 +217,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
   }, [])
 
   const createRoom = useCallback(
-    async (playerName: string) => {
+    async (playerName: string, extras?: Record<string, unknown>) => {
       if (!supabase) return
       const cfg = configRef.current
       setStatus('creating')
@@ -224,7 +225,14 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
 
       const id = crypto.randomUUID()
       const code = generateRoomCode()
-      const initialState = cfg.createLobbyState({ id, name: playerName, isHost: true as const })
+      const hostPlayer = cfg.createPlayer({
+        id,
+        name: playerName,
+        isHost: true,
+        playerIndex: 0,
+        extras,
+      })
+      const initialState = cfg.createLobbyState(hostPlayer)
 
       const { data: inserted, error: err } = await supabase
         .from(cfg.tableName)
@@ -248,7 +256,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
   )
 
   const joinRoom = useCallback(
-    async (code: string, playerName: string) => {
+    async (code: string, playerName: string, extras?: Record<string, unknown>) => {
       if (!supabase) return
       const cfg = configRef.current
       setStatus('joining')
@@ -288,6 +296,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         name: playerName,
         isHost: false,
         playerIndex: currentState.players.length,
+        extras,
       })
       const newState = cfg.addPlayer(currentState, player)
 
@@ -388,7 +397,12 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
           .eq('version', currentVersion)
           .select('version')
 
-        if (data && data.length > 0) return
+        if (data && data.length > 0) {
+          // Apply the accepted state locally right away so controls feel instant
+          // instead of waiting for the realtime echo from Supabase.
+          setStateAndRef(newState, currentVersion + 1)
+          return
+        }
 
         if (attempt < MAX_RETRIES) {
           const { data: fresh } = await supabase

--- a/src/hooks/useInviteCode.ts
+++ b/src/hooks/useInviteCode.ts
@@ -1,18 +1,19 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 /**
- * Reads `?code=XXXX` from the current URL synchronously on first render.
- * Returns the uppercased code or null if absent.
+ * Reads `?code=XXXX` from the current URL after mount.
+ * Returns the uppercased code, null if absent, or undefined until resolved.
  */
-export function useInviteCode(): string | null {
-  const [code] = useState<string | null>(() => {
-    if (typeof window === 'undefined') return null
+export function useInviteCode(): string | null | undefined {
+  const [code, setCode] = useState<string | null | undefined>(undefined)
+
+  useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const raw = params.get('code')
-    return raw && raw.trim().length > 0 ? raw.trim().toUpperCase() : null
-  })
+    setCode(raw && raw.trim().length > 0 ? raw.trim().toUpperCase() : null)
+  }, [])
 
   return code
 }


### PR DESCRIPTION
## What changed

This redesigns the Skribbl game flow to match the new white-theme discover direction while keeping the implementation reusable for future multiplayer game refreshes.

Highlights:
- adds a shared `ArcadeShell` and `ArcadeAvatar` layer for multiplayer game presentation
- rebuilds the Skribbl experience around the new shell, lobby, drawing board, and entry flow
- updates room/session plumbing so new player metadata and future game-specific extras can be passed more generically
- adds lobby host controls for settings updates and removing offline players
- fixes invite-link hydration issues and preserves GitHub Pages routing under `/library-games`
- fixes several layout issues including mobile header behavior, create-room fit, lobby scrolling, and drawing/lobby viewport sizing

## Why

The old Skribbl screen did not match the new design system and several behaviors became visible while iterating on the redesign:
- direct invite links could briefly render the wrong screen and trigger hydration mismatches
- lobby settings and host actions could get pushed below the fold
- the drawing screen could overflow the viewport
- offline players could remain stuck in the lobby with no host recovery path

This PR brings Skribbl in line with the new design while also making the shell/presence pieces reusable for similar redesigns in other multiplayer games.

## Impact

- players get a redesigned white-theme Skribbl experience that aligns with the latest main branch visuals
- hosts can manage offline players in the lobby
- invite links and GitHub Pages deployment paths behave correctly
- the room hook supports more generic per-game extras for future redesigns

## Validation

- `pnpm test -- src/games/skribbl/logic.test.ts src/games/skribbl/schema.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build` was attempted, but sandboxed network restrictions prevented `next/font` from fetching Google Fonts during the build