### PR TITLE
refactor: extract shared skribbl multiplayer UI primitives

### DIFF
--- a/src/components/multiplayer/AvatarPicker.test.tsx
+++ b/src/components/multiplayer/AvatarPicker.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { AvatarPicker } from './AvatarPicker'
+
+describe('AvatarPicker', () => {
+  it('renders the requested avatar count and marks the selected avatar', () => {
+    render(<AvatarPicker selectedIndex={2} onSelect={() => {}} count={4} />)
+
+    expect(screen.getAllByRole('button')).toHaveLength(4)
+    expect(screen.getByRole('button', { name: 'Select avatar 3' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('calls onSelect with the clicked avatar index', () => {
+    const onSelect = jest.fn()
+
+    render(<AvatarPicker selectedIndex={0} onSelect={onSelect} count={4} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select avatar 4' }))
+
+    expect(onSelect).toHaveBeenCalledWith(3)
+  })
+})

--- a/src/components/multiplayer/AvatarPicker.tsx
+++ b/src/components/multiplayer/AvatarPicker.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/lib/utils'
+import { ArcadeAvatar } from './ArcadeAvatar'
+
+interface AvatarPickerProps {
+  selectedIndex: number
+  onSelect: (index: number) => void
+  count?: number
+  size?: number
+  className?: string
+  buttonClassName?: string
+  selectedButtonClassName?: string
+}
+
+export function AvatarPicker({
+  selectedIndex,
+  onSelect,
+  count = 8,
+  size = 42,
+  className,
+  buttonClassName,
+  selectedButtonClassName,
+}: AvatarPickerProps) {
+  return (
+    <div className={className}>
+      {Array.from({ length: count }, (_, index) => (
+        <button
+          key={index}
+          type="button"
+          aria-label={`Select avatar ${index + 1}`}
+          aria-pressed={selectedIndex === index}
+          onClick={() => onSelect(index)}
+          className={cn(buttonClassName, selectedIndex === index && selectedButtonClassName)}
+        >
+          <ArcadeAvatar index={index} size={size} />
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/components/multiplayer/LobbyActions.test.tsx
+++ b/src/components/multiplayer/LobbyActions.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { LobbyActions } from './LobbyActions'
+
+describe('LobbyActions', () => {
+  it('renders host controls and respects the disabled start state', () => {
+    render(<LobbyActions isHost canStart={false} onLeave={() => {}} onStart={() => {}} />)
+
+    expect(screen.getByText("You're the host")).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Start game →' })).toBeDisabled()
+  })
+
+  it('renders guest waiting copy and triggers leave', () => {
+    const onLeave = jest.fn()
+
+    render(<LobbyActions isHost={false} canStart onLeave={onLeave} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }))
+
+    expect(screen.getByText('Waiting for host to start')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Start game →' })).not.toBeInTheDocument()
+    expect(onLeave).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/multiplayer/LobbyActions.tsx
+++ b/src/components/multiplayer/LobbyActions.tsx
@@ -1,0 +1,54 @@
+import { cn } from '@/lib/utils'
+
+interface LobbyActionsProps {
+  isHost: boolean
+  canStart: boolean
+  onLeave: () => void
+  onStart?: () => void
+  hostLabel?: string
+  guestLabel?: string
+  leaveLabel?: string
+  startLabel?: string
+  className?: string
+  statusClassName?: string
+  actionsClassName?: string
+  leaveButtonClassName?: string
+  startButtonClassName?: string
+}
+
+export function LobbyActions({
+  isHost,
+  canStart,
+  onLeave,
+  onStart,
+  hostLabel = "You're the host",
+  guestLabel = 'Waiting for host to start',
+  leaveLabel = 'Leave',
+  startLabel = 'Start game →',
+  className,
+  statusClassName,
+  actionsClassName,
+  leaveButtonClassName,
+  startButtonClassName,
+}: LobbyActionsProps) {
+  return (
+    <footer className={className}>
+      <span className={statusClassName}>{isHost ? hostLabel : guestLabel}</span>
+      <div className={actionsClassName}>
+        <button type="button" onClick={onLeave} className={leaveButtonClassName}>
+          {leaveLabel}
+        </button>
+        {isHost && onStart && (
+          <button
+            type="button"
+            disabled={!canStart}
+            onClick={onStart}
+            className={cn(startButtonClassName)}
+          >
+            {startLabel}
+          </button>
+        )}
+      </div>
+    </footer>
+  )
+}

--- a/src/components/multiplayer/PlayerRoster.test.tsx
+++ b/src/components/multiplayer/PlayerRoster.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { PlayerRoster } from './PlayerRoster'
+
+const players = [
+  { id: 'host', name: 'Host', avatar: 0, isHost: true },
+  { id: 'offline', name: 'Offline', avatar: 1, isHost: false },
+]
+
+describe('PlayerRoster', () => {
+  it('renders player count and default status labels', () => {
+    render(
+      <PlayerRoster
+        players={players}
+        currentPlayerId="host"
+        onlinePlayerIds={['host']}
+        maxPlayers={8}
+      />
+    )
+
+    expect(screen.getByText('Players')).toBeInTheDocument()
+    expect(screen.getByText('2 / 8')).toBeInTheDocument()
+    expect(screen.getByText('you')).toBeInTheDocument()
+    expect(screen.getByText('offline')).toBeInTheDocument()
+    expect(screen.getByText('host')).toBeInTheDocument()
+    expect(screen.getByText('away')).toBeInTheDocument()
+  })
+
+  it('shows remove action only for removable players and calls onRemovePlayer', () => {
+    const onRemovePlayer = jest.fn()
+
+    render(
+      <PlayerRoster
+        players={players}
+        currentPlayerId="host"
+        onlinePlayerIds={['host']}
+        maxPlayers={8}
+        currentPlayerIsHost
+        onRemovePlayer={onRemovePlayer}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Offline' }))
+
+    expect(onRemovePlayer).toHaveBeenCalledWith('offline')
+    expect(screen.queryByRole('button', { name: 'Remove Host' })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/multiplayer/PlayerRoster.tsx
+++ b/src/components/multiplayer/PlayerRoster.tsx
@@ -1,0 +1,108 @@
+import { cn } from '@/lib/utils'
+import { ArcadeAvatar } from './ArcadeAvatar'
+
+export interface MultiplayerRosterPlayer {
+  id: string
+  name: string
+  avatar: number
+  isHost: boolean
+}
+
+interface PlayerRosterProps {
+  players: MultiplayerRosterPlayer[]
+  currentPlayerId: string
+  onlinePlayerIds: string[]
+  maxPlayers: number
+  currentPlayerIsHost?: boolean
+  onRemovePlayer?: (playerId: string) => void
+  title?: string
+  className?: string
+  headerClassName?: string
+  listClassName?: string
+  rowClassName?: string
+  currentPlayerRowClassName?: string
+  avatarClassName?: string
+  infoClassName?: string
+  nameClassName?: string
+  metaClassName?: string
+  tagsClassName?: string
+  tagClassName?: string
+  hostTagClassName?: string
+  removeButtonClassName?: string
+}
+
+export function PlayerRoster({
+  players,
+  currentPlayerId,
+  onlinePlayerIds,
+  maxPlayers,
+  currentPlayerIsHost = false,
+  onRemovePlayer,
+  title = 'Players',
+  className,
+  headerClassName,
+  listClassName,
+  rowClassName,
+  currentPlayerRowClassName,
+  avatarClassName,
+  infoClassName,
+  nameClassName,
+  metaClassName,
+  tagsClassName,
+  tagClassName,
+  hostTagClassName,
+  removeButtonClassName,
+}: PlayerRosterProps) {
+  return (
+    <section className={className}>
+      <div className={headerClassName}>
+        <span>{title}</span>
+        <span>
+          {players.length} / {maxPlayers}
+        </span>
+      </div>
+
+      <div className={listClassName}>
+        {players.map((player) => {
+          const isOnline = onlinePlayerIds.includes(player.id)
+          const isCurrentPlayer = player.id === currentPlayerId
+          const canRemove =
+            currentPlayerIsHost && !isOnline && !player.isHost && player.id !== currentPlayerId
+
+          return (
+            <div
+              key={player.id}
+              className={cn(rowClassName, isCurrentPlayer && currentPlayerRowClassName)}
+            >
+              <div className={avatarClassName}>
+                <ArcadeAvatar index={player.avatar} size={30} />
+              </div>
+
+              <div className={infoClassName}>
+                <div className={nameClassName}>{player.name}</div>
+                <div className={metaClassName}>
+                  {isCurrentPlayer ? 'you' : isOnline ? 'online' : 'offline'}
+                </div>
+              </div>
+
+              <div className={tagsClassName}>
+                {player.isHost && <span className={cn(tagClassName, hostTagClassName)}>host</span>}
+                {!isOnline && <span className={tagClassName}>away</span>}
+                {canRemove && onRemovePlayer && (
+                  <button
+                    type="button"
+                    onClick={() => onRemovePlayer(player.id)}
+                    className={cn(tagClassName, removeButtonClassName)}
+                    aria-label={`Remove ${player.name}`}
+                  >
+                    remove
+                  </button>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/multiplayer/ResultsTable.test.tsx
+++ b/src/components/multiplayer/ResultsTable.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import { ResultsTable } from './ResultsTable'
+
+describe('ResultsTable', () => {
+  it('renders rows with rank, player, delta, and total', () => {
+    render(
+      <ResultsTable
+        rows={[
+          {
+            id: 'roman',
+            rankLabel: '1',
+            name: 'Roman',
+            avatar: 0,
+            secondaryLabel: '+120',
+            totalLabel: '450',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('Roman')).toBeInTheDocument()
+    expect(screen.getByText('+120')).toBeInTheDocument()
+    expect(screen.getByText('450')).toBeInTheDocument()
+  })
+
+  it('marks winner rows with a dedicated data attribute', () => {
+    const { container } = render(
+      <ResultsTable
+        rows={[
+          {
+            id: 'winner',
+            rankLabel: '👑',
+            name: 'Winner',
+            avatar: 1,
+            secondaryLabel: 'Winner',
+            totalLabel: '999',
+            isWinner: true,
+          },
+        ]}
+      />
+    )
+
+    expect(container.querySelector('[data-winner="true"]')).toBeInTheDocument()
+  })
+})

--- a/src/components/multiplayer/ResultsTable.tsx
+++ b/src/components/multiplayer/ResultsTable.tsx
@@ -1,0 +1,54 @@
+import { cn } from '@/lib/utils'
+import { ArcadeAvatar } from './ArcadeAvatar'
+
+export interface ResultsTableRow {
+  id: string
+  rankLabel: React.ReactNode
+  name: string
+  avatar: number
+  secondaryLabel?: React.ReactNode
+  totalLabel: React.ReactNode
+  isWinner?: boolean
+}
+
+interface ResultsTableProps {
+  rows: ResultsTableRow[]
+  className?: string
+  rowClassName?: string
+  winnerRowClassName?: string
+  rankClassName?: string
+  playerClassName?: string
+  secondaryClassName?: string
+  totalClassName?: string
+}
+
+export function ResultsTable({
+  rows,
+  className,
+  rowClassName,
+  winnerRowClassName,
+  rankClassName,
+  playerClassName,
+  secondaryClassName,
+  totalClassName,
+}: ResultsTableProps) {
+  return (
+    <div className={className}>
+      {rows.map((row) => (
+        <div
+          key={row.id}
+          className={cn(rowClassName, row.isWinner && winnerRowClassName)}
+          data-winner={row.isWinner ? 'true' : 'false'}
+        >
+          <span className={rankClassName}>{row.rankLabel}</span>
+          <div className={playerClassName}>
+            <ArcadeAvatar index={row.avatar} size={26} />
+            <span>{row.name}</span>
+          </div>
+          <span className={secondaryClassName}>{row.secondaryLabel ?? ''}</span>
+          <span className={totalClassName}>{row.totalLabel}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/multiplayer/ResumeSessionCard.test.tsx
+++ b/src/components/multiplayer/ResumeSessionCard.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ResumeSessionCard } from './ResumeSessionCard'
+
+describe('ResumeSessionCard', () => {
+  it('renders default copy from the saved session', () => {
+    render(
+      <ResumeSessionCard session={{ playerName: 'Roman', roomCode: 'AB12' }} onResume={() => {}} />
+    )
+
+    expect(screen.getByText('Resume your last room')).toBeInTheDocument()
+    expect(screen.getByText('Room AB12 as Roman')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Resume →' })).toBeInTheDocument()
+  })
+
+  it('invokes onResume when the action button is clicked', () => {
+    const onResume = jest.fn()
+
+    render(
+      <ResumeSessionCard
+        session={{ playerName: 'Roman', roomCode: 'AB12' }}
+        onResume={onResume}
+        actionLabel="Continue"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/multiplayer/ResumeSessionCard.tsx
+++ b/src/components/multiplayer/ResumeSessionCard.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils'
+import type { SavedSessionSummary } from './ResumeSessionButton'
+
+interface ResumeSessionCardProps {
+  session: SavedSessionSummary
+  onResume: () => void
+  title?: string
+  actionLabel?: string
+  description?: React.ReactNode
+  className?: string
+  contentClassName?: string
+  titleClassName?: string
+  descriptionClassName?: string
+  actionClassName?: string
+}
+
+export function ResumeSessionCard({
+  session,
+  onResume,
+  title = 'Resume your last room',
+  actionLabel = 'Resume →',
+  description,
+  className,
+  contentClassName,
+  titleClassName,
+  descriptionClassName,
+  actionClassName,
+}: ResumeSessionCardProps) {
+  return (
+    <div className={className}>
+      <div className={cn('min-w-0', contentClassName)}>
+        <div className={titleClassName}>{title}</div>
+        <div className={descriptionClassName}>
+          {description ?? `Room ${session.roomCode} as ${session.playerName}`}
+        </div>
+      </div>
+      <button type="button" onClick={onResume} className={actionClassName}>
+        {actionLabel}
+      </button>
+    </div>
+  )
+}

--- a/src/components/multiplayer/RoomInviteCard.test.tsx
+++ b/src/components/multiplayer/RoomInviteCard.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { RoomInviteCard } from './RoomInviteCard'
+
+describe('RoomInviteCard', () => {
+  it('renders the room code and default meta copy', () => {
+    render(
+      <RoomInviteCard
+        roomCode="AB12"
+        inviteLink="https://example.com/invite"
+        copied={null}
+        onCopy={() => {}}
+      />
+    )
+
+    expect(screen.getByText('AB12')).toBeInTheDocument()
+    expect(screen.getByText('/ lobby · waiting for players')).toBeInTheDocument()
+  })
+
+  it('routes copy actions through the provided callback', () => {
+    const onCopy = jest.fn()
+
+    render(
+      <RoomInviteCard
+        roomCode="AB12"
+        inviteLink="https://example.com/invite"
+        copied={null}
+        onCopy={onCopy}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+    fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+
+    expect(onCopy).toHaveBeenNthCalledWith(1, 'AB12', 'code')
+    expect(onCopy).toHaveBeenNthCalledWith(2, 'https://example.com/invite', 'link')
+  })
+})

--- a/src/components/multiplayer/RoomInviteCard.tsx
+++ b/src/components/multiplayer/RoomInviteCard.tsx
@@ -1,0 +1,58 @@
+import { Copy, Link2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface RoomInviteCardProps {
+  roomCode: string
+  inviteLink: string
+  copied: 'code' | 'link' | null
+  onCopy: (value: string, kind: 'code' | 'link') => void
+  title?: React.ReactNode
+  meta?: React.ReactNode
+  className?: string
+  titleClassName?: string
+  roomCodeClassName?: string
+  actionsClassName?: string
+  actionClassName?: string
+  metaClassName?: string
+}
+
+export function RoomInviteCard({
+  roomCode,
+  inviteLink,
+  copied,
+  onCopy,
+  title = 'Room · share this code',
+  meta = '/ lobby · waiting for players',
+  className,
+  titleClassName,
+  roomCodeClassName,
+  actionsClassName,
+  actionClassName,
+  metaClassName,
+}: RoomInviteCardProps) {
+  return (
+    <section className={className}>
+      <span className={titleClassName}>{title}</span>
+      <div className={roomCodeClassName}>{roomCode}</div>
+      <div className={actionsClassName}>
+        <button
+          type="button"
+          className={cn(actionClassName)}
+          onClick={() => onCopy(roomCode, 'code')}
+        >
+          <Copy className="h-3.5 w-3.5" />
+          {copied === 'code' ? 'Copied' : 'Copy code'}
+        </button>
+        <button
+          type="button"
+          className={cn(actionClassName)}
+          onClick={() => onCopy(inviteLink, 'link')}
+        >
+          <Link2 className="h-3.5 w-3.5" />
+          {copied === 'link' ? 'Copied' : 'Copy link'}
+        </button>
+      </div>
+      <div className={metaClassName}>{meta}</div>
+    </section>
+  )
+}

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -1,13 +1,19 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Copy, Eraser, Link2, PencilLine, Trash2, Undo2 } from 'lucide-react'
+import { Eraser, PencilLine, Trash2, Undo2 } from 'lucide-react'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
 import { cn } from '@/lib/utils'
 import { ArcadeAvatar } from '@/components/multiplayer/ArcadeAvatar'
 import { ArcadeShell, arcadeShellStyles } from '@/components/multiplayer/ArcadeShell'
+import { AvatarPicker } from '@/components/multiplayer/AvatarPicker'
+import { LobbyActions } from '@/components/multiplayer/LobbyActions'
+import { PlayerRoster } from '@/components/multiplayer/PlayerRoster'
+import { ResultsTable } from '@/components/multiplayer/ResultsTable'
+import { ResumeSessionCard } from '@/components/multiplayer/ResumeSessionCard'
+import { RoomInviteCard } from '@/components/multiplayer/RoomInviteCard'
 import { useSkribblRoom, type UseSkribblRoomReturn } from './useSkribblRoom'
 import {
   decodeWord,
@@ -666,21 +672,14 @@ function EntryScreen({
         </div>
 
         {savedSession && (
-          <div className={styles.resumeCard}>
-            <div>
-              <div className={styles.resumeTitle}>Resume your last room</div>
-              <div className={styles.resumeCopy}>
-                Room {savedSession.roomCode} as {savedSession.playerName}
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={onRestore}
-              className={cn(arcadeShellStyles.button, arcadeShellStyles.buttonSmall)}
-            >
-              Resume →
-            </button>
-          </div>
+          <ResumeSessionCard
+            session={savedSession}
+            onResume={onRestore}
+            className={styles.resumeCard}
+            titleClassName={styles.resumeTitle}
+            descriptionClassName={styles.resumeCopy}
+            actionClassName={cn(arcadeShellStyles.button, arcadeShellStyles.buttonSmall)}
+          />
         )}
 
         <div className={styles.entryChoiceGrid}>
@@ -745,18 +744,13 @@ function EntryScreen({
 
         <div className={styles.field}>
           <span className={cn(styles.label, arcadeShellStyles.mono)}>Pick an avatar</span>
-          <div className={styles.avatarGrid}>
-            {Array.from({ length: 8 }, (_, index) => (
-              <button
-                key={index}
-                type="button"
-                onClick={() => setAvatar(index)}
-                className={cn(styles.avatarButton, avatar === index && styles.avatarButtonActive)}
-              >
-                <ArcadeAvatar index={index} size={42} />
-              </button>
-            ))}
-          </div>
+          <AvatarPicker
+            selectedIndex={avatar}
+            onSelect={setAvatar}
+            className={styles.avatarGrid}
+            buttonClassName={styles.avatarButton}
+            selectedButtonClassName={styles.avatarButtonActive}
+          />
         </div>
 
         {mode === 'join' && (
@@ -834,80 +828,41 @@ function LobbyScreen({
 
   return (
     <div className={styles.lobby}>
-      <section className={styles.roomCard}>
-        <span className={cn(styles.roomLabel, arcadeShellStyles.mono)}>Room · share this code</span>
-        <div className={styles.roomCode}>{roomCode}</div>
-        <div className={styles.roomActions}>
-          <button
-            type="button"
-            className={cn(styles.roomAction, arcadeShellStyles.mono)}
-            onClick={() => copyValue(roomCode, 'code')}
-          >
-            <Copy className="h-3.5 w-3.5" />
-            {copied === 'code' ? 'Copied' : 'Copy code'}
-          </button>
-          <button
-            type="button"
-            className={cn(styles.roomAction, arcadeShellStyles.mono)}
-            onClick={() => copyValue(getInviteLink('skribbl', roomCode), 'link')}
-          >
-            <Link2 className="h-3.5 w-3.5" />
-            {copied === 'link' ? 'Copied' : 'Copy link'}
-          </button>
-        </div>
-        <div className={cn(styles.roomMeta, arcadeShellStyles.mono)}>
-          / lobby · waiting for players
-        </div>
-      </section>
+      <RoomInviteCard
+        roomCode={roomCode}
+        inviteLink={getInviteLink('skribbl', roomCode)}
+        copied={copied}
+        onCopy={copyValue}
+        className={styles.roomCard}
+        titleClassName={cn(styles.roomLabel, arcadeShellStyles.mono)}
+        roomCodeClassName={styles.roomCode}
+        actionsClassName={styles.roomActions}
+        actionClassName={cn(styles.roomAction, arcadeShellStyles.mono)}
+        metaClassName={cn(styles.roomMeta, arcadeShellStyles.mono)}
+      />
 
       <div className={styles.lobbySide}>
-        <section className={styles.playersPanel}>
-          <div className={cn(styles.panelHead, arcadeShellStyles.mono)}>
-            <span>Players</span>
-            <span>{gameState.players.length} / 8</span>
-          </div>
-
-          <div className={styles.playerList}>
-            {gameState.players.map((player) => {
-              const isOnline = onlinePlayerIds.includes(player.id)
-              const canRemove = isHost && !isOnline && !player.isHost && player.id !== playerId
-
-              return (
-                <div
-                  key={player.id}
-                  className={cn(styles.playerRow, player.id === playerId && styles.playerRowYou)}
-                >
-                  <div className={styles.playerAvatar}>
-                    <ArcadeAvatar index={player.avatar} size={30} />
-                  </div>
-
-                  <div className={styles.playerInfo}>
-                    <div className={styles.playerName}>{player.name}</div>
-                    <div className={styles.playerMeta}>
-                      {player.id === playerId ? 'you' : isOnline ? 'online' : 'offline'}
-                    </div>
-                  </div>
-
-                  <div className={styles.playerTags}>
-                    {player.isHost && (
-                      <span className={cn(styles.playerTag, styles.playerTagHost)}>host</span>
-                    )}
-                    {!isOnline && <span className={styles.playerTag}>away</span>}
-                    {canRemove && (
-                      <button
-                        type="button"
-                        onClick={() => onRemovePlayer(player.id)}
-                        className={cn(styles.playerTag, styles.playerRemove)}
-                      >
-                        remove
-                      </button>
-                    )}
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        </section>
+        <PlayerRoster
+          players={gameState.players}
+          currentPlayerId={playerId}
+          onlinePlayerIds={onlinePlayerIds}
+          maxPlayers={8}
+          currentPlayerIsHost={isHost}
+          onRemovePlayer={onRemovePlayer}
+          className={styles.playersPanel}
+          headerClassName={cn(styles.panelHead, arcadeShellStyles.mono)}
+          listClassName={styles.playerList}
+          rowClassName={styles.playerRow}
+          currentPlayerRowClassName={styles.playerRowYou}
+          avatarClassName={styles.playerAvatar}
+          infoClassName={styles.playerInfo}
+          nameClassName={styles.playerName}
+          metaClassName={styles.playerMeta}
+          tagsClassName={styles.playerTags}
+          tagClassName={styles.playerTag}
+          hostTagClassName={styles.playerTagHost}
+          removeButtonClassName={styles.playerRemove}
+        />
 
         <section className={styles.settingsPanel}>
           <div className={styles.settingsRow}>
@@ -952,34 +907,21 @@ function LobbyScreen({
         </section>
       </div>
 
-      <footer className={styles.lobbyFooter}>
-        <span className={cn(styles.waiting, arcadeShellStyles.mono)}>
-          {isHost ? "You're the host" : 'Waiting for host to start'}
-        </span>
-        <div className={styles.entryActions}>
-          <button
-            type="button"
-            onClick={onLeave}
-            className={cn(
-              arcadeShellStyles.button,
-              arcadeShellStyles.buttonGhost,
-              arcadeShellStyles.buttonSmall
-            )}
-          >
-            Leave
-          </button>
-          {isHost && (
-            <button
-              type="button"
-              disabled={gameState.players.length < 2}
-              onClick={onStart}
-              className={arcadeShellStyles.button}
-            >
-              Start game →
-            </button>
-          )}
-        </div>
-      </footer>
+      <LobbyActions
+        isHost={isHost}
+        canStart={gameState.players.length >= 2}
+        onLeave={onLeave}
+        onStart={onStart}
+        className={styles.lobbyFooter}
+        statusClassName={cn(styles.waiting, arcadeShellStyles.mono)}
+        actionsClassName={styles.entryActions}
+        leaveButtonClassName={cn(
+          arcadeShellStyles.button,
+          arcadeShellStyles.buttonGhost,
+          arcadeShellStyles.buttonSmall
+        )}
+        startButtonClassName={arcadeShellStyles.button}
+      />
     </div>
   )
 }
@@ -1129,21 +1071,24 @@ function RoundEndScreen({
         <span className={styles.endWordAccent}>{decodeWord(gameState.word ?? '')}</span>
       </p>
 
-      <div className={styles.resultsTable}>
-        {sortedPlayers.map((player, index) => (
-          <div key={player.id} className={styles.resultRow}>
-            <span className={cn(styles.resultTotal, arcadeShellStyles.mono)}>{index + 1}</span>
-            <div className={styles.resultPlayer}>
-              <ArcadeAvatar index={player.avatar} size={26} />
-              <span>{player.name}</span>
-            </div>
-            <span className={styles.resultDelta}>
-              {gameState.scoreDeltas[player.id] ? `+${gameState.scoreDeltas[player.id]}` : '—'}
-            </span>
-            <span className={styles.resultTotal}>{player.score}</span>
-          </div>
-        ))}
-      </div>
+      <ResultsTable
+        rows={sortedPlayers.map((player, index) => ({
+          id: player.id,
+          rankLabel: index + 1,
+          name: player.name,
+          avatar: player.avatar,
+          secondaryLabel: gameState.scoreDeltas[player.id]
+            ? `+${gameState.scoreDeltas[player.id]}`
+            : '—',
+          totalLabel: player.score,
+        }))}
+        className={styles.resultsTable}
+        rowClassName={styles.resultRow}
+        rankClassName={cn(styles.resultTotal, arcadeShellStyles.mono)}
+        playerClassName={styles.resultPlayer}
+        secondaryClassName={styles.resultDelta}
+        totalClassName={styles.resultTotal}
+      />
 
       <div className={styles.endActions}>
         <button
@@ -1196,24 +1141,24 @@ function FinishedScreen({
         with <span className={styles.endWordAccent}>{winner?.score ?? 0}</span> points
       </p>
 
-      <div className={styles.resultsTable}>
-        {sortedPlayers.map((player, index) => (
-          <div
-            key={player.id}
-            className={cn(styles.resultRow, index === 0 && styles.resultRowWinner)}
-          >
-            <span className={cn(styles.resultTotal, arcadeShellStyles.mono)}>
-              {index === 0 ? '👑' : index + 1}
-            </span>
-            <div className={styles.resultPlayer}>
-              <ArcadeAvatar index={player.avatar} size={26} />
-              <span>{player.name}</span>
-            </div>
-            <span className={styles.resultDelta}>{index === 0 ? 'Winner' : ''}</span>
-            <span className={styles.resultTotal}>{player.score}</span>
-          </div>
-        ))}
-      </div>
+      <ResultsTable
+        rows={sortedPlayers.map((player, index) => ({
+          id: player.id,
+          rankLabel: index === 0 ? '👑' : index + 1,
+          name: player.name,
+          avatar: player.avatar,
+          secondaryLabel: index === 0 ? 'Winner' : '',
+          totalLabel: player.score,
+          isWinner: index === 0,
+        }))}
+        className={styles.resultsTable}
+        rowClassName={styles.resultRow}
+        winnerRowClassName={styles.resultRowWinner}
+        rankClassName={cn(styles.resultTotal, arcadeShellStyles.mono)}
+        playerClassName={styles.resultPlayer}
+        secondaryClassName={styles.resultDelta}
+        totalClassName={styles.resultTotal}
+      />
 
       <div className={styles.endActions}>
         <button


### PR DESCRIPTION
## Summary
- extract reusable multiplayer UI primitives from the Skribbl flow
- replace duplicated room invite, roster, lobby action, avatar picker, results, and resume-session markup
- add focused tests for each shared component

## Test plan
- pnpm lint
- pnpm test -- src/components/multiplayer/AvatarPicker.test.tsx src/components/multiplayer/LobbyActions.test.tsx src/components/multiplayer/PlayerRoster.test.tsx src/components/multiplayer/ResultsTable.test.tsx src/components/multiplayer/ResumeSessionCard.test.tsx src/components/multiplayer/RoomInviteCard.test.tsx