### PR TITLE
docs: refresh README for current app experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # Library Games
 
-A collection of classic and modern browser games built with Next.js.
+Library Games is a polished browser arcade built with Next.js. It mixes classic single-player games with real-time multiplayer party games, all shipped as a static site on GitHub Pages.
 
 Live: https://kkulykk.github.io/library-games
+
+## What’s in the app
+
+- Discover + Library home experience
+  - Discover: featured hero carousel, trending rail, quick plays, and multiplayer spotlight
+  - Library: searchable/filterable catalog with sort controls and poster-grid browsing
+- 18 total titles
+  - 17 live
+  - 11 single-player
+  - 7 online multiplayer
+  - 1 coming soon
+- Real-time multiplayer rooms powered by Supabase
+- Static export deployment via GitHub Pages
 
 ## Games
 
@@ -27,53 +40,69 @@ Live: https://kkulykk.github.io/library-games
 | 🧠 Mindmeld               | Online multiplayer | Live        |
 | ♟️ Chess                  | Online multiplayer | Coming Soon |
 
-Source of truth for metadata and status: `src/data/games.ts`.
+Source of truth for game metadata and status: `src/data/games.ts`.
 
-## Tech Stack
+## Tech stack
 
-- Next.js 16 (App Router, static export via `output: 'export'`)
-- React 19 + TypeScript (strict)
+- Next.js 16 (App Router, static export)
+- React 19
+- TypeScript (strict mode)
 - Tailwind CSS 4
 - Jest 30 + Testing Library
-- Supabase Realtime for online multiplayer rooms
+- Supabase Realtime for multiplayer room sync
 
 ## Development
 
-Prerequisite: pnpm (or `corepack pnpm`)
+Prerequisite: `pnpm`
 
 ```bash
-corepack pnpm install
-corepack pnpm dev        # http://localhost:3000/library-games
+pnpm install
+pnpm dev        # http://localhost:3000/library-games
 ```
 
 ```bash
-corepack pnpm lint           # ESLint + Prettier check
-corepack pnpm lint:fix       # auto-fix lint & formatting
-corepack pnpm test           # run all tests
-corepack pnpm test:watch     # watch mode
-corepack pnpm test:coverage  # coverage report (>=80% required on logic files)
-corepack pnpm build          # static export -> /out
+pnpm lint           # ESLint + Prettier check
+pnpm lint:fix       # auto-fix lint & formatting
+pnpm test           # run all tests
+pnpm test:watch     # watch mode
+pnpm test:coverage  # coverage report (>=80% required on logic files)
+pnpm build          # static export -> /out
 ```
 
 ## Architecture
 
-Each game follows a strict separation:
+Each game follows a strict split between pure logic and UI:
 
 ```text
 src/games/<slug>/
-  logic.ts          # Pure functions — all game state, no React
+  logic.ts          # Pure functions — game state and rules
   logic.test.ts     # Jest unit tests
   <Name>Game.tsx    # 'use client' component — rendering + event wiring only
 ```
 
-Game routes (`src/app/games/<slug>/page.tsx`) are server components that wrap client components in `GameLayout`. All game metadata lives in `src/data/games.ts`.
+Important project structure:
 
-## Adding a Game
+- `src/app/page.tsx` — home route entry
+- `src/components/home/` — Discover + Library home experience
+- `src/data/games.ts` — source of truth for game metadata
+- `src/games/<slug>/` — per-game logic and UI
+- `src/app/games/<slug>/page.tsx` — route wrappers for implemented/playable games
 
-1. Add entry to `src/data/games.ts` (`GameMeta`)
-2. Implement pure logic in `src/games/<slug>/logic.ts`
-3. Write tests in `src/games/<slug>/logic.test.ts`
-4. Build UI in `src/games/<slug>/<Name>Game.tsx` (`'use client'`)
-5. Create route in `src/app/games/<slug>/page.tsx`
+## Online multiplayer
 
-See `CLAUDE.md` for full contributor guidance.
+Online multiplayer games use Supabase as the real-time state bus.
+
+- room state is stored in a single `jsonb` payload
+- clients subscribe to updates with `postgres_changes`
+- shared room orchestration lives in `src/hooks/useGameRoom.ts`, with per-game `use<Name>Room.ts` wrappers
+- gameplay state transitions stay in pure `logic.ts` files
+
+## Adding a game
+
+1. Add the metadata entry in `src/data/games.ts`
+2. Implement pure rules in `src/games/<slug>/logic.ts`
+3. Add tests in `src/games/<slug>/logic.test.ts`
+4. Build the client component in `src/games/<slug>/<Name>Game.tsx`
+5. Create the route in `src/app/games/<slug>/page.tsx`
+
+See `CLAUDE.md` for the fuller contributor guide and project constraints.


### PR DESCRIPTION
## Summary
- rewrite the README intro to reflect the current Discover + Library home experience
- refresh game counts, tech stack, development commands, and architecture notes from the actual codebase
- document the current multiplayer architecture and contributor entry points

## Test plan
- pnpm lint
- independent README accuracy review against the repository
