### PR TITLE
test: add Playwright multiplayer E2E baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
 
 # next.js
 /.next/

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -44,7 +44,7 @@
 
 **Branch:** `feat/playwright-multiplayer-e2e`
 
-**Last updated:** 2026-04-25 07:39 UTC
+**Last updated:** 2026-04-25 08:22 UTC
 
 **Completed:**
 
@@ -58,6 +58,7 @@
 - [x] Task 7 — Added fake Supabase reset endpoint plus Playwright reset helper/fixture.
 - [x] Task 8 — Added shared room-create contract spec covering Skribbl, Uno, Agario, Cards Against Humanity, Codenames, and Mindmeld.
 - [x] Task 9 — Extended shared room contract spec with cross-context join flow assertions across all live multiplayer slugs.
+- [x] Task 10 — Added edge-state room contract coverage (invalid code, started-game join rejection, room-full rejection, leave/session-clear, reload restore path, expired/malformed session handling).
 - [x] Security fix — Sanitized fake Supabase 500 responses so server exception details are logged locally but not returned over HTTP.
 
 **Verification passed:**
@@ -79,7 +80,7 @@
 - Codenames lobby now surfaces unassigned players in the roster so hosts are visible before choosing a team/role.
 - GitHub Advanced Security flagged fake Supabase error responses for information exposure; 500 responses are now generic while details stay in server logs.
 
-**Next:** Task 10 — Error and edge room states.
+**Next:** Task 11 — Uno full turn smoke test.
 
 ---
 

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -40,6 +40,34 @@
 
 ---
 
+## Progress
+
+**Branch:** `feat/playwright-multiplayer-e2e`
+
+**Last updated:** 2026-04-24 15:50 UTC
+
+**Completed:**
+
+- [x] Task 1 — Installed Playwright (`@playwright/test`) and Chromium.
+- [x] Task 2 — Added `playwright.config.ts` for Chromium, `/library-games` base URL, dev server startup, CI retries, and trace/screenshot/video artifacts.
+- [x] Task 3 — Added `pnpm e2e`, `pnpm e2e:ui`, `pnpm e2e:debug`, and `pnpm e2e:ci` scripts.
+- [x] Task 4 — Added stable `data-testid` selectors for shared multiplayer create/join/lobby flows across Uno, Skribbl, Agario, Cards Against Humanity, Codenames, and Mindmeld.
+
+**Verification passed:**
+
+- `pnpm lint`
+- `pnpm e2e --list`
+
+**Notes:**
+
+- Added `e2e/playwright-setup.spec.ts` as a skipped placeholder so Playwright config/list commands succeed before real E2E specs are added.
+- Added `/playwright-report/` and `/test-results/` to `.gitignore`.
+- Mindmeld currently exposes `data-testid="room-code"` on text formatted as `Room ABCD`; future helpers should parse the 4-character code or this can be normalized in Task 5.
+
+**Next:** Task 5 — Create reusable E2E helpers.
+
+---
+
 ## Stage 1 — Playwright Baseline
 
 ### Task 1: Install Playwright
@@ -102,7 +130,7 @@
 
 **Verification:**
 
-- Run: `pnpm e2e -- --list`
+- Run: `pnpm e2e --list`
 - Expected: Playwright lists tests once tests are added; no config crash.
 
 ---

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -44,7 +44,7 @@
 
 **Branch:** `feat/playwright-multiplayer-e2e`
 
-**Last updated:** 2026-04-24 15:50 UTC
+**Last updated:** 2026-04-24 16:38 UTC
 
 **Completed:**
 
@@ -52,19 +52,28 @@
 - [x] Task 2 — Added `playwright.config.ts` for Chromium, `/library-games` base URL, dev server startup, CI retries, and trace/screenshot/video artifacts.
 - [x] Task 3 — Added `pnpm e2e`, `pnpm e2e:ui`, `pnpm e2e:debug`, and `pnpm e2e:ci` scripts.
 - [x] Task 4 — Added stable `data-testid` selectors for shared multiplayer create/join/lobby flows across Uno, Skribbl, Agario, Cards Against Humanity, Codenames, and Mindmeld.
+- [x] CI fix — Updated Jest config so Jest ignores Playwright E2E specs under `e2e/`.
+- [x] Task 5 — Added reusable E2E helper modules for player contexts, game navigation, room create/join, roster assertions, room-code parsing, and start-game interactions.
+- [x] Task 6 — Added injectable Supabase boundary and browser-side fake Supabase client backed by a local HTTP server.
+- [x] Task 7 — Added fake Supabase reset endpoint plus Playwright reset helper/fixture.
 
 **Verification passed:**
 
 - `pnpm lint`
+- `pnpm test:coverage`
 - `pnpm e2e --list`
+- `pnpm build`
 
 **Notes:**
 
 - Added `e2e/playwright-setup.spec.ts` as a skipped placeholder so Playwright config/list commands succeed before real E2E specs are added.
 - Added `/playwright-report/` and `/test-results/` to `.gitignore`.
 - Mindmeld currently exposes `data-testid="room-code"` on text formatted as `Room ABCD`; future helpers should parse the 4-character code or this can be normalized in Task 5.
+- Root cause of the failed CI run was Jest collecting `e2e/playwright-setup.spec.ts`; `jest.config.js` now ignores `<rootDir>/e2e/`.
+- ESLint now ignores generated coverage and Playwright artifact directories.
+- Playwright now starts both the fake Supabase server and the Next dev server for E2E runs.
 
-**Next:** Task 5 — Create reusable E2E helpers.
+**Next:** Task 8 — Create room contract spec.
 
 ---
 

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -44,7 +44,7 @@
 
 **Branch:** `feat/playwright-multiplayer-e2e`
 
-**Last updated:** 2026-04-24 16:38 UTC
+**Last updated:** 2026-04-24 20:10 UTC
 
 **Completed:**
 
@@ -56,12 +56,14 @@
 - [x] Task 5 — Added reusable E2E helper modules for player contexts, game navigation, room create/join, roster assertions, room-code parsing, and start-game interactions.
 - [x] Task 6 — Added injectable Supabase boundary and browser-side fake Supabase client backed by a local HTTP server.
 - [x] Task 7 — Added fake Supabase reset endpoint plus Playwright reset helper/fixture.
+- [x] Task 8 — Added shared room-create contract spec covering Skribbl, Uno, Agario, Cards Against Humanity, Codenames, and Mindmeld.
 
 **Verification passed:**
 
 - `pnpm lint`
 - `pnpm test:coverage`
 - `pnpm e2e --list`
+- `pnpm e2e -- e2e/multiplayer-room-contract.spec.ts`
 - `pnpm build`
 
 **Notes:**
@@ -72,8 +74,9 @@
 - Root cause of the failed CI run was Jest collecting `e2e/playwright-setup.spec.ts`; `jest.config.js` now ignores `<rootDir>/e2e/`.
 - ESLint now ignores generated coverage and Playwright artifact directories.
 - Playwright now starts both the fake Supabase server and the Next dev server for E2E runs.
+- Codenames lobby now surfaces unassigned players in the roster so hosts are visible before choosing a team/role.
 
-**Next:** Task 8 — Create room contract spec.
+**Next:** Task 9 — Join room contract spec.
 
 ---
 

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -44,7 +44,7 @@
 
 **Branch:** `feat/playwright-multiplayer-e2e`
 
-**Last updated:** 2026-04-24 20:10 UTC
+**Last updated:** 2026-04-24 21:13 UTC
 
 **Completed:**
 
@@ -57,6 +57,7 @@
 - [x] Task 6 — Added injectable Supabase boundary and browser-side fake Supabase client backed by a local HTTP server.
 - [x] Task 7 — Added fake Supabase reset endpoint plus Playwright reset helper/fixture.
 - [x] Task 8 — Added shared room-create contract spec covering Skribbl, Uno, Agario, Cards Against Humanity, Codenames, and Mindmeld.
+- [x] Security fix — Sanitized fake Supabase 500 responses so server exception details are logged locally but not returned over HTTP.
 
 **Verification passed:**
 
@@ -75,6 +76,7 @@
 - ESLint now ignores generated coverage and Playwright artifact directories.
 - Playwright now starts both the fake Supabase server and the Next dev server for E2E runs.
 - Codenames lobby now surfaces unassigned players in the roster so hosts are visible before choosing a team/role.
+- GitHub Advanced Security flagged fake Supabase error responses for information exposure; 500 responses are now generic while details stay in server logs.
 
 **Next:** Task 9 — Join room contract spec.
 

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -44,7 +44,7 @@
 
 **Branch:** `feat/playwright-multiplayer-e2e`
 
-**Last updated:** 2026-04-24 21:13 UTC
+**Last updated:** 2026-04-25 07:39 UTC
 
 **Completed:**
 
@@ -57,6 +57,7 @@
 - [x] Task 6 — Added injectable Supabase boundary and browser-side fake Supabase client backed by a local HTTP server.
 - [x] Task 7 — Added fake Supabase reset endpoint plus Playwright reset helper/fixture.
 - [x] Task 8 — Added shared room-create contract spec covering Skribbl, Uno, Agario, Cards Against Humanity, Codenames, and Mindmeld.
+- [x] Task 9 — Extended shared room contract spec with cross-context join flow assertions across all live multiplayer slugs.
 - [x] Security fix — Sanitized fake Supabase 500 responses so server exception details are logged locally but not returned over HTTP.
 
 **Verification passed:**
@@ -78,7 +79,7 @@
 - Codenames lobby now surfaces unassigned players in the roster so hosts are visible before choosing a team/role.
 - GitHub Advanced Security flagged fake Supabase error responses for information exposure; 500 responses are now generic while details stay in server logs.
 
-**Next:** Task 9 — Join room contract spec.
+**Next:** Task 10 — Error and edge room states.
 
 ---
 

--- a/docs/plans/2026-04-25-task10-edge-room-states-implementation.md
+++ b/docs/plans/2026-04-25-task10-edge-room-states-implementation.md
@@ -1,0 +1,38 @@
+# Task 10 — Error and Edge Room States Implementation Plan
+
+> For Hermes: execute with strict TDD (RED -> GREEN -> REFACTOR) and keep this file updated.
+
+Goal: Implement Stage 4 Task 10 from `docs/plans/2026-04-24-playwright-e2e-multiplayer.md` by extending room-contract E2E tests to cover deterministic unhappy-path and session edge-state behavior.
+
+Scope:
+
+- Add edge-state tests in `e2e/multiplayer-room-contract.spec.ts` for:
+  - invalid room code error
+  - joining started game error
+  - full room error (where enforceable)
+  - leave room returns to entry + session clear behavior
+  - reload restores valid session
+  - expired/missing session ignored
+- Use fake Supabase server mode and shared helpers.
+
+Execution steps:
+
+- [x] 1. Inspect existing room-state UX/messages and session storage behavior.
+- [x] 2. RED: add failing edge-state tests.
+- [x] 3. Run targeted spec and capture failure output.
+- [x] 4. GREEN: implement minimal helper/app changes to satisfy tests.
+- [x] 5. Re-run targeted E2E spec until green.
+- [x] 6. Run lint.
+- [x] 7. Update main multiplayer plan progress section for Task 10.
+
+Progress log:
+
+- Created task plan.
+- Inspected `useGameRoom.ts` and multiplayer entry/lobby UX to confirm canonical error messages and session semantics.
+- RED: added edge-state tests for invalid code, started-game join rejection, room-full rejection, leave/session clear, reload restore, and expired/malformed session handling.
+- First RED run failed on negative-path assumptions and on how-to gate handling after reload/navigation.
+- GREEN: updated test flows to use explicit negative-join form submissions, handle `play-game-button` gate when present, and optimize room-full setup via fake Supabase query seeding.
+- Added `fakeSupabaseQuery(...)` helper in `e2e/helpers/fakeSupabase.ts` for deterministic fake-backend room setup in E2E.
+- Verified green: `pnpm e2e -- e2e/multiplayer-room-contract.spec.ts` (18/18 passing).
+- Verified quality: `pnpm lint` passing.
+- Updated main multiplayer E2E plan: Task 10 marked complete and next moved to Task 11.

--- a/docs/plans/2026-04-25-task9-join-room-contract-implementation.md
+++ b/docs/plans/2026-04-25-task9-join-room-contract-implementation.md
@@ -1,0 +1,29 @@
+# Task 9 — Join Room Contract Spec Implementation Plan
+
+> For Hermes: execute with strict TDD (RED -> GREEN -> REFACTOR) and keep this file updated.
+
+Goal: Implement Stage 4 Task 9 from `docs/plans/2026-04-24-playwright-e2e-multiplayer.md` by extending `e2e/multiplayer-room-contract.spec.ts` to validate cross-context join flow for all live multiplayer slugs.
+
+Scope:
+
+- Add join-room contract tests for `skribbl`, `uno`, `agario`, `cards-against-humanity`, `codenames`, `mindmeld`.
+- Use existing helper primitives where possible.
+- Keep deterministic fake Supabase flow.
+
+Execution steps:
+
+- [x] 1. RED: add failing join-room contract test(s) in `e2e/multiplayer-room-contract.spec.ts`.
+- [x] 2. Run targeted spec and capture failure output.
+- [x] 3. GREEN: implement minimal changes (helpers/spec/UI test IDs if needed) to make tests pass.
+- [x] 4. Run targeted E2E spec to verify green.
+- [x] 5. Run lint and fix formatting issues.
+- [x] 6. Update main plan progress section to mark Task 9 complete and set next task.
+
+Progress log:
+
+- Created task plan.
+- RED: Added cross-context join-room contract test for each live multiplayer slug. Initial run failed on Uno join flow (guest stuck before join due rules gate).
+- GREEN: Updated `joinRoom(...)` helper to click `play-game-button` when present, matching create flow behavior.
+- Verified green: `pnpm e2e -- e2e/multiplayer-room-contract.spec.ts` (12/12 passing).
+- Verified quality: `pnpm lint` passing after formatting this plan file.
+- Updated main multiplayer E2E plan progress: Task 9 marked complete; next set to Task 10.

--- a/e2e/fake-supabase/server.mjs
+++ b/e2e/fake-supabase/server.mjs
@@ -1,0 +1,233 @@
+import http from 'node:http'
+
+const host = process.env.E2E_FAKE_SUPABASE_HOST ?? '127.0.0.1'
+const port = Number(process.env.E2E_FAKE_SUPABASE_PORT ?? '54321')
+
+let state = createState()
+
+function createState() {
+  return {
+    tables: new Map(),
+    events: [],
+    nextEventId: 1,
+    presence: new Map(),
+  }
+}
+
+function reset() {
+  state = createState()
+}
+
+function tableRows(table) {
+  let rows = state.tables.get(table)
+  if (!rows) {
+    rows = []
+    state.tables.set(table, rows)
+  }
+  return rows
+}
+
+function emit(event) {
+  state.events.push({ id: state.nextEventId++, ...event })
+  if (state.events.length > 1000) state.events.splice(0, state.events.length - 1000)
+}
+
+function selectedRow(row, columns) {
+  if (!columns || columns === '*') return { ...row }
+  const names = columns
+    .split(',')
+    .map((column) => column.trim())
+    .filter(Boolean)
+
+  return Object.fromEntries(names.map((name) => [name, row[name]]))
+}
+
+function matches(row, filters) {
+  return filters.every(({ column, value }) => row[column] === value)
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = ''
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      data += chunk
+    })
+    req.on('end', () => {
+      if (!data) {
+        resolve({})
+        return
+      }
+
+      try {
+        resolve(JSON.parse(data))
+      } catch (error) {
+        reject(error)
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res, status, body) {
+  res.writeHead(status, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET,POST,OPTIONS',
+    'access-control-allow-headers': 'content-type',
+    'content-type': 'application/json',
+  })
+  res.end(JSON.stringify(body))
+}
+
+function presenceState(channel) {
+  const members = state.presence.get(channel) ?? new Map()
+  const grouped = {}
+
+  for (const [clientId, payload] of members.entries()) {
+    grouped[clientId] = [{ ...payload }]
+  }
+
+  return grouped
+}
+
+async function handleQuery(req, res) {
+  const body = await readBody(req)
+  const { op, table, values, filters = [], columns } = body
+  const rows = tableRows(table)
+
+  if (op === 'insert') {
+    const inputRows = Array.isArray(values) ? values : [values]
+    const inserted = inputRows.map((value) => ({ version: 1, ...value }))
+    rows.push(...inserted)
+    sendJson(res, 200, { data: inserted.map((row) => selectedRow(row, columns)), error: null })
+    return
+  }
+
+  if (op === 'select') {
+    const found = rows
+      .filter((row) => matches(row, filters))
+      .map((row) => selectedRow(row, columns))
+    if (body.single) {
+      sendJson(res, 200, {
+        data: found[0] ?? null,
+        error: found[0] ? null : { message: 'No rows found' },
+      })
+      return
+    }
+
+    sendJson(res, 200, { data: found, error: null })
+    return
+  }
+
+  if (op === 'update') {
+    const updated = []
+    for (let index = 0; index < rows.length; index++) {
+      const row = rows[index]
+      if (!matches(row, filters)) continue
+
+      const next = { ...row, ...values }
+      rows[index] = next
+      updated.push(next)
+      emit({ type: 'postgres_changes', table, old: row, new: next })
+    }
+
+    sendJson(res, 200, { data: updated.map((row) => selectedRow(row, columns)), error: null })
+    return
+  }
+
+  sendJson(res, 400, { data: null, error: { message: `Unsupported op: ${op}` } })
+}
+
+async function handleEvents(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`)
+  const since = Number(url.searchParams.get('since') ?? '0')
+  sendJson(res, 200, { events: state.events.filter((event) => event.id > since) })
+}
+
+async function handleBroadcast(req, res) {
+  const body = await readBody(req)
+  emit({ type: 'broadcast', channel: body.channel, event: body.event, payload: body.payload })
+  sendJson(res, 200, { ok: true })
+}
+
+async function handleTrack(req, res) {
+  const body = await readBody(req)
+  let members = state.presence.get(body.channel)
+  if (!members) {
+    members = new Map()
+    state.presence.set(body.channel, members)
+  }
+  members.set(body.clientId, body.payload ?? {})
+  emit({ type: 'presence', channel: body.channel, state: presenceState(body.channel) })
+  sendJson(res, 200, { ok: true, state: presenceState(body.channel) })
+}
+
+async function handleUntrack(req, res) {
+  const body = await readBody(req)
+  const members = state.presence.get(body.channel)
+  if (members) {
+    members.delete(body.clientId)
+    emit({ type: 'presence', channel: body.channel, state: presenceState(body.channel) })
+  }
+  sendJson(res, 200, { ok: true })
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === 'OPTIONS') {
+      sendJson(res, 204, {})
+      return
+    }
+
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`)
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      sendJson(res, 200, { ok: true })
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/reset') {
+      reset()
+      sendJson(res, 200, { ok: true })
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/query') {
+      await handleQuery(req, res)
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/events') {
+      await handleEvents(req, res)
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/broadcast') {
+      await handleBroadcast(req, res)
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/presence/track') {
+      await handleTrack(req, res)
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/presence/untrack') {
+      await handleUntrack(req, res)
+      return
+    }
+
+    sendJson(res, 404, { error: { message: 'Not found' } })
+  } catch (error) {
+    sendJson(res, 500, {
+      error: { message: error instanceof Error ? error.message : String(error) },
+    })
+  }
+})
+
+server.listen(port, host, () => {
+  console.log(`Fake Supabase server listening on http://${host}:${port}`)
+})
+
+process.on('SIGTERM', () => server.close())
+process.on('SIGINT', () => server.close())

--- a/e2e/fake-supabase/server.mjs
+++ b/e2e/fake-supabase/server.mjs
@@ -219,8 +219,9 @@ const server = http.createServer(async (req, res) => {
 
     sendJson(res, 404, { error: { message: 'Not found' } })
   } catch (error) {
+    console.error('Fake Supabase request failed', error)
     sendJson(res, 500, {
-      error: { message: error instanceof Error ? error.message : String(error) },
+      error: { message: 'Internal fake Supabase server error' },
     })
   }
 })

--- a/e2e/helpers/assertions.ts
+++ b/e2e/helpers/assertions.ts
@@ -1,0 +1,58 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+const ROOM_CODE_PATTERN = /[A-Z0-9]{4}/
+
+export function playerNameInput(page: Page): Locator {
+  return page.getByTestId('player-name-input')
+}
+
+export function roomCodeInput(page: Page): Locator {
+  return page.getByTestId('room-code-input')
+}
+
+export function roomCodeDisplay(page: Page): Locator {
+  return page.getByTestId('room-code')
+}
+
+export function playerRoster(page: Page): Locator {
+  return page.getByTestId('player-roster')
+}
+
+export async function readRoomCode(page: Page): Promise<string> {
+  const text = (await roomCodeDisplay(page).innerText()).trim()
+  const match = text.match(ROOM_CODE_PATTERN)
+
+  if (!match) {
+    throw new Error(`Could not find a 4-character room code in: ${text}`)
+  }
+
+  return match[0]
+}
+
+export async function createRoom(page: Page, playerName: string): Promise<string> {
+  await page.getByTestId('create-room-button').first().click()
+  await playerNameInput(page).fill(playerName)
+  await page.getByTestId('create-room-button').last().click()
+  await expect(roomCodeDisplay(page)).toBeVisible()
+
+  return readRoomCode(page)
+}
+
+export async function joinRoom(page: Page, roomCode: string, playerName: string): Promise<void> {
+  await page.getByTestId('join-room-button').first().click()
+  await playerNameInput(page).fill(playerName)
+  await roomCodeInput(page).fill(roomCode)
+  await page.getByTestId('join-room-button').last().click()
+  await expect(roomCodeDisplay(page)).toBeVisible()
+}
+
+export async function expectPlayerVisible(page: Page, playerName: string): Promise<void> {
+  await expect(playerRoster(page)).toContainText(playerName)
+}
+
+export async function startGame(page: Page): Promise<void> {
+  const startButton = page.getByTestId('start-game-button')
+  await expect(startButton).toBeVisible()
+  await startButton.click()
+  await expect(startButton).toBeHidden()
+}

--- a/e2e/helpers/assertions.ts
+++ b/e2e/helpers/assertions.ts
@@ -18,6 +18,16 @@ export function playerRoster(page: Page): Locator {
   return page.getByTestId('player-roster')
 }
 
+export async function readInviteLink(page: Page): Promise<string> {
+  const inviteLink = await page.getByTestId('invite-link').getAttribute('data-invite-link')
+
+  if (!inviteLink) {
+    throw new Error('Could not find invite link data attribute')
+  }
+
+  return inviteLink
+}
+
 export async function readRoomCode(page: Page): Promise<string> {
   const text = (await roomCodeDisplay(page).innerText()).trim()
   const match = text.match(ROOM_CODE_PATTERN)
@@ -29,20 +39,52 @@ export async function readRoomCode(page: Page): Promise<string> {
   return match[0]
 }
 
+async function clickFirstVisible(locator: Locator): Promise<boolean> {
+  const count = await locator.count()
+
+  for (let index = 0; index < count; index += 1) {
+    const candidate = locator.nth(index)
+
+    if (await candidate.isVisible()) {
+      await candidate.click()
+      return true
+    }
+  }
+
+  return false
+}
+
+async function clickCreateRoom(page: Page): Promise<void> {
+  if (await clickFirstVisible(page.getByTestId('create-room-button'))) {
+    return
+  }
+
+  await page
+    .getByRole('button', { name: /create room/i })
+    .first()
+    .click({ force: true })
+}
+
 export async function createRoom(page: Page, playerName: string): Promise<string> {
-  await page.getByTestId('create-room-button').first().click()
+  const playButton = page.getByTestId('play-game-button')
+
+  if (await playButton.isVisible().catch(() => false)) {
+    await playButton.click()
+  }
+
+  await clickCreateRoom(page)
   await playerNameInput(page).fill(playerName)
-  await page.getByTestId('create-room-button').last().click()
+  await clickCreateRoom(page)
   await expect(roomCodeDisplay(page)).toBeVisible()
 
   return readRoomCode(page)
 }
 
 export async function joinRoom(page: Page, roomCode: string, playerName: string): Promise<void> {
-  await page.getByTestId('join-room-button').first().click()
+  await page.getByTestId('join-room-button').filter({ visible: true }).first().click()
   await playerNameInput(page).fill(playerName)
   await roomCodeInput(page).fill(roomCode)
-  await page.getByTestId('join-room-button').last().click()
+  await page.getByTestId('join-room-button').filter({ visible: true }).last().click()
   await expect(roomCodeDisplay(page)).toBeVisible()
 }
 

--- a/e2e/helpers/assertions.ts
+++ b/e2e/helpers/assertions.ts
@@ -81,6 +81,12 @@ export async function createRoom(page: Page, playerName: string): Promise<string
 }
 
 export async function joinRoom(page: Page, roomCode: string, playerName: string): Promise<void> {
+  const playButton = page.getByTestId('play-game-button')
+
+  if (await playButton.isVisible().catch(() => false)) {
+    await playButton.click()
+  }
+
   await page.getByTestId('join-room-button').filter({ visible: true }).first().click()
   await playerNameInput(page).fill(playerName)
   await roomCodeInput(page).fill(roomCode)

--- a/e2e/helpers/fakeSupabase.ts
+++ b/e2e/helpers/fakeSupabase.ts
@@ -2,11 +2,41 @@ import { expect, test as base } from '@playwright/test'
 
 const fakeSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://127.0.0.1:54321'
 
+type FakeSupabaseQueryPayload = {
+  op: 'select' | 'update' | 'insert'
+  table: string
+  values?: unknown
+  filters?: Array<{ column: string; value: unknown }>
+  columns?: string
+  single?: boolean
+}
+
+type FakeSupabaseQueryResult<T = unknown> = {
+  data: T | null
+  error: { message: string } | null
+}
+
 export async function resetFakeSupabase(): Promise<void> {
   const response = await fetch(`${fakeSupabaseUrl}/reset`, { method: 'POST' })
   if (!response.ok) {
     throw new Error(`Failed to reset fake Supabase: ${response.status} ${response.statusText}`)
   }
+}
+
+export async function fakeSupabaseQuery<T = unknown>(
+  payload: FakeSupabaseQueryPayload
+): Promise<FakeSupabaseQueryResult<T>> {
+  const response = await fetch(`${fakeSupabaseUrl}/query`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Fake Supabase /query failed: ${response.status} ${response.statusText}`)
+  }
+
+  return (await response.json()) as FakeSupabaseQueryResult<T>
 }
 
 export const test = base.extend({

--- a/e2e/helpers/fakeSupabase.ts
+++ b/e2e/helpers/fakeSupabase.ts
@@ -1,0 +1,19 @@
+import { expect, test as base } from '@playwright/test'
+
+const fakeSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://127.0.0.1:54321'
+
+export async function resetFakeSupabase(): Promise<void> {
+  const response = await fetch(`${fakeSupabaseUrl}/reset`, { method: 'POST' })
+  if (!response.ok) {
+    throw new Error(`Failed to reset fake Supabase: ${response.status} ${response.statusText}`)
+  }
+}
+
+export const test = base.extend({
+  page: async ({ page }, runTest) => {
+    await resetFakeSupabase()
+    await runTest(page)
+  },
+})
+
+export { expect }

--- a/e2e/helpers/navigation.ts
+++ b/e2e/helpers/navigation.ts
@@ -1,0 +1,5 @@
+import type { Page } from '@playwright/test'
+
+export async function gotoGame(page: Page, slug: string): Promise<void> {
+  await page.goto(`/games/${slug}`)
+}

--- a/e2e/helpers/navigation.ts
+++ b/e2e/helpers/navigation.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test'
 
 export async function gotoGame(page: Page, slug: string): Promise<void> {
-  await page.goto(`/games/${slug}`)
+  await page.goto(`/library-games/games/${slug}`)
 }

--- a/e2e/helpers/players.ts
+++ b/e2e/helpers/players.ts
@@ -1,0 +1,18 @@
+import type { Browser, BrowserContext, Page } from '@playwright/test'
+
+export interface TestPlayer {
+  name: string
+  context: BrowserContext
+  page: Page
+}
+
+export async function createPlayer(browser: Browser, name: string): Promise<TestPlayer> {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  return { name, context, page }
+}
+
+export async function closePlayers(players: TestPlayer[]): Promise<void> {
+  await Promise.all(players.map((player) => player.context.close()))
+}

--- a/e2e/multiplayer-room-contract.spec.ts
+++ b/e2e/multiplayer-room-contract.spec.ts
@@ -1,0 +1,31 @@
+import { createRoom, expectPlayerVisible, readInviteLink } from './helpers/assertions'
+import { test, expect } from './helpers/fakeSupabase'
+import { gotoGame } from './helpers/navigation'
+
+const multiplayerGames = [
+  'skribbl',
+  'uno',
+  'agario',
+  'cards-against-humanity',
+  'codenames',
+  'mindmeld',
+] as const
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('multiplayer room contract', () => {
+  for (const slug of multiplayerGames) {
+    test(`${slug} can create a room with host roster and invite link`, async ({ page }) => {
+      await gotoGame(page, slug)
+
+      const hostName = `Host ${slug.slice(0, 6)}`
+      const roomCode = await createRoom(page, hostName)
+
+      expect(roomCode).toMatch(/^[A-Z0-9]{4}$/)
+      await expectPlayerVisible(page, hostName)
+
+      const inviteLink = await readInviteLink(page)
+      expect(inviteLink).toContain(`/library-games/games/${slug}?code=${roomCode}`)
+    })
+  }
+})

--- a/e2e/multiplayer-room-contract.spec.ts
+++ b/e2e/multiplayer-room-contract.spec.ts
@@ -1,6 +1,7 @@
-import { createRoom, expectPlayerVisible, readInviteLink } from './helpers/assertions'
+import { createRoom, expectPlayerVisible, joinRoom, readInviteLink } from './helpers/assertions'
 import { test, expect } from './helpers/fakeSupabase'
 import { gotoGame } from './helpers/navigation'
+import { closePlayers, createPlayer } from './helpers/players'
 
 const multiplayerGames = [
   'skribbl',
@@ -26,6 +27,26 @@ test.describe('multiplayer room contract', () => {
 
       const inviteLink = await readInviteLink(page)
       expect(inviteLink).toContain(`/library-games/games/${slug}?code=${roomCode}`)
+    })
+
+    test(`${slug} allows a second player to join and sync roster`, async ({ page, browser }) => {
+      const host = { page, name: `Host ${slug.slice(0, 6)}` }
+      const guest = await createPlayer(browser, `Guest ${slug.slice(0, 6)}`)
+
+      try {
+        await gotoGame(host.page, slug)
+        const roomCode = await createRoom(host.page, host.name)
+
+        await gotoGame(guest.page, slug)
+        await joinRoom(guest.page, roomCode, guest.name)
+
+        await expectPlayerVisible(host.page, host.name)
+        await expectPlayerVisible(host.page, guest.name)
+        await expectPlayerVisible(guest.page, host.name)
+        await expectPlayerVisible(guest.page, guest.name)
+      } finally {
+        await closePlayers([guest])
+      }
     })
   }
 })

--- a/e2e/multiplayer-room-contract.spec.ts
+++ b/e2e/multiplayer-room-contract.spec.ts
@@ -1,5 +1,11 @@
-import { createRoom, expectPlayerVisible, joinRoom, readInviteLink } from './helpers/assertions'
-import { test, expect } from './helpers/fakeSupabase'
+import {
+  createRoom,
+  expectPlayerVisible,
+  joinRoom,
+  readInviteLink,
+  startGame,
+} from './helpers/assertions'
+import { fakeSupabaseQuery, test, expect } from './helpers/fakeSupabase'
 import { gotoGame } from './helpers/navigation'
 import { closePlayers, createPlayer } from './helpers/players'
 
@@ -49,4 +55,207 @@ test.describe('multiplayer room contract', () => {
       }
     })
   }
+})
+
+test.describe('multiplayer room edge states', () => {
+  test('uno shows error for invalid room code', async ({ page }) => {
+    await gotoGame(page, 'uno')
+
+    const playButton = page.getByTestId('play-game-button')
+    if (await playButton.isVisible().catch(() => false)) {
+      await playButton.click()
+    }
+
+    await page.getByTestId('join-room-button').filter({ visible: true }).first().click()
+    await page.getByTestId('player-name-input').fill('Late Guest')
+    await page.getByTestId('room-code-input').fill('NOPE')
+    await page.getByTestId('join-room-button').filter({ visible: true }).last().click()
+
+    await expect(page.getByTestId('room-error')).toContainText(
+      'Room not found. Check the code and try again.'
+    )
+  })
+
+  test('uno blocks joining after game starts', async ({ page, browser }) => {
+    const host = { page, name: 'Host Uno' }
+    const guest = await createPlayer(browser, 'Guest Uno')
+    const lateJoiner = await createPlayer(browser, 'Late Uno')
+
+    try {
+      await gotoGame(host.page, 'uno')
+      const roomCode = await createRoom(host.page, host.name)
+
+      await gotoGame(guest.page, 'uno')
+      await joinRoom(guest.page, roomCode, guest.name)
+
+      await startGame(host.page)
+
+      await gotoGame(lateJoiner.page, 'uno')
+      const playButton = lateJoiner.page.getByTestId('play-game-button')
+      if (await playButton.isVisible().catch(() => false)) {
+        await playButton.click()
+      }
+
+      await lateJoiner.page
+        .getByTestId('join-room-button')
+        .filter({ visible: true })
+        .first()
+        .click()
+      await lateJoiner.page.getByTestId('player-name-input').fill(lateJoiner.name)
+      await lateJoiner.page.getByTestId('room-code-input').fill(roomCode)
+      await lateJoiner.page.getByTestId('join-room-button').filter({ visible: true }).last().click()
+
+      await expect(lateJoiner.page.getByTestId('room-error')).toContainText(
+        'This game has already started.'
+      )
+    } finally {
+      await closePlayers([guest, lateJoiner])
+    }
+  })
+
+  test('agario blocks join when room is full', async ({ page, browser }) => {
+    const host = { page, name: 'Host Agario' }
+    const overflow = await createPlayer(browser, 'Overflow')
+
+    try {
+      await gotoGame(host.page, 'agario')
+      const roomCode = await createRoom(host.page, host.name)
+
+      const selected = await fakeSupabaseQuery<{
+        state: {
+          phase: string
+          hostId: string
+          players: Array<{ id: string; name: string; isHost: boolean; color: string }>
+        }
+        version: number
+      }>({
+        op: 'select',
+        table: 'agario_rooms',
+        columns: 'state,version',
+        filters: [{ column: 'code', value: roomCode }],
+        single: true,
+      })
+
+      if (!selected.data || selected.error) {
+        throw new Error(
+          `Failed to load agario room for full-room setup: ${selected.error?.message}`
+        )
+      }
+
+      const current = selected.data
+      const players = [
+        ...current.state.players,
+        ...Array.from({ length: 7 }, (_, index) => ({
+          id: `seed-${index + 1}`,
+          name: `Seed ${index + 1}`,
+          isHost: false,
+          color: `#${(index + 1).toString(16).padStart(6, '0').slice(0, 6)}`,
+        })),
+      ].slice(0, 8)
+
+      const updated = await fakeSupabaseQuery({
+        op: 'update',
+        table: 'agario_rooms',
+        values: {
+          state: { ...current.state, players },
+          version: current.version + 1,
+        },
+        filters: [{ column: 'code', value: roomCode }],
+      })
+
+      if (updated.error) {
+        throw new Error(`Failed to seed full agario room: ${updated.error.message}`)
+      }
+
+      await gotoGame(overflow.page, 'agario')
+      const playButton = overflow.page.getByTestId('play-game-button')
+      if (await playButton.isVisible().catch(() => false)) {
+        await playButton.click()
+      }
+
+      await overflow.page.getByTestId('join-room-button').filter({ visible: true }).first().click()
+      await overflow.page.getByTestId('player-name-input').fill(overflow.name)
+      await overflow.page.getByTestId('room-code-input').fill(roomCode)
+      await overflow.page.getByTestId('join-room-button').filter({ visible: true }).last().click()
+
+      await expect(overflow.page.getByTestId('room-error')).toContainText('Room is full.')
+    } finally {
+      await closePlayers([overflow])
+    }
+  })
+
+  test('uno leave room returns to entry and clears session', async ({ page }) => {
+    await gotoGame(page, 'uno')
+    const roomCode = await createRoom(page, 'Host Leave')
+
+    await expect(page.getByTestId('room-code')).toContainText(roomCode)
+    await page.getByTestId('leave-room-button').click()
+
+    await expect(
+      page.getByTestId('create-room-button').filter({ visible: true }).first()
+    ).toBeVisible()
+
+    const sessionValue = await page.evaluate(() => localStorage.getItem('uno_session'))
+    expect(sessionValue).toBeNull()
+  })
+
+  test('uno reload offers restore and reconnects to active session', async ({ page }) => {
+    await gotoGame(page, 'uno')
+    const roomCode = await createRoom(page, 'Host Restore')
+
+    await page.reload()
+
+    const playButton = page.getByTestId('play-game-button')
+    if (await playButton.isVisible().catch(() => false)) {
+      await playButton.click()
+    }
+
+    const roomCodeLocator = page.getByTestId('room-code')
+    if ((await roomCodeLocator.count()) === 0) {
+      await page.getByRole('button', { name: /resume/i }).click()
+    }
+
+    await expect(page.getByTestId('room-code')).toContainText(roomCode)
+  })
+
+  test('uno ignores expired or malformed saved session', async ({ page }) => {
+    await page.goto('/library-games')
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'uno_session',
+        JSON.stringify({
+          roomCode: 'AB12',
+          playerId: 'expired-player',
+          playerName: 'Expired',
+          ts: Date.now() - 25 * 60 * 60 * 1000,
+        })
+      )
+    })
+
+    await gotoGame(page, 'uno')
+
+    const playButton = page.getByTestId('play-game-button')
+    if (await playButton.isVisible().catch(() => false)) {
+      await playButton.click()
+    }
+
+    await expect(
+      page.getByTestId('create-room-button').filter({ visible: true }).first()
+    ).toBeVisible()
+    await expect(page.getByTestId('room-code')).toHaveCount(0)
+
+    await page.evaluate(() => {
+      localStorage.setItem('uno_session', '{bad-json')
+    })
+    await page.reload()
+
+    if (await playButton.isVisible().catch(() => false)) {
+      await playButton.click()
+    }
+
+    await expect(
+      page.getByTestId('create-room-button').filter({ visible: true }).first()
+    ).toBeVisible()
+    await expect(page.getByTestId('room-code')).toHaveCount(0)
+  })
 })

--- a/e2e/playwright-setup.spec.ts
+++ b/e2e/playwright-setup.spec.ts
@@ -1,0 +1,3 @@
+import { test } from '@playwright/test'
+
+test.skip('Playwright is configured; real E2E coverage is added in staged specs', async () => {})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,15 @@ import eslintConfigPrettier from 'eslint-config-prettier'
 import tseslint from 'typescript-eslint'
 
 const eslintConfig = defineConfig([
-  globalIgnores(['next-env.d.ts', '.next/**', 'out/**', 'node_modules/**']),
+  globalIgnores([
+    'next-env.d.ts',
+    '.next/**',
+    'out/**',
+    'node_modules/**',
+    'coverage/**',
+    'playwright-report/**',
+    'test-results/**',
+  ]),
   {
     extends: [...nextCoreWebVitals, eslintConfigPrettier],
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const config = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   collectCoverageFrom: ['src/games/**/logic.ts'],
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
   coverageThreshold: {
     global: {
       lines: 80,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "test": "jest --config jest.config.js",
     "test:watch": "jest --config jest.config.js --watch",
     "test:coverage": "jest --config jest.config.js --coverage",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:debug": "playwright test --debug",
+    "e2e:ci": "playwright test --reporter=github,line",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -28,6 +32,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = process.env.PORT ?? '3000'
+const HOST = '127.0.0.1'
+const baseURL = `http://${HOST}:${PORT}/library-games`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['github'], ['line']] : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: `pnpm dev --hostname ${HOST} --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_E2E_FAKE_SUPABASE: '1',
+      NEXT_PUBLIC_SUPABASE_URL: 'http://127.0.0.1:54321',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'e2e-anon-key',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,17 +17,25 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
-  webServer: {
-    command: `pnpm dev --hostname ${HOST} --port ${PORT}`,
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-    env: {
-      NEXT_PUBLIC_E2E_FAKE_SUPABASE: '1',
-      NEXT_PUBLIC_SUPABASE_URL: 'http://127.0.0.1:54321',
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'e2e-anon-key',
+  webServer: [
+    {
+      command: 'node e2e/fake-supabase/server.mjs',
+      url: 'http://127.0.0.1:54321/health',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
     },
-  },
+    {
+      command: `pnpm dev --hostname ${HOST} --port ${PORT}`,
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        NEXT_PUBLIC_E2E_FAKE_SUPABASE: '1',
+        NEXT_PUBLIC_SUPABASE_URL: 'http://127.0.0.1:54321',
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: 'e2e-anon-key',
+      },
+    },
+  ],
   projects: [
     {
       name: 'chromium',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.7.0(react@19.2.4)
       next:
         specifier: ^16.2.3
-        version: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -36,6 +36,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -732,6 +735,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -1800,6 +1808,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2713,6 +2726,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4028,6 +4051,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rtsao/scc@1.1.0': {}
 
   '@sinclair/typebox@0.34.48': {}
@@ -5246,6 +5273,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6162,7 +6192,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -6181,6 +6211,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6333,6 +6364,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/components/GameRulesGate.tsx
+++ b/src/components/GameRulesGate.tsx
@@ -36,6 +36,7 @@ export function GameRulesGate({ emoji, title, rules, children }: GameRulesGatePr
       </div>
 
       <button
+        data-testid="play-game-button"
         onClick={() => setStarted(true)}
         className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg px-8 py-3 text-sm font-semibold transition-colors"
       >

--- a/src/components/multiplayer/LobbyActions.tsx
+++ b/src/components/multiplayer/LobbyActions.tsx
@@ -35,12 +35,18 @@ export function LobbyActions({
     <footer className={className}>
       <span className={statusClassName}>{isHost ? hostLabel : guestLabel}</span>
       <div className={actionsClassName}>
-        <button type="button" onClick={onLeave} className={leaveButtonClassName}>
+        <button
+          type="button"
+          data-testid="leave-room-button"
+          onClick={onLeave}
+          className={leaveButtonClassName}
+        >
           {leaveLabel}
         </button>
         {isHost && onStart && (
           <button
             type="button"
+            data-testid="start-game-button"
             disabled={!canStart}
             onClick={onStart}
             className={cn(startButtonClassName)}

--- a/src/components/multiplayer/PlayerRoster.tsx
+++ b/src/components/multiplayer/PlayerRoster.tsx
@@ -54,7 +54,7 @@ export function PlayerRoster({
   removeButtonClassName,
 }: PlayerRosterProps) {
   return (
-    <section className={className}>
+    <section data-testid="player-roster" className={className}>
       <div className={headerClassName}>
         <span>{title}</span>
         <span>

--- a/src/components/multiplayer/RoomInviteCard.tsx
+++ b/src/components/multiplayer/RoomInviteCard.tsx
@@ -33,7 +33,9 @@ export function RoomInviteCard({
   return (
     <section className={className}>
       <span className={titleClassName}>{title}</span>
-      <div className={roomCodeClassName}>{roomCode}</div>
+      <div data-testid="room-code" className={roomCodeClassName}>
+        {roomCode}
+      </div>
       <div className={actionsClassName}>
         <button
           type="button"
@@ -45,6 +47,7 @@ export function RoomInviteCard({
         </button>
         <button
           type="button"
+          data-testid="invite-link"
           className={cn(actionClassName)}
           onClick={() => onCopy(inviteLink, 'link')}
         >

--- a/src/components/multiplayer/RoomInviteCard.tsx
+++ b/src/components/multiplayer/RoomInviteCard.tsx
@@ -48,6 +48,7 @@ export function RoomInviteCard({
         <button
           type="button"
           data-testid="invite-link"
+          data-invite-link={inviteLink}
           className={cn(actionClassName)}
           onClick={() => onCopy(inviteLink, 'link')}
         >

--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -720,6 +720,7 @@ function Lobby({
           <button
             onClick={copyInviteLink}
             data-testid="invite-link"
+            data-invite-link={getInviteLink('agario', roomCode)}
             className="hover:bg-background rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors"
           >
             {copied === 'link' ? 'Copied!' : 'Copy invite link'}

--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -706,7 +706,9 @@ function Lobby({
     <div className="flex flex-col items-center gap-6">
       <div className="text-center">
         <p className="text-muted-foreground mb-1 text-sm">Room Code</p>
-        <p className="font-mono text-4xl font-bold tracking-widest">{roomCode}</p>
+        <p data-testid="room-code" className="font-mono text-4xl font-bold tracking-widest">
+          {roomCode}
+        </p>
         <p className="text-muted-foreground mt-1 text-sm">Share this code with friends</p>
         <div className="mt-2 flex justify-center gap-2">
           <button
@@ -717,6 +719,7 @@ function Lobby({
           </button>
           <button
             onClick={copyInviteLink}
+            data-testid="invite-link"
             className="hover:bg-background rounded-lg border px-4 py-1.5 text-xs font-medium transition-colors"
           >
             {copied === 'link' ? 'Copied!' : 'Copy invite link'}
@@ -726,7 +729,7 @@ function Lobby({
 
       <div className="w-full max-w-xs">
         <h3 className="mb-2 text-sm font-semibold">Players ({gameState.players.length}/8)</h3>
-        <div className="space-y-1">
+        <div data-testid="player-roster" className="space-y-1">
           {gameState.players.map((p) => (
             <div
               key={p.id}
@@ -748,6 +751,7 @@ function Lobby({
 
       {isHost ? (
         <button
+          data-testid="start-game-button"
           onClick={onStart}
           disabled={gameState.players.length < 2}
           className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg px-8 py-2 font-semibold transition disabled:opacity-50"
@@ -820,6 +824,7 @@ function FinishedScreen({
           </button>
         )}
         <button
+          data-testid="leave-room-button"
           onClick={onLeave}
           className="bg-muted hover:bg-muted/80 rounded-lg px-6 py-2 font-semibold transition"
         >
@@ -1416,7 +1421,12 @@ export function AgarioGame() {
       </p>
 
       {error && (
-        <div className="bg-destructive/10 text-destructive rounded px-4 py-2 text-sm">{error}</div>
+        <div
+          data-testid="room-error"
+          className="bg-destructive/10 text-destructive rounded px-4 py-2 text-sm"
+        >
+          {error}
+        </div>
       )}
 
       {savedSession && (
@@ -1431,12 +1441,14 @@ export function AgarioGame() {
       {mode === 'menu' && (
         <div className="flex w-full max-w-xs flex-col gap-3">
           <button
+            data-testid="create-room-button"
             onClick={() => setMode('create')}
             className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg px-4 py-3 font-semibold transition"
           >
             Create Room
           </button>
           <button
+            data-testid="join-room-button"
             onClick={() => setMode('join')}
             className="bg-muted hover:bg-muted/80 rounded-lg px-4 py-3 font-semibold transition"
           >
@@ -1457,6 +1469,7 @@ export function AgarioGame() {
           className="flex w-full max-w-xs flex-col gap-3"
         >
           <input
+            data-testid="player-name-input"
             type="text"
             placeholder="Your name"
             value={nameInput}
@@ -1475,6 +1488,7 @@ export function AgarioGame() {
             </button>
             <button
               type="submit"
+              data-testid="create-room-button"
               disabled={!nameInput.trim()}
               className="bg-primary text-primary-foreground hover:bg-primary/90 flex-1 rounded-lg px-4 py-2 text-sm font-semibold transition disabled:opacity-50"
             >
@@ -1496,6 +1510,7 @@ export function AgarioGame() {
           className="flex w-full max-w-xs flex-col gap-3"
         >
           <input
+            data-testid="player-name-input"
             type="text"
             placeholder="Your name"
             value={nameInput}
@@ -1505,6 +1520,7 @@ export function AgarioGame() {
             autoFocus
           />
           <input
+            data-testid="room-code-input"
             type="text"
             placeholder="Room code"
             value={codeInput}
@@ -1522,6 +1538,7 @@ export function AgarioGame() {
             </button>
             <button
               type="submit"
+              data-testid="join-room-button"
               disabled={!nameInput.trim() || codeInput.length < 4}
               className="bg-primary text-primary-foreground hover:bg-primary/90 flex-1 rounded-lg px-4 py-2 text-sm font-semibold transition disabled:opacity-50"
             >

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -304,6 +304,7 @@ function EntryScreen({
 
         <div className="flex gap-4">
           <button
+            data-testid="create-room-button"
             onClick={() => setMode('create')}
             className="group border-border/50 bg-card hover:border-border flex w-40 flex-col items-center gap-3 rounded-2xl border px-6 py-6 text-center transition-all hover:-translate-y-1 hover:shadow-lg active:translate-y-0 active:scale-[0.98]"
           >
@@ -316,6 +317,7 @@ function EntryScreen({
             </div>
           </button>
           <button
+            data-testid="join-room-button"
             onClick={() => setMode('join')}
             className="group border-border/50 bg-card hover:border-border flex w-40 flex-col items-center gap-3 rounded-2xl border px-6 py-6 text-center transition-all hover:-translate-y-1 hover:shadow-lg active:translate-y-0 active:scale-[0.98]"
           >
@@ -343,13 +345,17 @@ function EntryScreen({
       </button>
       <h2 className="text-xl font-black">{isCreate ? 'Create Room' : 'Join Room'}</h2>
       {error && (
-        <p className="animate-cah-slide-down bg-destructive/10 text-destructive rounded-xl px-4 py-2.5 text-sm font-medium">
+        <p
+          data-testid="room-error"
+          className="animate-cah-slide-down bg-destructive/10 text-destructive rounded-xl px-4 py-2.5 text-sm font-medium"
+        >
           {error}
         </p>
       )}
       <label className="flex flex-col gap-1.5">
         <span className="text-muted-foreground text-xs font-semibold">Your name</span>
         <input
+          data-testid="player-name-input"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Enter your name"
@@ -361,6 +367,7 @@ function EntryScreen({
         <label className="flex flex-col gap-1.5">
           <span className="text-muted-foreground text-xs font-semibold">Room code</span>
           <input
+            data-testid="room-code-input"
             value={joinCode}
             onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
             placeholder="e.g. AB12"
@@ -370,6 +377,7 @@ function EntryScreen({
         </label>
       )}
       <button
+        data-testid={isCreate ? 'create-room-button' : 'join-room-button'}
         disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
         onClick={() => {
           savePlayerName(name.trim())
@@ -423,7 +431,9 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
         <p className="mb-1 text-[10px] font-bold tracking-[0.2em] text-white/50 uppercase">
           Room code
         </p>
-        <p className="mb-4 text-5xl font-black tracking-[0.3em]">{roomCode}</p>
+        <p data-testid="room-code" className="mb-4 text-5xl font-black tracking-[0.3em]">
+          {roomCode}
+        </p>
         <div className="flex justify-center gap-2">
           <button
             onClick={copyCode}
@@ -433,6 +443,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
           </button>
           <button
             onClick={copyInviteLink}
+            data-testid="invite-link"
             className="rounded-lg bg-white/10 px-4 py-1.5 text-xs font-semibold transition-all hover:bg-white/20 active:scale-95"
           >
             {copied === 'link' ? '✓ Copied!' : 'Share link'}
@@ -441,7 +452,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
       </div>
 
       {/* Players list */}
-      <div className="flex flex-col gap-2">
+      <div data-testid="player-roster" className="flex flex-col gap-2">
         <p className="text-muted-foreground flex items-center gap-2 text-xs font-bold tracking-wider uppercase">
           <span className="flex h-2 w-2 rounded-full bg-green-400">
             <span className="inline-flex h-2 w-2 animate-ping rounded-full bg-green-400 opacity-75" />
@@ -495,6 +506,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
       <div className="flex gap-3">
         {isHost ? (
           <button
+            data-testid="start-game-button"
             disabled={gameState.players.length < 3}
             onClick={onStart}
             className="flex-1 rounded-xl bg-black px-4 py-3 text-sm font-bold text-white transition-all hover:bg-gray-800 active:scale-[0.98] disabled:opacity-30 dark:bg-white dark:text-black dark:hover:bg-gray-200"
@@ -510,6 +522,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
           </div>
         )}
         <button
+          data-testid="leave-room-button"
           onClick={onLeave}
           className="text-muted-foreground hover:bg-secondary hover:text-foreground rounded-xl border px-5 py-3 text-sm font-semibold transition-colors"
         >
@@ -731,6 +744,7 @@ function GameBoard({
           {selectedCards.length === pick && (
             <div className="mt-4 flex justify-center">
               <button
+                data-testid="cah-submit-card"
                 onClick={handleSubmit}
                 className="animate-cah-slide-up rounded-xl bg-black px-8 py-3 text-sm font-bold text-white shadow-xl transition-all hover:bg-gray-800 active:scale-95 dark:bg-white dark:text-black dark:hover:bg-gray-200"
               >
@@ -766,6 +780,7 @@ function GameBoard({
 
       {/* Leave button */}
       <button
+        data-testid="leave-room-button"
         onClick={onLeave}
         className="text-muted-foreground/60 hover:text-muted-foreground rounded-lg px-3 py-2 text-xs transition-colors"
       >

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -444,6 +444,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
           <button
             onClick={copyInviteLink}
             data-testid="invite-link"
+            data-invite-link={getInviteLink('cards-against-humanity', roomCode)}
             className="rounded-lg bg-white/10 px-4 py-1.5 text-xs font-semibold transition-all hover:bg-white/20 active:scale-95"
           >
             {copied === 'link' ? '✓ Copied!' : 'Share link'}

--- a/src/games/codenames/CodenamesGame.tsx
+++ b/src/games/codenames/CodenamesGame.tsx
@@ -291,6 +291,7 @@ function LobbyScreen({
   const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
   const [copied, setCopied] = useState<'code' | 'link' | null>(null)
   const ready = canStartGame(gameState)
+  const unassignedPlayers = gameState.players.filter((player) => !player.team || !player.role)
 
   function copyCode() {
     navigator.clipboard.writeText(roomCode).then(
@@ -330,6 +331,7 @@ function LobbyScreen({
           </button>
           <button
             data-testid="invite-link"
+            data-invite-link={getInviteLink('codenames', roomCode)}
             onClick={copyInviteLink}
             className="hover:bg-background rounded-lg border px-3 py-1 text-xs font-medium transition-colors"
           >
@@ -343,9 +345,29 @@ function LobbyScreen({
         {gameState.players.length !== 1 ? 's' : ''} in room)
       </p>
 
-      <div data-testid="player-roster" className="flex gap-3">
-        <TeamPanel team="red" gameState={gameState} playerId={playerId} onJoinTeam={onJoinTeam} />
-        <TeamPanel team="blue" gameState={gameState} playerId={playerId} onJoinTeam={onJoinTeam} />
+      <div data-testid="player-roster" className="flex flex-col gap-3">
+        {unassignedPlayers.length > 0 && (
+          <div className="bg-secondary/60 rounded-xl p-3 text-xs">
+            <p className="text-muted-foreground mb-2 font-medium">Choosing teams</p>
+            <div className="flex flex-wrap gap-2">
+              {unassignedPlayers.map((player) => (
+                <span key={player.id} className="bg-background rounded-lg px-2 py-1 font-medium">
+                  {player.name}
+                  {player.isHost ? ' (host)' : ''}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+        <div className="flex gap-3">
+          <TeamPanel team="red" gameState={gameState} playerId={playerId} onJoinTeam={onJoinTeam} />
+          <TeamPanel
+            team="blue"
+            gameState={gameState}
+            playerId={playerId}
+            onJoinTeam={onJoinTeam}
+          />
+        </div>
       </div>
 
       {!ready && (

--- a/src/games/codenames/CodenamesGame.tsx
+++ b/src/games/codenames/CodenamesGame.tsx
@@ -104,6 +104,7 @@ function EntryScreen({
         )}
         <div className="flex gap-3">
           <button
+            data-testid="create-room-button"
             onClick={() => setMode('create')}
             className="bg-secondary hover:bg-secondary/70 flex w-36 flex-col items-center gap-2 rounded-2xl px-6 py-5 text-center font-semibold transition-all hover:shadow-lg active:scale-95"
           >
@@ -114,6 +115,7 @@ function EntryScreen({
             <span className="text-muted-foreground text-xs font-normal">Host a game</span>
           </button>
           <button
+            data-testid="join-room-button"
             onClick={() => setMode('join')}
             className="bg-secondary hover:bg-secondary/70 flex w-36 flex-col items-center gap-2 rounded-2xl px-6 py-5 text-center font-semibold transition-all hover:shadow-lg active:scale-95"
           >
@@ -139,11 +141,17 @@ function EntryScreen({
       </button>
       <h2 className="text-lg font-bold">{isCreate ? 'Create Room' : 'Join Room'}</h2>
       {error && (
-        <p className="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm">{error}</p>
+        <p
+          data-testid="room-error"
+          className="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm"
+        >
+          {error}
+        </p>
       )}
       <label className="flex flex-col gap-1">
         <span className="text-muted-foreground text-xs font-medium">Your name</span>
         <input
+          data-testid="player-name-input"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Enter your name"
@@ -155,6 +163,7 @@ function EntryScreen({
         <label className="flex flex-col gap-1">
           <span className="text-muted-foreground text-xs font-medium">Room code</span>
           <input
+            data-testid="room-code-input"
             value={joinCode}
             onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
             placeholder="e.g. AB12"
@@ -164,6 +173,7 @@ function EntryScreen({
         </label>
       )}
       <button
+        data-testid={isCreate ? 'create-room-button' : 'join-room-button'}
         disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
         onClick={() => {
           savePlayerName(name.trim())
@@ -308,7 +318,9 @@ function LobbyScreen({
         <p className="text-muted-foreground mb-1 text-xs font-medium">
           Room code &mdash; share with friends
         </p>
-        <p className="mb-2 text-3xl font-black tracking-widest">{roomCode}</p>
+        <p data-testid="room-code" className="mb-2 text-3xl font-black tracking-widest">
+          {roomCode}
+        </p>
         <div className="flex justify-center gap-2">
           <button
             onClick={copyCode}
@@ -317,6 +329,7 @@ function LobbyScreen({
             {copied === 'code' ? 'Copied!' : 'Copy code'}
           </button>
           <button
+            data-testid="invite-link"
             onClick={copyInviteLink}
             className="hover:bg-background rounded-lg border px-3 py-1 text-xs font-medium transition-colors"
           >
@@ -330,7 +343,7 @@ function LobbyScreen({
         {gameState.players.length !== 1 ? 's' : ''} in room)
       </p>
 
-      <div className="flex gap-3">
+      <div data-testid="player-roster" className="flex gap-3">
         <TeamPanel team="red" gameState={gameState} playerId={playerId} onJoinTeam={onJoinTeam} />
         <TeamPanel team="blue" gameState={gameState} playerId={playerId} onJoinTeam={onJoinTeam} />
       </div>
@@ -344,6 +357,7 @@ function LobbyScreen({
       <div className="flex gap-3">
         {isHost && (
           <button
+            data-testid="start-game-button"
             disabled={!ready}
             onClick={onStart}
             className="bg-primary text-primary-foreground flex-1 rounded-lg px-4 py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
@@ -357,6 +371,7 @@ function LobbyScreen({
           </p>
         )}
         <button
+          data-testid="leave-room-button"
           onClick={onLeave}
           className="hover:bg-secondary rounded-lg border px-4 py-2.5 text-sm font-semibold"
         >

--- a/src/games/mindmeld/MindmeldGame.tsx
+++ b/src/games/mindmeld/MindmeldGame.tsx
@@ -113,6 +113,7 @@ function EntryScreen({
 
           <div className="grid gap-3 sm:grid-cols-2">
             <button
+              data-testid="create-room-button"
               onClick={() => setMode('create')}
               className="rounded-[1.5rem] border border-white/10 bg-white/8 px-6 py-6 text-left transition hover:-translate-y-0.5 hover:bg-white/12"
             >
@@ -123,6 +124,7 @@ function EntryScreen({
               <div className="mt-1 text-sm text-white/65">Host the psychic signal.</div>
             </button>
             <button
+              data-testid="join-room-button"
               onClick={() => setMode('join')}
               className="rounded-[1.5rem] border border-white/10 bg-white/8 px-6 py-6 text-left transition hover:-translate-y-0.5 hover:bg-white/12"
             >
@@ -162,11 +164,17 @@ function EntryScreen({
         </p>
       </div>
       {error && (
-        <p className="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm">{error}</p>
+        <p
+          data-testid="room-error"
+          className="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm"
+        >
+          {error}
+        </p>
       )}
       <label className="flex flex-col gap-1.5">
         <span className="text-muted-foreground text-xs font-medium">Your name</span>
         <input
+          data-testid="player-name-input"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Enter your name"
@@ -178,6 +186,7 @@ function EntryScreen({
         <label className="flex flex-col gap-1.5">
           <span className="text-muted-foreground text-xs font-medium">Room code</span>
           <input
+            data-testid="room-code-input"
             value={joinCode}
             onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
             placeholder="e.g. AB12"
@@ -187,6 +196,7 @@ function EntryScreen({
         </label>
       )}
       <button
+        data-testid={isCreate ? 'create-room-button' : 'join-room-button'}
         disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
         onClick={() => {
           savePlayerName(name.trim())
@@ -230,7 +240,9 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
               <div className="text-[11px] font-semibold tracking-[0.28em] text-amber-200/90 uppercase">
                 Lobby frequency
               </div>
-              <h2 className="mt-2 text-3xl font-black tracking-tight">Room {roomCode}</h2>
+              <h2 data-testid="room-code" className="mt-2 text-3xl font-black tracking-tight">
+                Room {roomCode}
+              </h2>
               <p className="mt-2 max-w-lg text-sm leading-6 text-white/68">
                 Psychic gives the clue. The rest of the table discusses and submits one shared dial
                 position, then the target is revealed.
@@ -247,6 +259,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
               {copied === 'code' ? 'Copied code' : 'Copy code'}
             </button>
             <button
+              data-testid="invite-link"
               onClick={() => handleCopy(getInviteLink('mindmeld', roomCode), 'link')}
               className="rounded-full border border-white/12 bg-white/8 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/12"
             >
@@ -279,7 +292,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
             </span>
           )}
         </div>
-        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        <div data-testid="player-roster" className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
           {gameState.players.map((player) => (
             <div
               key={player.id}
@@ -304,6 +317,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
       <div className="flex gap-3">
         {isHost ? (
           <button
+            data-testid="start-game-button"
             disabled={!ready}
             onClick={onStart}
             className="bg-foreground text-background flex-1 rounded-xl px-4 py-3 text-sm font-semibold transition hover:opacity-90 disabled:opacity-40"
@@ -316,6 +330,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
           </div>
         )}
         <button
+          data-testid="leave-room-button"
           onClick={onLeave}
           className="hover:bg-secondary rounded-xl border px-4 py-3 text-sm font-semibold transition"
         >
@@ -851,6 +866,7 @@ function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedS
           </div>
         )}
         <button
+          data-testid="leave-room-button"
           onClick={onLeave}
           className="hover:bg-secondary rounded-xl border px-4 py-3 text-sm font-semibold transition"
         >

--- a/src/games/mindmeld/MindmeldGame.tsx
+++ b/src/games/mindmeld/MindmeldGame.tsx
@@ -260,6 +260,7 @@ function LobbyScreen({ gameState, playerId, roomCode, onStart, onLeave }: LobbyS
             </button>
             <button
               data-testid="invite-link"
+              data-invite-link={getInviteLink('mindmeld', roomCode)}
               onClick={() => handleCopy(getInviteLink('mindmeld', roomCode), 'link')}
               className="rounded-full border border-white/12 bg-white/8 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/12"
             >

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -318,6 +318,7 @@ function DrawingCanvas({
   return (
     <div className={cn(styles.canvasSurface, !isDrawer && styles.canvasReadOnly)}>
       <canvas
+        data-testid="skribbl-canvas"
         ref={canvasRef}
         width={800}
         height={560}
@@ -685,6 +686,7 @@ function EntryScreen({
         <div className={styles.entryChoiceGrid}>
           <button
             type="button"
+            data-testid="create-room-button"
             className={cn(styles.entryCard, styles.entryCardAccent)}
             onClick={() => setMode('create')}
           >
@@ -694,7 +696,12 @@ function EntryScreen({
             </div>
           </button>
 
-          <button type="button" className={styles.entryCard} onClick={() => setMode('join')}>
+          <button
+            type="button"
+            data-testid="join-room-button"
+            className={styles.entryCard}
+            onClick={() => setMode('join')}
+          >
             <div className={styles.entryCardTitle}>Join Room</div>
             <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
               Enter a 4-char code
@@ -729,11 +736,16 @@ function EntryScreen({
       </div>
 
       <div className={styles.entryForm}>
-        {error && <div className={styles.error}>{error}</div>}
+        {error && (
+          <div data-testid="room-error" className={styles.error}>
+            {error}
+          </div>
+        )}
 
         <label className={styles.field}>
           <span className={cn(styles.label, arcadeShellStyles.mono)}>Your name</span>
           <input
+            data-testid="player-name-input"
             value={name}
             onChange={(event) => setName(event.target.value)}
             maxLength={16}
@@ -757,6 +769,7 @@ function EntryScreen({
           <label className={styles.field}>
             <span className={cn(styles.label, arcadeShellStyles.mono)}>Room code</span>
             <input
+              data-testid="room-code-input"
               value={code}
               onChange={(event) =>
                 setCode(event.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))
@@ -782,6 +795,7 @@ function EntryScreen({
           </button>
           <button
             type="button"
+            data-testid={mode === 'create' ? 'create-room-button' : 'join-room-button'}
             onClick={submit}
             disabled={loading || !canSubmit}
             className={arcadeShellStyles.button}

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -520,7 +520,12 @@ function HowToScreen({ onStart }: { onStart: () => void }) {
           chat. Faster guesses, more points. Three rounds, one winner.
         </p>
         <div className={styles.heroActions}>
-          <button type="button" onClick={onStart} className={arcadeShellStyles.button}>
+          <button
+            type="button"
+            data-testid="play-game-button"
+            onClick={onStart}
+            className={arcadeShellStyles.button}
+          >
             Play now →
           </button>
           <span className={cn(styles.heroMeta, arcadeShellStyles.mono)}>
@@ -1433,7 +1438,9 @@ function GameBoardScreen({
 export function SkribblGame() {
   const inviteCode = useInviteCode()
   const inviteCodeResolved = inviteCode !== undefined
-  const [entryMode, setEntryMode] = useState<'howto' | 'entry'>('howto')
+  const [entryMode, setEntryMode] = useState<'howto' | 'entry'>(
+    process.env.NEXT_PUBLIC_E2E_FAKE_SUPABASE === '1' ? 'entry' : 'howto'
+  )
   const {
     createRoom,
     dispatch,

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -312,7 +312,12 @@ function HowToScreen({ onStart }: { onStart: () => void }) {
           cards, call UNO before your friends catch you, and survive the draw piles.
         </p>
         <div className={styles.heroActions}>
-          <button type="button" onClick={onStart} className={arcadeShellStyles.button}>
+          <button
+            type="button"
+            data-testid="play-game-button"
+            onClick={onStart}
+            className={arcadeShellStyles.button}
+          >
             Play now →
           </button>
           <span className={cn(styles.heroMeta, arcadeShellStyles.mono)}>
@@ -1014,7 +1019,9 @@ function ConfettiEffect() {
 export function UnoGame() {
   const inviteCode = useInviteCode()
   const inviteCodeResolved = inviteCode !== undefined
-  const [entryMode, setEntryMode] = useState<'howto' | 'entry'>('howto')
+  const [entryMode, setEntryMode] = useState<'howto' | 'entry'>(
+    process.env.NEXT_PUBLIC_E2E_FAKE_SUPABASE === '1' ? 'entry' : 'howto'
+  )
   const {
     gameState,
     playerId,

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -141,6 +141,7 @@ function UnoCard({
 
   return (
     <button
+      data-testid={!faceDown && onClick ? 'uno-hand-card' : undefined}
       onClick={onClick}
       disabled={!playable && !faceDown && onClick !== undefined}
       className={cn(
@@ -421,6 +422,7 @@ function EntryScreen({
         <div className={styles.entryChoiceGrid}>
           <button
             type="button"
+            data-testid="create-room-button"
             className={cn(styles.entryCard, styles.entryCardAccent)}
             onClick={() => setMode('create')}
           >
@@ -430,7 +432,12 @@ function EntryScreen({
             </div>
           </button>
 
-          <button type="button" className={styles.entryCard} onClick={() => setMode('join')}>
+          <button
+            type="button"
+            data-testid="join-room-button"
+            className={styles.entryCard}
+            onClick={() => setMode('join')}
+          >
             <div className={styles.entryCardTitle}>Join Room</div>
             <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
               Enter a 4-char code
@@ -466,11 +473,16 @@ function EntryScreen({
       </div>
 
       <div className={styles.entryForm}>
-        {error && <div className={styles.error}>{error}</div>}
+        {error && (
+          <div data-testid="room-error" className={styles.error}>
+            {error}
+          </div>
+        )}
 
         <label className={styles.field}>
           <span className={cn(styles.label, arcadeShellStyles.mono)}>Your name</span>
           <input
+            data-testid="player-name-input"
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="e.g. Marble"
@@ -483,6 +495,7 @@ function EntryScreen({
           <label className={styles.field}>
             <span className={cn(styles.label, arcadeShellStyles.mono)}>Room code</span>
             <input
+              data-testid="room-code-input"
               value={joinCode}
               onChange={(event) =>
                 setJoinCode(event.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))
@@ -508,6 +521,7 @@ function EntryScreen({
           </button>
           <button
             type="button"
+            data-testid={isCreate ? 'create-room-button' : 'join-room-button'}
             disabled={loading || !canSubmit}
             onClick={submit}
             className={arcadeShellStyles.button}

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -142,7 +142,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
           .filter(Boolean)
         setOnlinePlayerIds(ids)
       })
-      .subscribe(async (s) => {
+      .subscribe(async (s: string) => {
         if (s === 'SUBSCRIBED') {
           await channel.track({ player_id: playerId })
         }
@@ -177,7 +177,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
             table: tableName,
             filter: `code=eq.${code}`,
           },
-          (payload) => {
+          (payload: { new: { state: unknown; version: unknown } }) => {
             const parsed = stateSchema.safeParse(payload.new.state)
             if (!parsed.success) {
               console.error(`[${channelPrefix}] Invalid GameState payload:`, parsed.error)
@@ -192,7 +192,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         broadcastChannelRef.current?.unsubscribe()
         broadcastChannelRef.current = supabase
           .channel(`${broadcastCfg.channelPrefix}:${code}`)
-          .on('broadcast', { event: 'game' }, (payload) => {
+          .on('broadcast', { event: 'game' }, (payload: { payload: unknown }) => {
             if (onBroadcastRef.current) {
               const parsed = broadcastCfg.schema.safeParse(payload.payload)
               if (!parsed.success) {

--- a/src/lib/e2e/fake-supabase.ts
+++ b/src/lib/e2e/fake-supabase.ts
@@ -1,0 +1,248 @@
+type QueryResult<T> = { data: T | null; error: { message: string } | null }
+
+type Filter = { column: string; value: unknown }
+
+type RealtimeStatus = 'SUBSCRIBED'
+
+type PostgresChangesConfig = {
+  event?: string
+  table?: string
+  filter?: string
+}
+
+type BroadcastConfig = {
+  event?: string
+}
+
+type PresenceConfig = {
+  event?: string
+}
+
+type PostgresPayload = {
+  new: Record<string, unknown>
+  old: Record<string, unknown>
+}
+
+type BroadcastPayload = {
+  event: string
+  payload: unknown
+}
+
+type PresencePayload = Record<string, unknown[]>
+
+type Handler =
+  | {
+      type: 'postgres_changes'
+      config: PostgresChangesConfig
+      callback: (payload: PostgresPayload) => void
+    }
+  | { type: 'broadcast'; config: BroadcastConfig; callback: (payload: BroadcastPayload) => void }
+  | { type: 'presence'; config: PresenceConfig; callback: () => void }
+
+type FakeEvent =
+  | {
+      id: number
+      type: 'postgres_changes'
+      table: string
+      new: Record<string, unknown>
+      old: Record<string, unknown>
+    }
+  | { id: number; type: 'broadcast'; channel: string; event: string; payload: unknown }
+  | { id: number; type: 'presence'; channel: string; state: PresencePayload }
+
+const fakeSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://127.0.0.1:54321'
+const pollMs = 100
+
+function clientId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return Math.random().toString(36).slice(2)
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${fakeSupabaseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) throw new Error(`Fake Supabase ${path} failed: ${response.status}`)
+  return (await response.json()) as T
+}
+
+async function get<T>(path: string): Promise<T> {
+  const response = await fetch(`${fakeSupabaseUrl}${path}`)
+  if (!response.ok) throw new Error(`Fake Supabase ${path} failed: ${response.status}`)
+  return (await response.json()) as T
+}
+
+function parseEqFilter(filter?: string): Filter | null {
+  if (!filter) return null
+  const match = filter.match(/^([^=]+)=eq\.(.+)$/)
+  if (!match) return null
+  return { column: match[1], value: match[2] }
+}
+
+class FakeQueryBuilder {
+  private readonly filters: Filter[] = []
+  private op: 'insert' | 'select' | 'update' | null = null
+  private values: unknown = null
+  private selectedColumns = '*'
+
+  constructor(private readonly table: string) {}
+
+  insert(values: unknown): this {
+    this.op = 'insert'
+    this.values = values
+    return this
+  }
+
+  update(values: unknown): this {
+    this.op = 'update'
+    this.values = values
+    return this
+  }
+
+  select(columns = '*'): Promise<QueryResult<Record<string, unknown>[]>> & this {
+    this.selectedColumns = columns
+    if (!this.op) this.op = 'select'
+    return this as Promise<QueryResult<Record<string, unknown>[]>> & this
+  }
+
+  eq(column: string, value: unknown): this {
+    this.filters.push({ column, value })
+    return this
+  }
+
+  async single(): Promise<QueryResult<Record<string, unknown>>> {
+    if (!this.op) this.op = 'select'
+    return this.execute<Record<string, unknown>>(true)
+  }
+
+  then<TResult1 = QueryResult<Record<string, unknown>[]>, TResult2 = never>(
+    onfulfilled?:
+      | ((value: QueryResult<Record<string, unknown>[]>) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return this.execute<Record<string, unknown>[]>(false).then(onfulfilled, onrejected)
+  }
+
+  private async execute<T>(single: boolean): Promise<QueryResult<T>> {
+    return post<QueryResult<T>>('/query', {
+      op: this.op,
+      table: this.table,
+      values: this.values,
+      filters: this.filters,
+      columns: this.selectedColumns,
+      single,
+    })
+  }
+}
+
+class FakeRealtimeChannel {
+  private readonly handlers: Handler[] = []
+  private readonly id = clientId()
+  private lastEventId = 0
+  private intervalId: ReturnType<typeof setInterval> | null = null
+  private currentPresenceState: PresencePayload = {}
+
+  constructor(private readonly name: string) {}
+
+  on(
+    type: Handler['type'],
+    config: PostgresChangesConfig | BroadcastConfig | PresenceConfig,
+    callback: ((payload: PostgresPayload | BroadcastPayload) => void) | (() => void)
+  ): this {
+    this.handlers.push({ type, config, callback } as Handler)
+    return this
+  }
+
+  subscribe(callback?: (status: RealtimeStatus) => void | Promise<void>): this {
+    this.intervalId ??= setInterval(() => {
+      void this.poll()
+    }, pollMs)
+
+    void Promise.resolve(callback?.('SUBSCRIBED'))
+    return this
+  }
+
+  async send(message: { type: 'broadcast'; event: string; payload: unknown }): Promise<'ok'> {
+    await post('/broadcast', { channel: this.name, event: message.event, payload: message.payload })
+    return 'ok'
+  }
+
+  async track(payload: Record<string, unknown>): Promise<'ok'> {
+    const response = await post<{ state: PresencePayload }>('/presence/track', {
+      channel: this.name,
+      clientId: this.id,
+      payload,
+    })
+    this.currentPresenceState = response.state
+    this.emitPresenceSync()
+    return 'ok'
+  }
+
+  presenceState(): PresencePayload {
+    return this.currentPresenceState
+  }
+
+  async unsubscribe(): Promise<'ok'> {
+    if (this.intervalId) clearInterval(this.intervalId)
+    this.intervalId = null
+    await post('/presence/untrack', { channel: this.name, clientId: this.id })
+    return 'ok'
+  }
+
+  private async poll(): Promise<void> {
+    const { events } = await get<{ events: FakeEvent[] }>(`/events?since=${this.lastEventId}`)
+    for (const event of events) {
+      this.lastEventId = Math.max(this.lastEventId, event.id)
+      this.dispatch(event)
+    }
+  }
+
+  private dispatch(event: FakeEvent): void {
+    for (const handler of this.handlers) {
+      if (event.type === 'postgres_changes' && handler.type === 'postgres_changes') {
+        if (handler.config.table && handler.config.table !== event.table) continue
+        const filter = parseEqFilter(handler.config.filter)
+        if (filter && event.new[filter.column] !== filter.value) continue
+        handler.callback({ new: event.new, old: event.old })
+      }
+
+      if (event.type === 'broadcast' && handler.type === 'broadcast') {
+        if (event.channel !== this.name) continue
+        if (handler.config.event && handler.config.event !== event.event) continue
+        handler.callback({ event: event.event, payload: event.payload })
+      }
+
+      if (event.type === 'presence' && handler.type === 'presence') {
+        if (event.channel !== this.name) continue
+        this.currentPresenceState = event.state
+        this.emitPresenceSync()
+      }
+    }
+  }
+
+  private emitPresenceSync(): void {
+    for (const handler of this.handlers) {
+      if (
+        handler.type === 'presence' &&
+        (!handler.config.event || handler.config.event === 'sync')
+      ) {
+        handler.callback()
+      }
+    }
+  }
+}
+
+export function createFakeSupabaseClient() {
+  return {
+    from(table: string) {
+      return new FakeQueryBuilder(table)
+    },
+    channel(name: string) {
+      return new FakeRealtimeChannel(name)
+    },
+  }
+}

--- a/src/lib/e2e/fake-supabase.ts
+++ b/src/lib/e2e/fake-supabase.ts
@@ -162,7 +162,9 @@ class FakeRealtimeChannel {
       void this.poll()
     }, pollMs)
 
-    void Promise.resolve(callback?.('SUBSCRIBED'))
+    queueMicrotask(() => {
+      void Promise.resolve(callback?.('SUBSCRIBED'))
+    })
     return this
   }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,41 @@
 import { createClient } from '@supabase/supabase-js'
+import { createFakeSupabaseClient } from '@/lib/e2e/fake-supabase'
+
+type QueryResult<T> = Promise<{ data: T | null; error: { message: string } | null }>
+
+type QueryBuilderBoundary = {
+  insert(values: unknown): QueryBuilderBoundary
+  update(values: unknown): QueryBuilderBoundary
+  select(columns?: string): QueryResult<Record<string, unknown>[]> & QueryBuilderBoundary
+  eq(column: string, value: unknown): QueryBuilderBoundary
+  single(): QueryResult<Record<string, unknown>>
+}
+
+type ChannelBoundary = {
+  on<TPayload = unknown>(
+    type: string,
+    config: unknown,
+    callback: (payload: TPayload) => void
+  ): ChannelBoundary
+  subscribe(callback?: (status: string) => void | Promise<void>): ChannelBoundary
+  send(message: unknown): Promise<unknown>
+  track(payload: Record<string, unknown>): Promise<unknown>
+  presenceState(): Record<string, unknown[]>
+  unsubscribe(): Promise<unknown>
+}
+
+type SupabaseBoundary = {
+  from(table: string): QueryBuilderBoundary
+  channel(name: string): ChannelBoundary
+}
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
 const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
+const useFakeSupabase = process.env.NEXT_PUBLIC_E2E_FAKE_SUPABASE === '1'
 
-export const supabase = url && key ? createClient(url, key) : null
-export const isSupabaseConfigured = Boolean(url && key)
+export const supabase: SupabaseBoundary | null = useFakeSupabase
+  ? (createFakeSupabaseClient() as unknown as SupabaseBoundary)
+  : url && key
+    ? (createClient(url, key) as unknown as SupabaseBoundary)
+    : null
+export const isSupabaseConfigured = useFakeSupabase || Boolean(url && key)


### PR DESCRIPTION
## Summary
- Set up Playwright multiplayer E2E baseline (config, scripts, bootstrapping) for Library Games.
- Added stable multiplayer `data-testid` selectors across online game flows.
- Implemented reusable E2E helpers and fake Supabase utilities for deterministic multiplayer tests.
- Added multiplayer room contract coverage across game slugs.
- Added edge-state coverage for room lifecycle behavior (invalid code, started game join-block, full room, leave/clear session, reload restore, malformed/expired session handling).
- Updated multiplayer E2E rollout plan docs with completed progress through Task 10.

## Implemented in this PR (current)
- Task 1–10 from `docs/plans/2026-04-24-playwright-e2e-multiplayer.md` are implemented.
- Latest commits:
  - `e5c511c` — `test(e2e): add multiplayer join-room contract coverage`
  - `66d707d` — `test(e2e): cover multiplayer room edge states`

## Test Plan
- [x] `pnpm lint`
- [x] `pnpm e2e --list`
- [x] `pnpm e2e -- e2e/multiplayer-room-contract.spec.ts` (18 passed)

## Next
- Task 11: Uno full turn smoke test.
- Remaining roadmap after that: Tasks 12–21 (additional per-game smoke flows, race/reconnect regressions, CI/docs finalization).
