### PR TITLE
test(e2e): complete multiplayer roadmap coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ pnpm test:coverage  # coverage report (>=80% required on logic files)
 pnpm build          # static export -> /out
 ```
 
+## E2E testing
+
+Playwright E2E tests cover multiplayer room flows, game smoke paths, race conditions, and reconnect behavior with a deterministic fake Supabase backend. See `docs/e2e.md` for local commands, fake backend details, selector conventions, CI artifacts, and debugging tips.
+
+```bash
+pnpm e2e        # run Playwright headless
+pnpm e2e:ui     # open Playwright UI mode
+pnpm e2e:debug  # run with Playwright debugger
+pnpm e2e:ci     # CI reporter format
+```
+
 ## Architecture
 
 Each game follows a strict split between pure logic and UI:

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -1,0 +1,111 @@
+# E2E testing
+
+Library Games uses Playwright for browser-level E2E coverage of multiplayer room flows, game smoke paths, race conditions, and reconnect behavior.
+
+## Commands
+
+```bash
+pnpm e2e        # run Playwright headless
+pnpm e2e:ui     # open Playwright UI mode
+pnpm e2e:debug  # run with Playwright debugger
+pnpm e2e:ci     # CI reporter format
+```
+
+Run a single spec:
+
+```bash
+pnpm e2e -- e2e/multiplayer-room-contract.spec.ts
+pnpm e2e -- e2e/games/uno.spec.ts
+pnpm e2e -- e2e/race-conditions.spec.ts
+```
+
+View the HTML report:
+
+```bash
+pnpm exec playwright show-report
+```
+
+## Fake Supabase
+
+E2E tests do not use the hosted Supabase project.
+
+Playwright starts a local fake Supabase server with:
+
+```bash
+node e2e/fake-supabase/server.mjs
+```
+
+The Next.js dev server is started with:
+
+```bash
+NEXT_PUBLIC_E2E_FAKE_SUPABASE=1
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=e2e-anon-key
+```
+
+When `NEXT_PUBLIC_E2E_FAKE_SUPABASE=1`, `src/lib/supabase.ts` exports the fake client from `src/lib/e2e/fake-supabase.ts` instead of the real Supabase client.
+
+The fake backend is shared across browser contexts, so tests can model multiple players in the same room. Tests can also call helpers in `e2e/helpers/fakeSupabase.ts` to reset state or seed deterministic room state.
+
+## Adding a game E2E spec
+
+1. Add shared create/join coverage to `e2e/multiplayer-room-contract.spec.ts` when adding a new live multiplayer game.
+2. Add game-specific smoke coverage in `e2e/games/<slug>.spec.ts`.
+3. Use helpers from:
+   - `e2e/helpers/players.ts`
+   - `e2e/helpers/navigation.ts`
+   - `e2e/helpers/assertions.ts`
+   - `e2e/helpers/fakeSupabase.ts`
+4. Start from the real UI flow where practical: create room, join room, start game.
+5. Use fake Supabase direct state setup only for deterministic deep-game states that would be slow, random, or time-based to reach through the UI.
+
+## Selector conventions
+
+Prefer accessible role/name locators when UI text is stable. Use `data-testid` only for stable interaction or observation points that should not depend on styling or marketing copy.
+
+Shared test IDs:
+
+- `play-game-button`
+- `player-name-input`
+- `room-code-input`
+- `create-room-button`
+- `join-room-button`
+- `room-code`
+- `invite-link`
+- `player-roster`
+- `start-game-button`
+- `leave-room-button`
+- `room-error`
+
+Game-specific test IDs should be prefixed with the game slug, for example:
+
+- `uno-hand-card`
+- `skribbl-canvas`
+- `cah-submit-card`
+- `codenames-board-card`
+- `mindmeld-guess-slider`
+- `agario-canvas`
+
+## CI artifacts and debugging
+
+CI runs:
+
+```bash
+pnpm exec playwright install --with-deps chromium
+pnpm e2e:ci
+```
+
+On failure, GitHub Actions uploads:
+
+- `playwright-report/`
+- `test-results/`
+
+Download the artifacts from the failed workflow run and inspect them locally. If an HTML report is available, run:
+
+```bash
+pnpm exec playwright show-report
+```
+
+## Workflow push permission pitfall
+
+Changing `.github/workflows/ci.yml` modifies a GitHub Actions workflow file. Automation credentials may need the GitHub `workflow` permission/scope to push the change. If a push is rejected for workflow scope, apply the same patch with a token/user that can update workflow files.

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -42,11 +42,11 @@
 
 ## Progress
 
-**Branch:** `feat/uno-e2e-smoke`
+**Branch:** `feat/mindmeld-e2e-smoke`
 
-**PR:** #118 — https://github.com/kkulykk/library-games/pull/118
+**PR:** #119 — https://github.com/kkulykk/library-games/pull/119
 
-**Last updated:** 2026-04-25 16:41 UTC
+**Last updated:** 2026-04-25 17:05 UTC
 
 **Completed:**
 
@@ -65,6 +65,7 @@
 - [x] Task 12 — Added deterministic Skribbl round smoke coverage for word picking, drawer/guesser visibility, canvas presence, wrong/correct guesses, scoring, round reveal, and drawer rotation.
 - [x] Task 13 — Added deterministic Cards Against Humanity smoke coverage for non-czar submissions, judging reveal flow, Czar winner selection, score increment, and next-round Czar rotation.
 - [x] Task 14 — Added deterministic Codenames smoke coverage for spymaster key visibility, operative redaction, clue submission, correct guess count/log updates, and assassin end-game flow.
+- [x] Task 15 — Added deterministic Mindmeld smoke coverage for Psychic clue submission, guesser target redaction, team dial locking, reveal scoring, Psychic rotation, and final leaderboard results.
 - [x] Security fix — Sanitized fake Supabase 500 responses so server exception details are logged locally but not returned over HTTP.
 
 **Verification passed:**
@@ -78,13 +79,13 @@
 - `pnpm e2e -- e2e/games/skribbl.spec.ts`
 - `pnpm e2e -- e2e/games/cards-against-humanity.spec.ts`
 - `pnpm e2e -- e2e/games/codenames.spec.ts`
+- `pnpm e2e -- e2e/games/mindmeld.spec.ts`
 - `pnpm build`
 
 **Latest PR/CI status checked:**
 
-- PR #118 is open on `feat/uno-e2e-smoke`.
-- Previous implementation commit `2e80ad8`: Build, CodeQL, Lint & Test, Analyze (javascript-typescript), and Analyze (actions) passed; Deploy skipped; `claude-review` failed and needs review/follow-up before merge.
-- Latest documentation-status commit: GitHub checks restarted and were in progress when last checked (`claude-review`, Lint & Test, Analyze javascript-typescript, Analyze actions).
+- PR #118 was merged into `main` before starting this Task 15 branch.
+- Task 15 is being prepared on fresh branch `feat/mindmeld-e2e-smoke`.
 
 **Notes:**
 
@@ -101,9 +102,10 @@
 - Task 12 seeds deterministic fake Supabase Skribbl drawing state after exercising the real create/join/start flow, then uses real guess actions to validate chat/scoring/reveal/rotation.
 - Task 13 seeds deterministic fake Supabase Cards Against Humanity playing/judging states after exercising the real create/join/start flow, then uses real submit/reveal/pick/next-round actions to validate Czar and non-Czar behavior.
 - Task 14 seeds deterministic fake Supabase Codenames playing state after exercising the real create/join flow, then uses real clue/guess actions to validate spymaster visibility, operative redaction, correct guesses, and assassin win behavior.
+- Task 15 seeds deterministic fake Supabase Mindmeld clue/final-reveal states after exercising the real create/join/start flow, then uses real clue, guess, next-round, and final-results actions to validate target redaction, reveal scoring, Psychic rotation, and leaderboard sync.
 - GitHub Advanced Security flagged fake Supabase error responses for information exposure; 500 responses are now generic while details stay in server logs.
 
-**Next:** Resolve/follow up on failed `claude-review` check for PR #118, then Task 15 — Mindmeld smoke test.
+**Next:** Task 16 — Agario/Slither.io smoke test.
 
 ---
 

--- a/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
+++ b/docs/plans/2026-04-24-playwright-e2e-multiplayer.md
@@ -46,7 +46,7 @@
 
 **PR:** #119 — https://github.com/kkulykk/library-games/pull/119
 
-**Last updated:** 2026-04-25 17:05 UTC
+**Last updated:** 2026-04-25 18:07 UTC
 
 **Completed:**
 
@@ -66,6 +66,12 @@
 - [x] Task 13 — Added deterministic Cards Against Humanity smoke coverage for non-czar submissions, judging reveal flow, Czar winner selection, score increment, and next-round Czar rotation.
 - [x] Task 14 — Added deterministic Codenames smoke coverage for spymaster key visibility, operative redaction, clue submission, correct guess count/log updates, and assassin end-game flow.
 - [x] Task 15 — Added deterministic Mindmeld smoke coverage for Psychic clue submission, guesser target redaction, team dial locking, reveal scoring, Psychic rotation, and final leaderboard results.
+- [x] Task 16 — Added Agario/Slither.io realtime smoke coverage for create/join/start flow, canvas gameplay entry, cross-client snake leaderboard sync, broadcast-driven game end, and final scores.
+- [x] Task 17 — Added deterministic concurrent join conflict coverage for optimistic room-version updates without player overwrites.
+- [x] Task 18 — Added deterministic concurrent action conflict coverage proving dispatch retries preserve simultaneous Skribbl correct guesses.
+- [x] Task 19 — Added reconnect/reload resilience coverage proving restored Uno players receive later realtime updates and leave clears session state.
+- [!] Task 20 — Prepared GitHub Actions Playwright E2E job patch with Chromium install and failure artifact uploads; pushing `.github/workflows/ci.yml` requires a token with `workflow` scope.
+- [x] Task 21 — Added E2E documentation for local commands, fake Supabase, selector conventions, CI artifacts, and debugging.
 - [x] Security fix — Sanitized fake Supabase 500 responses so server exception details are logged locally but not returned over HTTP.
 
 **Verification passed:**
@@ -80,6 +86,9 @@
 - `pnpm e2e -- e2e/games/cards-against-humanity.spec.ts`
 - `pnpm e2e -- e2e/games/codenames.spec.ts`
 - `pnpm e2e -- e2e/games/mindmeld.spec.ts`
+- `pnpm e2e -- e2e/games/agario.spec.ts`
+- `pnpm e2e -- e2e/race-conditions.spec.ts`
+- `pnpm e2e:ci`
 - `pnpm build`
 
 **Latest PR/CI status checked:**
@@ -103,9 +112,13 @@
 - Task 13 seeds deterministic fake Supabase Cards Against Humanity playing/judging states after exercising the real create/join/start flow, then uses real submit/reveal/pick/next-round actions to validate Czar and non-Czar behavior.
 - Task 14 seeds deterministic fake Supabase Codenames playing state after exercising the real create/join flow, then uses real clue/guess actions to validate spymaster visibility, operative redaction, correct guesses, and assassin win behavior.
 - Task 15 seeds deterministic fake Supabase Mindmeld clue/final-reveal states after exercising the real create/join/start flow, then uses real clue, guess, next-round, and final-results actions to validate target redaction, reveal scoring, Psychic rotation, and leaderboard sync.
+- Task 16 uses Agario broadcast helpers after the real create/join/start flow to validate realtime canvas entry, cross-client snake leaderboard sync, and final score rendering without brittle canvas pixel assertions.
+- Tasks 17-19 use Playwright route barriers and restore flows to make optimistic-version conflict and reconnect coverage deterministic instead of “probably simultaneous” flaky.
+- Task 20 patch is saved locally at `/tmp/library-games-e2e-ci-workflow.patch`; applying it requires GitHub workflow-file write permission.
+- Task 21 documents E2E commands, fake Supabase, adding specs, selector conventions, and trace/report debugging in `docs/e2e.md`.
 - GitHub Advanced Security flagged fake Supabase error responses for information exposure; 500 responses are now generic while details stay in server logs.
 
-**Next:** Task 16 — Agario/Slither.io smoke test.
+**Next:** Multiplayer E2E roadmap code/docs coverage is complete except applying the Task 20 workflow patch with a workflow-scoped credential. Merge PR #119 after CI review; then apply `/tmp/library-games-e2e-ci-workflow.patch` with a token/user that can update `.github/workflows/ci.yml`.
 
 ---
 

--- a/docs/plans/2026-04-25-task15-mindmeld-smoke-implementation.md
+++ b/docs/plans/2026-04-25-task15-mindmeld-smoke-implementation.md
@@ -1,0 +1,77 @@
+# Task 15 Mindmeld Smoke Test Implementation Plan
+
+> **For Hermes:** Follow test-driven-development. Write the Playwright spec first, watch it fail, then add the minimum stable selectors/implementation needed to pass.
+
+**Goal:** Add deterministic Mindmeld gameplay E2E coverage for the multiplayer E2E roadmap.
+
+**Architecture:** Exercise the real browser create/join/start room flow, then seed deterministic `mindmeld_rooms` state through the fake Supabase helper. Use real clue, team guess, reveal/next-round, and final-results UI actions to verify reducer wiring and cross-context realtime sync without depending on random puzzle/psychic selection.
+
+**Tech Stack:** Next.js, React 19, TypeScript, Playwright, fake Supabase E2E server, pnpm.
+
+---
+
+## Progress
+
+- [x] Repo updated to latest `origin/main` and fresh branch created: `feat/mindmeld-e2e-smoke`.
+- [x] Write failing Mindmeld Playwright smoke spec.
+- [x] Run targeted spec and confirm RED failure from missing selectors/coverage.
+  - RED: `pnpm e2e -- e2e/games/mindmeld.spec.ts` failed on missing `mindmeld-status` selector.
+- [x] Add stable Mindmeld E2E selectors to semantic UI surfaces.
+- [x] Run targeted Mindmeld spec and confirm GREEN.
+  - GREEN: `pnpm e2e -- e2e/games/mindmeld.spec.ts` passed, 1/1.
+- [x] Update global E2E roadmap progress.
+- [x] Run verification gate.
+  - Passed after `pnpm lint:fix`: `pnpm lint`, `pnpm test`, targeted Mindmeld/Codenames/CAH/Skribbl/Uno E2E specs, room-contract E2E, and `pnpm build`.
+- [x] Commit, push, and open PR.
+  - PR #119: https://github.com/kkulykk/library-games/pull/119
+
+## Test Scope
+
+Create `e2e/games/mindmeld.spec.ts` covering:
+
+1. Host creates room and guest joins through shared helpers.
+2. Host starts game to validate the real start path.
+3. Spec seeds deterministic playing state where host is Psychic, target is known, and guest is guesser.
+4. Host sees private target; guest sees hidden/waiting clue state.
+5. Host submits a clue through the real UI.
+6. Guest sees clue, adjusts shared dial guess, and locks guess through the real UI.
+7. Both contexts see reveal with target, team guess, distance, and score increment.
+8. Host advances to the next round and the guest becomes Psychic.
+9. Spec seeds final reveal state and clicks results, verifying final leaderboard on both contexts.
+
+## Files
+
+- Create: `e2e/games/mindmeld.spec.ts`
+- Modify: `src/games/mindmeld/MindmeldGame.tsx`
+- Modify: `docs/plans/2026-04-24-playwright-e2e-multiplayer.md`
+- Modify: this plan file
+
+## Expected Selectors
+
+Add only stable semantic selectors:
+
+- `mindmeld-status`
+- `mindmeld-leaderboard`
+- `mindmeld-dial`
+- `mindmeld-private-target`
+- `mindmeld-waiting-clue`
+- `mindmeld-current-clue`
+- `mindmeld-clue-input`
+- `mindmeld-send-clue`
+- `mindmeld-guess-slider`
+- `mindmeld-lock-guess`
+- `mindmeld-reveal`
+- `mindmeld-round-score`
+- `mindmeld-next-round`
+- `mindmeld-finished`
+- `mindmeld-final-leaderboard`
+
+## Verification Gate
+
+Run from repo root:
+
+```bash
+pnpm lint && pnpm test && pnpm e2e -- e2e/games/mindmeld.spec.ts && pnpm e2e -- e2e/games/codenames.spec.ts && pnpm e2e -- e2e/games/cards-against-humanity.spec.ts && pnpm e2e -- e2e/games/skribbl.spec.ts && pnpm e2e -- e2e/games/uno.spec.ts && pnpm e2e -- e2e/multiplayer-room-contract.spec.ts && pnpm build
+```
+
+If this is too slow while iterating, run the targeted Mindmeld spec first, then the full gate before commit.

--- a/docs/plans/2026-04-25-tasks16-21-complete-e2e-implementation.md
+++ b/docs/plans/2026-04-25-tasks16-21-complete-e2e-implementation.md
@@ -1,0 +1,123 @@
+# Remaining Multiplayer E2E Tasks 16-21 Implementation Plan
+
+> **For Hermes:** Implement this plan directly with strict TDD where behavior changes/tests are involved. Keep updating progress in this file.
+
+**Goal:** Finish the multiplayer E2E roadmap by adding Agario/Slither.io smoke coverage, race/reconnect regression tests, CI Playwright execution, and E2E documentation.
+
+**Architecture:** Continue on the active E2E roadmap branch/PR and keep coverage deterministic with the existing fake Supabase backend. Use real browser create/join/start flows first, then use fake Supabase queries or broadcasts only where needed to avoid random/time-based gameplay flake. Add stable semantic selectors only where existing DOM is not observable.
+
+**Tech Stack:** Next.js static app, React 19, TypeScript, pnpm, Playwright, fake Supabase E2E server, GitHub Actions.
+
+---
+
+## Progress
+
+- [x] Inspected current branch and remaining roadmap tasks.
+- [x] Created this Tasks 16-21 implementation plan.
+- [x] Task 16 RED: write Agario smoke spec and confirm it fails on missing selectors/coverage.
+  - RED: `pnpm e2e -- e2e/games/agario.spec.ts` failed on missing `agario-canvas` selector.
+- [x] Task 16 GREEN: add minimal Agario selectors and make smoke spec pass.
+  - GREEN: `pnpm e2e -- e2e/games/agario.spec.ts` passed, 1/1.
+- [x] Tasks 17-19 RED: write race/reconnect regression spec and confirm targeted failures.
+  - RED: initial `pnpm e2e -- e2e/race-conditions.spec.ts` exposed missing/insufficient stable UI assertions for round-end chat and in-game Uno leave controls.
+- [x] Tasks 17-19 GREEN: add only minimal helpers/behavior changes if required and make spec pass.
+  - GREEN: `pnpm e2e -- e2e/race-conditions.spec.ts` passed, 3/3.
+- [!] Task 20: prepared Playwright E2E GitHub Actions patch, but the current token cannot push workflow-file changes without `workflow` scope.
+  - Saved patch: `/tmp/library-games-e2e-ci-workflow.patch`
+- [x] Task 21: document E2E commands, fake Supabase, selector conventions, and debugging.
+- [x] Update global roadmap progress for Tasks 16-21.
+- [x] Run verification gate.
+  - Passed after `pnpm lint:fix`: `pnpm lint`, `pnpm test`, targeted Agario E2E, race-conditions E2E, full `pnpm e2e:ci` (27 passed, 1 skipped), and `pnpm build`.
+- [ ] Commit, push, and update PR #119.
+
+## Task 16 — Agario/Slither.io smoke test
+
+**Objective:** Cover realtime gameplay lifecycle without pixel/canvas assertions.
+
+**Files:**
+
+- Create: `e2e/games/agario.spec.ts`
+- Modify: `src/games/agario/AgarioGame.tsx`
+
+**Steps:**
+
+1. Write `e2e/games/agario.spec.ts` using real create/join/start flow.
+2. Broadcast deterministic `game_start` and `game_end` messages through the fake Supabase `/broadcast` endpoint.
+3. Assert both players see `agario-canvas`, cross-client leaderboard presence, and final scores.
+4. Run `pnpm e2e -- e2e/games/agario.spec.ts` and confirm RED failure from missing selectors.
+5. Add minimal selectors: `agario-canvas`, `agario-game-area`, `agario-leaderboard`, `agario-leaderboard-row`, `agario-finished`, `agario-final-scores`, `agario-final-score-row`.
+6. Re-run targeted spec and confirm GREEN.
+
+## Tasks 17-19 — Race and reconnect tests
+
+**Objective:** Add deterministic regression coverage for optimistic version conflicts and restore/subscription behavior.
+
+**Files:**
+
+- Create: `e2e/race-conditions.spec.ts`
+
+**Task 17:** Concurrent join conflict
+
+- Use Uno.
+- Create host room.
+- Two guests join concurrently through browser UI with a route barrier that makes both joiners read the same room version.
+- Assert final room contains host + exactly one guest, no overwrite, and the losing guest sees retryable error.
+
+**Task 18:** Concurrent action conflict
+
+- Use Skribbl correct guesses.
+- Seed deterministic drawing state.
+- Two guessers submit correct guesses concurrently with a route barrier on first update.
+- Assert dispatch retry preserves both guessed players/messages and host sees round end.
+
+**Task 19:** Reconnect/reload resilience
+
+- Use Uno.
+- Guest joins, reloads, resumes, then host starts game.
+- Assert restored guest receives the later playing-state update.
+- Guest leaves, reloads, and does not auto-rejoin.
+
+## Task 20 — CI integration
+
+**Objective:** Run Playwright in GitHub Actions and upload artifacts on failure.
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+
+**Steps:**
+
+1. Add `e2e` job after `lint-and-test`.
+2. Install dependencies and Playwright Chromium with deps.
+3. Run `pnpm e2e:ci`.
+4. Upload `playwright-report/` and `test-results/` on failure.
+5. Gate deploy on both `build` and `e2e`.
+
+**Caution:** Pushing workflow edits may require a GitHub token with workflow permission.
+
+## Task 21 — Documentation
+
+**Objective:** Make E2E runnable/debuggable by humans who do not have all this context loaded in their brain meat.
+
+**Files:**
+
+- Create: `docs/e2e.md`
+- Modify: `README.md`
+
+**Document:**
+
+- Local E2E commands.
+- Fake Supabase server/client and env vars.
+- How to add game specs.
+- Selector conventions.
+- CI artifacts and trace/report debugging.
+
+## Verification Gate
+
+Run before commit/push:
+
+```bash
+pnpm lint && pnpm test && pnpm e2e -- e2e/games/agario.spec.ts && pnpm e2e -- e2e/race-conditions.spec.ts && pnpm e2e:ci && pnpm build
+```
+
+If time is ugly, run targeted specs first while iterating, then the full gate before final commit.

--- a/docs/plans/2026-04-25-tasks16-21-complete-e2e-implementation.md
+++ b/docs/plans/2026-04-25-tasks16-21-complete-e2e-implementation.md
@@ -28,7 +28,10 @@
 - [x] Update global roadmap progress for Tasks 16-21.
 - [x] Run verification gate.
   - Passed after `pnpm lint:fix`: `pnpm lint`, `pnpm test`, targeted Agario E2E, race-conditions E2E, full `pnpm e2e:ci` (27 passed, 1 skipped), and `pnpm build`.
-- [ ] Commit, push, and update PR #119.
+- [x] Commit, push, and update PR #119.
+  - PR: https://github.com/kkulykk/library-games/pull/119
+  - Branch pushed at `5717630`.
+  - PR body updated with implemented tasks, validation results, and Task 20 workflow-token note.
 
 ## Task 16 — Agario/Slither.io smoke test
 

--- a/e2e/games/agario.spec.ts
+++ b/e2e/games/agario.spec.ts
@@ -1,0 +1,175 @@
+import { createRoom, expectPlayerVisible, joinRoom, startGame } from '../helpers/assertions'
+import { fakeSupabaseQuery, test, expect } from '../helpers/fakeSupabase'
+import { gotoGame } from '../helpers/navigation'
+import { closePlayers, createPlayer } from '../helpers/players'
+
+type AgarioPlayer = {
+  id: string
+  name: string
+  isHost: boolean
+  color: string
+}
+
+type AgarioState = {
+  phase: 'lobby' | 'playing' | 'finished'
+  players: AgarioPlayer[]
+  hostId: string
+}
+
+type AgarioRoomRow = {
+  state: AgarioState
+  version: number
+}
+
+type Position = {
+  x: number
+  y: number
+}
+
+type Food = {
+  id: number
+  x: number
+  y: number
+  color: string
+  size: number
+}
+
+type SnakeState = {
+  id: string
+  name: string
+  color: string
+  segments: Position[]
+  angle: number
+  targetLength: number
+  score: number
+  alive: boolean
+  boosting: boolean
+  deathTime: number | null
+  foodEaten: number
+}
+
+type AgarioBroadcastMessage =
+  | { type: 'snake_update'; snake: SnakeState }
+  | { type: 'food_sync'; food: Food[]; nextFoodId: number }
+  | { type: 'eat_food'; playerId: string; foodIds: number[] }
+  | { type: 'snake_killed'; killerId: string; killedId: string }
+  | { type: 'death_food'; food: Food[] }
+  | { type: 'game_start'; startTime: number; food: Food[]; nextFoodId: number }
+  | { type: 'game_end' }
+
+const fakeSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://127.0.0.1:54321'
+
+async function readAgarioRoom(roomCode: string): Promise<AgarioRoomRow> {
+  const selected = await fakeSupabaseQuery<AgarioRoomRow>({
+    op: 'select',
+    table: 'agario_rooms',
+    columns: 'state,version',
+    filters: [{ column: 'code', value: roomCode }],
+    single: true,
+  })
+
+  if (!selected.data || selected.error) {
+    throw new Error(`Failed to read Agario room ${roomCode}: ${selected.error?.message}`)
+  }
+
+  return selected.data
+}
+
+async function broadcastAgario(roomCode: string, payload: AgarioBroadcastMessage): Promise<void> {
+  const response = await fetch(`${fakeSupabaseUrl}/broadcast`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      channel: `agario-game:${roomCode}`,
+      event: 'game',
+      payload,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to broadcast Agario message: ${response.status} ${response.statusText}`)
+  }
+}
+
+function seededFood(count = 20): Food[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index,
+    x: 1000 + index * 20,
+    y: 1000 + index * 10,
+    color: '#39FF14',
+    size: 5,
+  }))
+}
+
+test.describe('Agario gameplay smoke', () => {
+  test('starts a realtime snake match, syncs player presence, and finishes for both players', async ({
+    page,
+    browser,
+  }) => {
+    const host = { page, name: 'Agario Host' }
+    const guest = await createPlayer(browser, 'Agario Guest')
+
+    try {
+      await gotoGame(host.page, 'agario')
+      const roomCode = await createRoom(host.page, host.name)
+
+      await gotoGame(guest.page, 'agario')
+      await joinRoom(guest.page, roomCode, guest.name)
+
+      await expectPlayerVisible(host.page, host.name)
+      await expectPlayerVisible(host.page, guest.name)
+      await expectPlayerVisible(guest.page, host.name)
+      await expectPlayerVisible(guest.page, guest.name)
+
+      const lobbyRoom = await readAgarioRoom(roomCode)
+      expect(lobbyRoom.state.phase).toBe('lobby')
+      expect(lobbyRoom.state.players).toHaveLength(2)
+
+      await startGame(host.page)
+      await broadcastAgario(roomCode, {
+        type: 'game_start',
+        startTime: Date.now(),
+        food: seededFood(),
+        nextFoodId: 20,
+      })
+
+      await expect(host.page.getByTestId('agario-canvas')).toBeVisible()
+      await expect(guest.page.getByTestId('agario-canvas')).toBeVisible()
+      await expect(host.page.getByTestId('agario-leaderboard')).toContainText(host.name)
+      await expect(guest.page.getByTestId('agario-leaderboard')).toContainText(guest.name)
+
+      const hostCanvas = host.page.getByTestId('agario-canvas')
+      const guestCanvas = guest.page.getByTestId('agario-canvas')
+
+      await hostCanvas.hover()
+      await host.page.mouse.move(500, 350)
+      await host.page.mouse.down()
+      await host.page.waitForTimeout(250)
+      await host.page.mouse.up()
+
+      await guestCanvas.hover()
+      await guest.page.mouse.move(450, 320)
+      await guest.page.keyboard.down('Space')
+      await guest.page.waitForTimeout(250)
+      await guest.page.keyboard.up('Space')
+
+      await expect(host.page.getByTestId('agario-leaderboard')).toContainText(guest.name, {
+        timeout: 10_000,
+      })
+      await expect(guest.page.getByTestId('agario-leaderboard')).toContainText(host.name, {
+        timeout: 10_000,
+      })
+
+      await broadcastAgario(roomCode, { type: 'game_end' })
+
+      await expect(host.page.getByTestId('agario-finished')).toContainText('Game Over')
+      await expect(guest.page.getByTestId('agario-finished')).toContainText('Game Over')
+      await expect(host.page.getByTestId('agario-final-scores')).toContainText(host.name)
+      await expect(host.page.getByTestId('agario-final-scores')).toContainText(guest.name)
+      await expect(guest.page.getByTestId('agario-final-scores')).toContainText(host.name)
+      await expect(guest.page.getByTestId('agario-final-scores')).toContainText(guest.name)
+    } finally {
+      await closePlayers([guest])
+    }
+  })
+})

--- a/e2e/games/mindmeld.spec.ts
+++ b/e2e/games/mindmeld.spec.ts
@@ -1,0 +1,185 @@
+import { createRoom, joinRoom, startGame } from '../helpers/assertions'
+import { fakeSupabaseQuery, test, expect } from '../helpers/fakeSupabase'
+import { gotoGame } from '../helpers/navigation'
+import { closePlayers, createPlayer } from '../helpers/players'
+
+type MindmeldPlayer = {
+  id: string
+  name: string
+  isHost: boolean
+  score: number
+}
+
+type MindmeldRound = {
+  number: number
+  psychicId: string
+  spectrum: { left: string; right: string }
+  target: number
+  clue: string | null
+  teamGuess: number | null
+  guessLockedBy: string | null
+  guesses: Record<string, number>
+  roundScores: Record<string, number>
+  phase: 'clue' | 'guessing' | 'reveal'
+}
+
+type MindmeldState = {
+  phase: 'lobby' | 'playing' | 'finished'
+  players: MindmeldPlayer[]
+  totalRounds: number
+  roundNumber: number
+  currentRound: MindmeldRound | null
+  log: string[]
+}
+
+type MindmeldRoomRow = {
+  state: MindmeldState
+  version: number
+}
+
+async function readMindmeldRoom(roomCode: string): Promise<MindmeldRoomRow> {
+  const selected = await fakeSupabaseQuery<MindmeldRoomRow>({
+    op: 'select',
+    table: 'mindmeld_rooms',
+    columns: 'state,version',
+    filters: [{ column: 'code', value: roomCode }],
+    single: true,
+  })
+
+  if (!selected.data || selected.error) {
+    throw new Error(`Failed to read Mindmeld room ${roomCode}: ${selected.error?.message}`)
+  }
+
+  return selected.data
+}
+
+async function updateMindmeldRoom(
+  roomCode: string,
+  row: MindmeldRoomRow,
+  nextState: MindmeldState
+): Promise<void> {
+  const updated = await fakeSupabaseQuery({
+    op: 'update',
+    table: 'mindmeld_rooms',
+    values: { state: nextState, version: row.version + 1 },
+    filters: [{ column: 'code', value: roomCode }],
+  })
+
+  if (updated.error) {
+    throw new Error(`Failed to update Mindmeld room ${roomCode}: ${updated.error.message}`)
+  }
+}
+
+function seededClueState(players: MindmeldPlayer[]): MindmeldState {
+  const [host] = players
+
+  return {
+    phase: 'playing',
+    players: players.map((player) => ({ ...player, score: 0 })),
+    totalRounds: 8,
+    roundNumber: 1,
+    currentRound: {
+      number: 1,
+      psychicId: host.id,
+      spectrum: { left: 'Cold', right: 'Hot' },
+      target: 64,
+      clue: null,
+      teamGuess: null,
+      guessLockedBy: null,
+      guesses: {},
+      roundScores: {},
+      phase: 'clue',
+    },
+    log: [`Game started — ${host.name} is the first Psychic.`],
+  }
+}
+
+function seededFinalRevealState(players: MindmeldPlayer[]): MindmeldState {
+  const [host, guest] = players.map((player) => ({ ...player, score: 18 }))
+
+  return {
+    phase: 'playing',
+    players: [host, guest],
+    totalRounds: 8,
+    roundNumber: 8,
+    currentRound: {
+      number: 8,
+      psychicId: host.id,
+      spectrum: { left: 'Quiet', right: 'Loud' },
+      target: 42,
+      clue: 'thunder',
+      teamGuess: 44,
+      guessLockedBy: guest.id,
+      guesses: {},
+      roundScores: {
+        [host.id]: 4,
+        [guest.id]: 4,
+      },
+      phase: 'reveal',
+    },
+    log: ['Final seeded reveal.'],
+  }
+}
+
+test.describe('Mindmeld gameplay smoke', () => {
+  test('submits clue and team guess, advances psychic, and shows final results', async ({
+    page,
+    browser,
+  }) => {
+    const host = { page, name: 'Host Mindmeld' }
+    const guest = await createPlayer(browser, 'Guest Mindmeld')
+
+    try {
+      await gotoGame(host.page, 'mindmeld')
+      const roomCode = await createRoom(host.page, host.name)
+
+      await gotoGame(guest.page, 'mindmeld')
+      await joinRoom(guest.page, roomCode, guest.name)
+      await startGame(host.page)
+
+      const startedRoom = await readMindmeldRoom(roomCode)
+      await updateMindmeldRoom(roomCode, startedRoom, seededClueState(startedRoom.state.players))
+
+      await expect(host.page.getByTestId('mindmeld-status')).toContainText('you are up')
+      await expect(host.page.getByTestId('mindmeld-private-target')).toContainText('64')
+      await expect(guest.page.getByTestId('mindmeld-status')).toContainText('is the Psychic')
+      await expect(guest.page.getByTestId('mindmeld-waiting-clue')).toContainText(
+        'Waiting for the clue'
+      )
+
+      await host.page.getByTestId('mindmeld-clue-input').fill('campfire')
+      await host.page.getByTestId('mindmeld-send-clue').click()
+
+      await expect(guest.page.getByTestId('mindmeld-current-clue')).toContainText('campfire')
+      await guest.page.getByTestId('mindmeld-guess-slider').fill('67')
+      await guest.page.getByTestId('mindmeld-lock-guess').click()
+
+      await expect(host.page.getByTestId('mindmeld-reveal')).toContainText('64')
+      await expect(host.page.getByTestId('mindmeld-reveal')).toContainText('67')
+      await expect(host.page.getByTestId('mindmeld-round-score')).toContainText('+4')
+      await expect(guest.page.getByTestId('mindmeld-round-score')).toContainText('+4')
+      await expect(host.page.getByTestId('mindmeld-leaderboard')).toContainText('Host Mindmeld · 4')
+
+      await host.page.getByTestId('mindmeld-next-round').click()
+      await expect(guest.page.getByTestId('mindmeld-status')).toContainText('you are up')
+
+      const secondRound = await readMindmeldRoom(roomCode)
+      await updateMindmeldRoom(
+        roomCode,
+        secondRound,
+        seededFinalRevealState(secondRound.state.players)
+      )
+      await host.page.getByTestId('mindmeld-next-round').click()
+
+      await expect(host.page.getByTestId('mindmeld-finished')).toContainText('win')
+      await expect(host.page.getByTestId('mindmeld-final-leaderboard')).toContainText(
+        'Host Mindmeld'
+      )
+      await expect(guest.page.getByTestId('mindmeld-final-leaderboard')).toContainText(
+        'Guest Mindmeld'
+      )
+    } finally {
+      await closePlayers([guest])
+    }
+  })
+})

--- a/e2e/race-conditions.spec.ts
+++ b/e2e/race-conditions.spec.ts
@@ -1,0 +1,369 @@
+import type { BrowserContext, Route } from '@playwright/test'
+import { createRoom, joinRoom, startGame } from './helpers/assertions'
+import { fakeSupabaseQuery, test, expect } from './helpers/fakeSupabase'
+import { gotoGame } from './helpers/navigation'
+import { closePlayers, createPlayer } from './helpers/players'
+
+const fakeSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://127.0.0.1:54321'
+
+type QueryPayload = {
+  op?: 'select' | 'update' | 'insert'
+  table?: string
+  values?: {
+    state?: unknown
+    version?: number
+  }
+  filters?: Array<{ column: string; value: unknown }>
+  columns?: string
+  single?: boolean
+}
+
+type RoomRow<TState> = {
+  state: TState
+  version: number
+}
+
+type UnoPlayer = {
+  id: string
+  name: string
+  isHost: boolean
+  hand: unknown[]
+  saidUno: boolean
+}
+
+type UnoState = {
+  phase: 'lobby' | 'playing' | 'finished'
+  players: UnoPlayer[]
+  hostId: string
+}
+
+type SkribblPlayer = {
+  id: string
+  name: string
+  isHost: boolean
+  score: number
+  avatar: number
+}
+
+type DrawPoint = {
+  x: number
+  y: number
+  color: string
+  size: number
+  tool: 'pen' | 'eraser'
+}
+
+type SkribblMessage = {
+  id: string
+  playerId: string
+  playerName: string
+  text: string
+  isCorrect?: boolean
+  isSystem?: boolean
+  isClose?: boolean
+}
+
+type SkribblState = {
+  phase: 'lobby' | 'picking' | 'drawing' | 'round-end' | 'finished'
+  players: SkribblPlayer[]
+  currentDrawerIndex: number
+  round: number
+  totalRounds: number
+  word: string | null
+  wordChoices: string[]
+  hint: string
+  strokes: Array<{ points: DrawPoint[] }>
+  messages: SkribblMessage[]
+  guessedPlayers: string[]
+  drawStartTime: number | null
+  turnDuration: number
+  turnEndTime: number | null
+  scoreDeltas: Record<string, number>
+}
+
+function hasFilter(payload: QueryPayload, column: string, value: unknown): boolean {
+  return (
+    payload.filters?.some((filter) => filter.column === column && filter.value === value) ?? false
+  )
+}
+
+async function installQueryBarrier(
+  contexts: BrowserContext[],
+  predicate: (payload: QueryPayload) => boolean
+): Promise<void> {
+  const waiting: Route[] = []
+  let released = false
+
+  await Promise.all(
+    contexts.map((context) =>
+      context.route(`${fakeSupabaseUrl}/query`, async (route) => {
+        const payload = route.request().postDataJSON() as QueryPayload
+
+        if (!released && predicate(payload)) {
+          waiting.push(route)
+
+          if (waiting.length === contexts.length) {
+            released = true
+            await Promise.all(waiting.splice(0).map((blocked) => blocked.continue()))
+          }
+
+          return
+        }
+
+        await route.continue()
+      })
+    )
+  )
+}
+
+async function readRoom<TState>(table: string, roomCode: string): Promise<RoomRow<TState>> {
+  const selected = await fakeSupabaseQuery<RoomRow<TState>>({
+    op: 'select',
+    table,
+    columns: 'state,version',
+    filters: [{ column: 'code', value: roomCode }],
+    single: true,
+  })
+
+  if (!selected.data || selected.error) {
+    throw new Error(`Failed to read ${table} room ${roomCode}: ${selected.error?.message}`)
+  }
+
+  return selected.data
+}
+
+async function updateRoom<TState>(
+  table: string,
+  roomCode: string,
+  row: RoomRow<TState>,
+  nextState: TState
+): Promise<void> {
+  const updated = await fakeSupabaseQuery({
+    op: 'update',
+    table,
+    values: { state: nextState, version: row.version + 1 },
+    filters: [{ column: 'code', value: roomCode }],
+  })
+
+  if (updated.error) {
+    throw new Error(`Failed to update ${table} room ${roomCode}: ${updated.error.message}`)
+  }
+}
+
+function encodeWord(word: string): string {
+  return Buffer.from(word, 'utf8').toString('base64')
+}
+
+function seededDrawingState(players: SkribblPlayer[]): SkribblState {
+  return {
+    phase: 'drawing',
+    players,
+    currentDrawerIndex: 0,
+    round: 1,
+    totalRounds: 3,
+    word: encodeWord('apple'),
+    wordChoices: [],
+    hint: '_ _ _ _ _',
+    strokes: [],
+    messages: [],
+    guessedPlayers: [],
+    drawStartTime: Date.now(),
+    turnDuration: 80,
+    turnEndTime: null,
+    scoreDeltas: {},
+  }
+}
+
+test.describe('multiplayer race conditions and reconnect resilience', () => {
+  test.setTimeout(60_000)
+
+  test('uno handles concurrent join version conflict without overwriting players', async ({
+    page,
+    browser,
+  }) => {
+    const host = { page, name: 'Race Host' }
+    const guestOne = await createPlayer(browser, 'Race Guest One')
+    const guestTwo = await createPlayer(browser, 'Race Guest Two')
+
+    try {
+      await gotoGame(host.page, 'uno')
+      const roomCode = await createRoom(host.page, host.name)
+
+      await gotoGame(guestOne.page, 'uno')
+      await gotoGame(guestTwo.page, 'uno')
+
+      await installQueryBarrier([guestOne.context, guestTwo.context], (payload) => {
+        return (
+          payload.op === 'select' &&
+          payload.table === 'uno_rooms' &&
+          payload.single === true &&
+          hasFilter(payload, 'code', roomCode)
+        )
+      })
+
+      await Promise.allSettled([
+        joinRoom(guestOne.page, roomCode, guestOne.name),
+        joinRoom(guestTwo.page, roomCode, guestTwo.name),
+      ])
+
+      const finalRoom = await readRoom<UnoState>('uno_rooms', roomCode)
+      const names = finalRoom.state.players.map((player) => player.name)
+      const joinedGuestNames = names.filter(
+        (name) => name === guestOne.name || name === guestTwo.name
+      )
+
+      expect(names).toContain(host.name)
+      expect(finalRoom.state.players).toHaveLength(2)
+      expect(new Set(names).size).toBe(names.length)
+      expect(joinedGuestNames).toHaveLength(1)
+
+      const guestOneJoined = names.includes(guestOne.name)
+      const winningGuest = guestOneJoined ? guestOne : guestTwo
+      const losingGuest = guestOneJoined ? guestTwo : guestOne
+
+      await expect(winningGuest.page.getByTestId('room-code')).toContainText(roomCode)
+      await expect(losingGuest.page.getByTestId('room-error')).toContainText(
+        'Failed to join room. Try again.'
+      )
+      await expect(host.page.getByTestId('player-roster')).toContainText(winningGuest.name)
+      await expect(host.page.getByTestId('player-roster')).not.toContainText(losingGuest.name)
+    } finally {
+      await closePlayers([guestOne, guestTwo])
+    }
+  })
+
+  test('skribbl retries concurrent correct guesses and preserves both actions', async ({
+    page,
+    browser,
+  }) => {
+    const host = { page, name: 'Race Drawer' }
+    const guesserOne = await createPlayer(browser, 'Race Guess One')
+    const guesserTwo = await createPlayer(browser, 'Race Guess Two')
+
+    try {
+      await gotoGame(host.page, 'skribbl')
+      const roomCode = await createRoom(host.page, host.name)
+
+      await gotoGame(guesserOne.page, 'skribbl')
+      await joinRoom(guesserOne.page, roomCode, guesserOne.name)
+
+      await gotoGame(guesserTwo.page, 'skribbl')
+      await joinRoom(guesserTwo.page, roomCode, guesserTwo.name)
+
+      await startGame(host.page)
+      const startedRoom = await readRoom<SkribblState>('skribbl_rooms', roomCode)
+      await updateRoom(
+        'skribbl_rooms',
+        roomCode,
+        startedRoom,
+        seededDrawingState(startedRoom.state.players)
+      )
+
+      await expect(guesserOne.page.getByTestId('skribbl-hint-mask')).toContainText('_ _ _ _ _')
+      await expect(guesserTwo.page.getByTestId('skribbl-hint-mask')).toContainText('_ _ _ _ _')
+
+      await installQueryBarrier([guesserOne.context, guesserTwo.context], (payload) => {
+        const state = payload.values?.state as Partial<SkribblState> | undefined
+        return (
+          payload.op === 'update' &&
+          payload.table === 'skribbl_rooms' &&
+          hasFilter(payload, 'code', roomCode) &&
+          state?.phase === 'drawing' &&
+          state.guessedPlayers?.length === 1 &&
+          state.messages?.some((message) => message.text.includes('guessed the word')) === true
+        )
+      })
+
+      await Promise.all([
+        guesserOne.page
+          .getByTestId('skribbl-guess-input')
+          .fill('apple')
+          .then(() => guesserOne.page.getByTestId('skribbl-guess-input').press('Enter')),
+        guesserTwo.page
+          .getByTestId('skribbl-guess-input')
+          .fill('apple')
+          .then(() => guesserTwo.page.getByTestId('skribbl-guess-input').press('Enter')),
+      ])
+
+      await expect(host.page.getByTestId('skribbl-round-end')).toBeVisible()
+      const finalRoom = await readRoom<SkribblState>('skribbl_rooms', roomCode)
+      const finalNamesById = new Map(
+        finalRoom.state.players.map((player) => [player.name, player.id])
+      )
+
+      expect(finalRoom.state.phase).toBe('round-end')
+      expect(finalRoom.state.guessedPlayers).toContain(finalNamesById.get(guesserOne.name))
+      expect(finalRoom.state.guessedPlayers).toContain(finalNamesById.get(guesserTwo.name))
+      expect(new Set(finalRoom.state.guessedPlayers).size).toBe(
+        finalRoom.state.guessedPlayers.length
+      )
+      expect(finalRoom.state.messages.map((message) => message.text)).toEqual(
+        expect.arrayContaining([
+          `${guesserOne.name} guessed the word!`,
+          `${guesserTwo.name} guessed the word!`,
+        ])
+      )
+      await expect(host.page.getByTestId('skribbl-round-word')).toContainText('apple')
+    } finally {
+      await closePlayers([guesserOne, guesserTwo])
+    }
+  })
+
+  test('uno restored player receives later realtime updates and leave prevents auto-rejoin', async ({
+    page,
+    browser,
+  }) => {
+    const host = { page, name: 'Restore Host' }
+    const guest = await createPlayer(browser, 'Restore Guest')
+
+    try {
+      await gotoGame(host.page, 'uno')
+      const roomCode = await createRoom(host.page, host.name)
+
+      await gotoGame(guest.page, 'uno')
+      await joinRoom(guest.page, roomCode, guest.name)
+
+      await guest.page.reload()
+      const playButton = guest.page.getByTestId('play-game-button')
+      if (await playButton.isVisible().catch(() => false)) {
+        await playButton.click()
+      }
+      const resumeButton = guest.page.getByRole('button', { name: /resume/i })
+      await expect(resumeButton.or(guest.page.getByTestId('room-code'))).toBeVisible()
+      if (
+        !(await guest.page
+          .getByTestId('room-code')
+          .isVisible()
+          .catch(() => false))
+      ) {
+        await resumeButton.click()
+      }
+
+      await expect(guest.page.getByTestId('room-code')).toContainText(roomCode)
+      await expect(guest.page.getByTestId('player-roster')).toContainText(host.name)
+      await expect(guest.page.getByTestId('player-roster')).toContainText(guest.name)
+
+      await startGame(host.page)
+      await expect(guest.page.getByTestId('uno-status')).toBeVisible()
+
+      await guest.page.getByTestId('leave-room-button').click()
+      await expect(
+        guest.page.getByTestId('create-room-button').filter({ visible: true }).first()
+      ).toBeVisible()
+      await expect
+        .poll(() => guest.page.evaluate(() => localStorage.getItem('uno_session')))
+        .toBeNull()
+
+      await guest.page.reload()
+      if (await playButton.isVisible().catch(() => false)) {
+        await playButton.click()
+      }
+      await expect(guest.page.getByTestId('room-code')).toHaveCount(0)
+      await expect(
+        guest.page.getByTestId('create-room-button').filter({ visible: true }).first()
+      ).toBeVisible()
+    } finally {
+      await closePlayers([guest])
+    }
+  })
+})

--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -407,6 +407,7 @@ function GameCanvas({
 
   return (
     <canvas
+      data-testid="agario-canvas"
       ref={canvasRef}
       className="block h-full w-full select-none"
       style={{
@@ -644,13 +645,21 @@ function Leaderboard({
     .slice(0, 8)
 
   return (
-    <div className="absolute top-10 right-2 rounded-lg border border-white/10 bg-[#0a0a2e]/80 px-3 py-2 text-sm text-white backdrop-blur-sm">
+    <div
+      data-testid="agario-leaderboard"
+      className="absolute top-10 right-2 rounded-lg border border-white/10 bg-[#0a0a2e]/80 px-3 py-2 text-sm text-white backdrop-blur-sm"
+    >
       <div className="mb-1 text-center text-xs font-bold tracking-wider text-white/50 uppercase">
         Leaderboard
       </div>
       {sorted.map((s, i) => (
         <div
           key={s.id}
+          data-testid="agario-leaderboard-row"
+          data-player-id={s.id}
+          data-player-name={s.name}
+          data-score={s.score}
+          data-length={Math.floor(s.targetLength)}
           className={cn('flex items-center gap-2 py-0.5', s.id === myId && 'font-bold')}
         >
           <span className="w-4 text-right text-white/40">{i + 1}.</span>
@@ -788,15 +797,19 @@ function FinishedScreen({
   const sorted = [...finalScores].sort((a, b) => b.score - a.score)
 
   return (
-    <div className="flex flex-col items-center gap-6">
+    <div data-testid="agario-finished" className="flex flex-col items-center gap-6">
       <h2 className="text-2xl font-bold">Game Over!</h2>
 
       <div className="w-full max-w-xs">
         <h3 className="mb-2 text-center text-sm font-semibold">Final Scores</h3>
-        <div className="space-y-1">
+        <div data-testid="agario-final-scores" className="space-y-1">
           {sorted.map((s, i) => (
             <div
               key={s.id}
+              data-testid="agario-final-score-row"
+              data-player-id={s.id}
+              data-player-name={s.name}
+              data-score={s.score}
               className={cn(
                 'bg-muted flex items-center gap-2 rounded px-3 py-2 text-sm',
                 s.id === myId && 'ring-primary ring-1',
@@ -1346,6 +1359,7 @@ export function AgarioGame() {
     return (
       <div className="relative flex flex-col items-center">
         <div
+          data-testid="agario-game-area"
           className="relative overflow-hidden rounded-lg border border-white/10"
           style={{ width: canvasSize.width, height: canvasSize.height }}
         >

--- a/src/games/mindmeld/MindmeldGame.tsx
+++ b/src/games/mindmeld/MindmeldGame.tsx
@@ -417,7 +417,10 @@ function PsychicDial({
   }
 
   return (
-    <div className="overflow-hidden rounded-[2rem] border bg-[linear-gradient(180deg,rgba(24,24,27,1),rgba(10,10,12,0.98))] p-6 text-white shadow-2xl">
+    <div
+      data-testid="mindmeld-dial"
+      className="overflow-hidden rounded-[2rem] border bg-[linear-gradient(180deg,rgba(24,24,27,1),rgba(10,10,12,0.98))] p-6 text-white shadow-2xl"
+    >
       <div className="mb-4 flex items-center justify-between">
         <div className="text-[11px] font-semibold tracking-[0.28em] text-white/55 uppercase">
           Psychic dial
@@ -562,12 +565,12 @@ function PlayingScreen({
           <div className="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase">
             Round {round.number} of {gameState.totalRounds}
           </div>
-          <h2 className="mt-1 text-2xl font-black tracking-tight">
+          <h2 data-testid="mindmeld-status" className="mt-1 text-2xl font-black tracking-tight">
             {psychic?.name ?? 'Psychic'}
             {youArePsychic ? ' · you are up' : ' is the Psychic'}
           </h2>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div data-testid="mindmeld-leaderboard" className="flex flex-wrap gap-2">
           {getLeaderboard(gameState).map((player) => (
             <span
               key={player.id}
@@ -598,7 +601,10 @@ function PlayingScreen({
               <div className="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase">
                 Private target
               </div>
-              <div className="bg-background mt-3 rounded-2xl border px-4 py-3">
+              <div
+                data-testid="mindmeld-private-target"
+                className="bg-background mt-3 rounded-2xl border px-4 py-3"
+              >
                 <div className="text-muted-foreground text-xs">Secret position</div>
                 <div className="mt-1 text-4xl font-black text-amber-500 tabular-nums">
                   {round.target}
@@ -627,6 +633,7 @@ function PlayingScreen({
                 className="mt-5 flex flex-col gap-3"
               >
                 <input
+                  data-testid="mindmeld-clue-input"
                   value={clueInput}
                   onChange={(e) => setClueInput(e.target.value)}
                   placeholder="Transmit your clue…"
@@ -635,6 +642,7 @@ function PlayingScreen({
                   className="bg-background focus:ring-primary/40 rounded-xl border px-3 py-3 text-sm outline-none focus:ring-2"
                 />
                 <button
+                  data-testid="mindmeld-send-clue"
                   type="submit"
                   disabled={!clueInput.trim()}
                   className="bg-foreground text-background rounded-xl px-4 py-3 text-sm font-semibold transition hover:opacity-90 disabled:opacity-40"
@@ -646,7 +654,10 @@ function PlayingScreen({
           )}
 
           {round.phase === 'clue' && !youArePsychic && (
-            <div className="bg-secondary/35 rounded-[1.75rem] border p-6 text-center shadow-sm">
+            <div
+              data-testid="mindmeld-waiting-clue"
+              className="bg-secondary/35 rounded-[1.75rem] border p-6 text-center shadow-sm"
+            >
               <div className="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase">
                 Stand by
               </div>
@@ -659,7 +670,10 @@ function PlayingScreen({
           )}
 
           {round.phase !== 'clue' && round.clue && (
-            <div className="rounded-[1.75rem] border bg-[linear-gradient(145deg,rgba(250,204,21,0.12),rgba(14,165,233,0.06))] p-5 shadow-sm">
+            <div
+              data-testid="mindmeld-current-clue"
+              className="rounded-[1.75rem] border bg-[linear-gradient(145deg,rgba(250,204,21,0.12),rgba(14,165,233,0.06))] p-5 shadow-sm"
+            >
               <div className="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase">
                 Current clue
               </div>
@@ -683,6 +697,7 @@ function PlayingScreen({
                   <span>{round.spectrum.right}</span>
                 </div>
                 <input
+                  data-testid="mindmeld-guess-slider"
                   type="range"
                   min={0}
                   max={100}
@@ -708,6 +723,7 @@ function PlayingScreen({
                 </div>
               </div>
               <button
+                data-testid="mindmeld-lock-guess"
                 onClick={() => onSubmitGuess(guess)}
                 className="bg-foreground text-background mt-4 w-full rounded-xl px-4 py-3 text-sm font-semibold transition hover:opacity-90"
               >
@@ -729,7 +745,10 @@ function PlayingScreen({
           )}
 
           {round.phase === 'reveal' && (
-            <div className="bg-background/95 rounded-[1.75rem] border p-5 shadow-sm">
+            <div
+              data-testid="mindmeld-reveal"
+              className="bg-background/95 rounded-[1.75rem] border p-5 shadow-sm"
+            >
               <div className="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase">
                 Reveal
               </div>
@@ -751,7 +770,10 @@ function PlayingScreen({
                   </div>
                 </div>
               </div>
-              <div className="mt-4 rounded-2xl border bg-[linear-gradient(145deg,rgba(250,204,21,0.12),rgba(74,222,128,0.08))] px-4 py-4">
+              <div
+                data-testid="mindmeld-round-score"
+                className="mt-4 rounded-2xl border bg-[linear-gradient(145deg,rgba(250,204,21,0.12),rgba(74,222,128,0.08))] px-4 py-4"
+              >
                 <div className="text-muted-foreground text-sm">
                   {lockedBy ? `${lockedBy} locked the dial.` : 'The team locked the dial.'}
                 </div>
@@ -777,6 +799,7 @@ function PlayingScreen({
 
               {isHost ? (
                 <button
+                  data-testid="mindmeld-next-round"
                   onClick={onNextRound}
                   className="bg-foreground text-background mt-4 w-full rounded-xl px-4 py-3 text-sm font-semibold transition hover:opacity-90"
                 >
@@ -820,7 +843,10 @@ function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedS
 
   return (
     <div className="animate-mindmeld-fade-up flex w-full max-w-3xl flex-col gap-5">
-      <div className="overflow-hidden rounded-[2rem] border border-amber-500/20 bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.2),_transparent_35%),linear-gradient(160deg,rgba(24,24,27,0.96),rgba(39,39,42,0.92))] p-8 text-white shadow-2xl">
+      <div
+        data-testid="mindmeld-finished"
+        className="overflow-hidden rounded-[2rem] border border-amber-500/20 bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.2),_transparent_35%),linear-gradient(160deg,rgba(24,24,27,0.96),rgba(39,39,42,0.92))] p-8 text-white shadow-2xl"
+      >
         <div className="text-5xl">{youWon ? '🏆' : '🧠'}</div>
         <h2 className="mt-4 text-4xl font-black tracking-tight">{winnerNames} win!</h2>
         <p className="mt-3 max-w-2xl text-sm leading-6 text-white/70">
@@ -830,7 +856,10 @@ function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedS
         </p>
       </div>
 
-      <div className="bg-background/95 rounded-[1.75rem] border p-5 shadow-sm">
+      <div
+        data-testid="mindmeld-final-leaderboard"
+        className="bg-background/95 rounded-[1.75rem] border p-5 shadow-sm"
+      >
         <div className="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase">
           Final leaderboard
         </div>

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -854,6 +854,7 @@ function GameBoard({
             )}
 
             <button
+              data-testid="leave-room-button"
               type="button"
               onClick={onLeave}
               className={cn(


### PR DESCRIPTION
## Summary
- Complete the remaining multiplayer E2E roadmap coverage for Tasks 15-19 and Task 21
- Add deterministic Agario/Slither.io smoke coverage for realtime canvas entry, cross-client leaderboard sync, broadcast-driven game end, and final scores
- Add race/reconnect regression coverage for concurrent Uno joins, concurrent Skribbl actions, and Uno reload/restore/leave behavior
- Add stable Agario and in-game Uno E2E selectors
- Add E2E contributor docs and update the global roadmap progress

## Test Plan
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm e2e -- e2e/games/agario.spec.ts`
- [x] `pnpm e2e -- e2e/race-conditions.spec.ts`
- [x] `pnpm e2e:ci` — 27 passed, 1 skipped
- [x] `pnpm build`

## Latest GitHub Checks
- [x] Lint & Test
- [x] Build
- [x] CodeQL
- [x] Analyze (javascript-typescript)
- [x] Analyze (actions)
- [ ] claude-review — failed before review because the GitHub App installation token could not be fetched; no app/test failure indicated

## Notes
Task 20 CI workflow integration was implemented locally but cannot be pushed by the current token because GitHub rejects workflow-file changes without `workflow` scope.

Saved patch:
`/tmp/library-games-e2e-ci-workflow.patch`

Apply that patch with a workflow-scoped credential/user to add the Playwright E2E GitHub Actions job.