### PR TITLE
feat(uno): redesign Uno UI to match Library Games design system

### DIFF
--- a/src/games/uno/UnoGame.module.css
+++ b/src/games/uno/UnoGame.module.css
@@ -1,8 +1,50 @@
+/* =========================================================================
+   UNO — game-board redesign in Library Games system.
+   Ported from the Anthropic Design handoff (project/uno-styles.css).
+   Reuses tokens from globals.css / ArcadeShell.module.css; adds card
+   geometry, table felt layout, and end-of-round leaderboard.
+   ========================================================================= */
+
+/* ─── Top-level shell ─────────────────────────────────────────────────────── */
+
+.shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--arcade-bg);
+  color: var(--arcade-ink);
+}
+
+.stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.5rem;
+  position: relative;
+}
+
+.stageGrid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, var(--arcade-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--arcade-line) 1px, transparent 1px);
+  background-size: 64px 64px;
+  opacity: 0.25;
+  pointer-events: none;
+  mask-image: radial-gradient(ellipse at center, black 30%, transparent 75%);
+}
+
+/* ─── How-to ──────────────────────────────────────────────────────────────── */
+
 .hero {
   display: grid;
   grid-template-columns: 1.08fr 1fr;
   gap: 2.5rem;
   align-items: center;
+  width: 100%;
+  max-width: 75rem;
 }
 
 .heroLeft {
@@ -29,6 +71,7 @@
 
 .heroTitle {
   margin: 0;
+  font-family: var(--font-display);
   font-size: clamp(3.1rem, 7vw, 5.5rem);
   line-height: 0.95;
   letter-spacing: -0.05em;
@@ -41,6 +84,7 @@
   background: var(--arcade-accent);
   color: var(--arcade-accent-ink);
   transform: rotate(-2deg);
+  font-style: italic;
 }
 
 .heroCopy {
@@ -51,12 +95,11 @@
   line-height: 1.6;
 }
 
-.heroActions,
-.entryActions,
-.endActions {
+.heroActions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.8rem;
+  align-items: center;
 }
 
 .heroMeta {
@@ -98,10 +141,10 @@
   place-items: center;
   border: 1px solid currentColor;
   background: #fff;
-  font-size: 1.35rem;
 }
 
 .stepTitle {
+  font-family: var(--font-display);
   font-size: 1rem;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -118,6 +161,8 @@
   color: color-mix(in oklch, var(--arcade-accent-ink) 75%, transparent);
 }
 
+/* ─── Entry ───────────────────────────────────────────────────────────────── */
+
 .entryShell {
   width: 100%;
   max-width: 36rem;
@@ -127,14 +172,13 @@
   gap: 1.5rem;
 }
 
-.entryHead,
-.endShell {
+.entryHead {
   text-align: center;
 }
 
-.entryHead h2,
-.endTitle {
+.entryHead h2 {
   margin: 0;
+  font-family: var(--font-display);
   font-size: clamp(2rem, 4vw, 2.8rem);
   font-weight: 800;
   letter-spacing: -0.04em;
@@ -160,6 +204,7 @@
   padding: 1.6rem;
   color: inherit;
   text-align: left;
+  cursor: pointer;
   transition:
     transform 150ms ease,
     box-shadow 150ms ease,
@@ -178,30 +223,71 @@
   border-color: var(--arcade-ink);
 }
 
+.entryCardIcon {
+  display: grid;
+  width: 2.6rem;
+  height: 2.6rem;
+  place-items: center;
+  border: 1.5px solid currentColor;
+  background: transparent;
+}
+
 .entryCardTitle {
+  font-family: var(--font-display);
   font-size: 1.6rem;
   font-weight: 800;
   letter-spacing: -0.03em;
 }
 
-.entryCardCopy,
+.entryCardCopy {
+  color: var(--arcade-ink-mute);
+}
+
+.entryForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 78%, var(--arcade-bg-2));
+  padding: 1.6rem;
+}
+
+.entryActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.entryActionsBetween {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
 .label {
   color: var(--arcade-ink-mute);
 }
 
-.resumeCard,
-.entryForm,
-.setup,
-.playersPanel,
-.lobbyFooter,
-.tablePanel,
-.statusBar,
-.playArea,
-.handPanel,
-.actionPanel,
-.endShell {
-  border: 1px solid var(--arcade-line);
-  background: color-mix(in oklch, #fff 78%, var(--arcade-bg-2));
+.codeInput {
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+}
+
+.error {
+  border: 1px solid color-mix(in oklch, var(--arcade-danger) 45%, transparent);
+  background: color-mix(in oklch, var(--arcade-danger) 12%, #fff);
+  padding: 0.85rem 1rem;
+  color: color-mix(in oklch, var(--arcade-danger) 78%, black);
+  font-size: 0.9rem;
 }
 
 .resumeCard {
@@ -209,6 +295,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 78%, var(--arcade-bg-2));
   padding: 1.6rem;
 }
 
@@ -221,21 +309,20 @@
   font-size: 0.88rem;
 }
 
-.entryForm,
-.setup {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1.6rem;
-}
-
 .setup {
   max-width: 36rem;
   margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid var(--arcade-line);
+  background: color-mix(in oklch, #fff 78%, var(--arcade-bg-2));
+  padding: 1.6rem;
   text-align: center;
 }
 
 .setup h2 {
+  font-family: var(--font-display);
   font-size: 2rem;
   font-weight: 800;
   letter-spacing: -0.04em;
@@ -251,389 +338,1354 @@
   background: var(--arcade-bg-2);
   padding: 1rem;
   text-align: left;
+  font-family: var(--font-mono);
 }
 
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.codeInput {
-  text-align: center;
-  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
-  font-size: 1.5rem;
-  font-weight: 700;
-  letter-spacing: 0.32em;
-  text-transform: uppercase;
-}
-
-.error {
-  border: 1px solid color-mix(in oklch, var(--arcade-danger) 45%, transparent);
-  background: color-mix(in oklch, var(--arcade-danger) 12%, #fff);
-  padding: 0.85rem 1rem;
-  color: color-mix(in oklch, var(--arcade-danger) 78%, black);
-  font-size: 0.9rem;
-}
+/* ─── Lobby ───────────────────────────────────────────────────────────────── */
 
 .lobby {
-  display: grid;
-  grid-template-columns: 1.1fr 0.95fr;
-  grid-template-rows: minmax(0, 1fr) auto;
-  grid-template-areas:
-    'room side'
-    'room footer';
-  gap: 1.25rem;
-  min-height: min(43rem, calc(100dvh - 11rem));
-  max-height: calc(100dvh - 11rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 75rem;
 }
 
-.roomCard {
-  grid-area: room;
-  position: relative;
-  display: flex;
-  min-height: 23rem;
-  flex-direction: column;
+.lobbyGrid {
+  display: grid;
+  grid-template-columns: 1fr 1.1fr 1fr;
   gap: 1rem;
+  align-items: stretch;
+}
+
+.lobbyCard {
+  background: #fff;
+  border: 1px solid var(--arcade-line);
+  padding: 1.25rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 17.5rem;
+}
+
+.lobbyCardHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 0.65rem;
+  border-bottom: 1px solid var(--arcade-line);
+  color: var(--arcade-ink-mute);
+}
+
+.lobbyCardLive {
+  color: var(--arcade-accent);
+}
+
+.roomCodeDisplay {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 900;
+  font-size: clamp(2.6rem, 6vw, 3.6rem);
+  letter-spacing: 0.05em;
+  display: flex;
+  justify-content: center;
+  gap: 0.55rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.roomCodeDisplay span {
+  display: inline-grid;
+  place-items: center;
+  width: 3rem;
+  height: 3.6rem;
+  background: var(--arcade-bg-2);
+  border: 1px solid var(--arcade-line);
+  color: var(--arcade-ink);
+  text-shadow: 2px 2px 0 color-mix(in oklch, var(--arcade-accent) 35%, transparent);
+}
+
+.roomShare {
+  margin-top: auto;
+}
+
+.roomLinkBtn {
+  width: 100%;
+  padding: 0.65rem 0.9rem;
+  background: var(--arcade-bg);
+  color: var(--arcade-ink);
   border: 1px solid var(--arcade-ink);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: all 0.1s;
+}
+
+.roomLinkBtn:hover {
   background: var(--arcade-ink);
-  padding: 2rem;
   color: var(--arcade-bg);
 }
 
-.roomCard::before {
-  content: '';
-  position: absolute;
-  inset: 0.45rem;
-  border: 1px dashed color-mix(in oklch, #fff 30%, transparent);
-  pointer-events: none;
-}
-
-.roomLabel {
-  opacity: 0.65;
-}
-
-.roomCode {
-  font-size: clamp(4rem, 11vw, 6.2rem);
-  line-height: 1;
-  letter-spacing: 0.08em;
-  font-weight: 800;
-  color: var(--arcade-accent);
-  text-shadow: 4px 4px 0 color-mix(in oklch, #fff 18%, transparent);
-}
-
-.roomActions {
+.players {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem;
+  flex-direction: column;
+  gap: 0.4rem;
+  overflow-y: auto;
 }
 
-.roomAction {
-  display: inline-flex;
-  min-width: 10.75rem;
-  justify-content: center;
-  border: 1px solid color-mix(in oklch, #fff 40%, transparent);
+.player {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.5rem 0.65rem;
+  background: var(--arcade-bg-2);
+  border: 1px solid var(--arcade-line);
+}
+
+.playerEmpty {
+  opacity: 0.4;
+}
+
+.playerHost {
+  border-color: var(--arcade-accent);
+}
+
+.playerYou {
+  border-color: var(--arcade-ink);
+}
+
+.playerNum {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  color: var(--arcade-ink-mute);
+  width: 1.5rem;
+  flex-shrink: 0;
+}
+
+.playerAvatar {
+  width: 1.85rem;
+  height: 1.85rem;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.85rem;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.playerAvatarEmpty {
   background: transparent;
-  padding: 0.65rem 0.95rem;
+  border: 1px dashed var(--arcade-line);
+}
+
+.playerName {
+  flex: 1;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.92rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.playerPill {
+  padding: 0.18rem 0.45rem;
+  background: var(--arcade-ink);
+  color: var(--arcade-bg);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.playerPillGhost {
+  background: transparent;
+  color: var(--arcade-ink-mute);
+  border: 1px solid var(--arcade-line);
+}
+
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.setting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.settingLabel {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--arcade-ink-dim);
+}
+
+.segmented {
+  display: flex;
+  border: 1px solid var(--arcade-line);
+}
+
+.segmented button {
+  background: #fff;
+  color: var(--arcade-ink-dim);
+  border: 0;
+  padding: 0.36rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-right: 1px solid var(--arcade-line);
+}
+
+.segmented button:last-child {
+  border-right: 0;
+}
+
+.segmentedOn {
+  background: var(--arcade-ink) !important;
+  color: var(--arcade-bg) !important;
+}
+
+.lobbyCta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.lobbyHostHint {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--arcade-ink-mute);
+}
+
+/* ─── Game board ──────────────────────────────────────────────────────────── */
+
+.table {
+  flex: 1;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: var(--arcade-bg);
+  position: relative;
+  width: 100%;
+  min-height: calc(100dvh - 4rem);
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  border-bottom: 1px solid var(--arcade-line);
+  background: var(--arcade-bg-2);
+  padding: 0.75rem 1.5rem;
+  gap: 1.1rem;
+}
+
+.hudLeft,
+.hudRight {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.hudRight {
+  justify-content: flex-end;
+}
+
+.hudCenter {
+  text-align: center;
+}
+
+.colorPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.36rem 0.75rem;
+  border: 1px solid var(--arcade-ink);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  background: var(--arcade-ink);
+  color: var(--arcade-bg);
+  white-space: nowrap;
+}
+
+.colorPill[data-c='red'] {
+  background: #e53935;
+  color: #fff;
+  border-color: #e53935;
+}
+
+.colorPill[data-c='yellow'] {
+  background: #fdd835;
+  color: #1a1a1a;
+  border-color: #fdd835;
+}
+
+.colorPill[data-c='green'] {
+  background: #43a047;
+  color: #fff;
+  border-color: #43a047;
+}
+
+.colorPill[data-c='blue'] {
+  background: #1e88e5;
+  color: #fff;
+  border-color: #1e88e5;
+}
+
+.colorPillStrong {
+  font-weight: 900;
+}
+
+.direction {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--arcade-ink-dim);
+}
+
+.direction svg {
+  transition: transform 0.4s;
+}
+
+.directionCw svg {
+  transform: rotate(0deg);
+}
+
+.directionCcw svg {
+  transform: scaleX(-1);
+}
+
+.pending {
+  background: var(--arcade-danger);
+  color: #fff;
+  padding: 0.36rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  animation: uno-flash 1s infinite;
+}
+
+@keyframes uno-flash {
+  50% {
+    opacity: 0.7;
+  }
+}
+
+.turn {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.36rem 0.85rem;
+  background: var(--arcade-bg);
+  border: 1px solid var(--arcade-line);
+}
+
+.turnLabel {
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--arcade-ink-mute);
+}
+
+.turnName {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 17.5rem;
+}
+
+.turnIsMe {
+  border-color: var(--arcade-accent);
+  background: color-mix(in oklch, var(--arcade-accent) 12%, transparent);
+}
+
+/* Felt — center play area */
+
+.felt {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 0;
+}
+
+.opponents {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 1.1rem 1.5rem 0.5rem;
+  flex-wrap: wrap;
+}
+
+.opponent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  border: 1px solid var(--arcade-line);
+  background: var(--arcade-bg-2);
+  min-width: 8.75rem;
+  position: relative;
+  transition: all 0.2s;
+}
+
+.opponentActive {
+  border-color: var(--arcade-accent);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--arcade-accent) 50%, transparent);
+}
+
+.opponentHead {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.opponentAvatar {
+  width: 1.75rem;
+  height: 1.75rem;
+  background: var(--arcade-bg);
+  border: 1px solid var(--arcade-line);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.8rem;
   color: #fff;
 }
 
-.roomAction:hover {
+.opponentName {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.88rem;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.opponentCount {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--arcade-ink-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.opponentMiniHand {
+  display: flex;
+  gap: 2px;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.opponentMini {
+  width: 14px;
+  height: 22px;
+  background: var(--arcade-ink);
+  border: 1px solid color-mix(in oklch, var(--arcade-bg) 30%, var(--arcade-ink));
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.opponentMiniLots {
+  width: 9px;
+}
+
+.opponentFlag {
+  position: absolute;
+  top: -0.6rem;
+  right: -0.5rem;
+  background: #fdd835;
+  color: #1a1a1a;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 900;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border: 1px solid #1a1a1a;
+  transform: rotate(8deg);
+  box-shadow: 2px 2px 0 #1a1a1a;
+  letter-spacing: -0.01em;
+}
+
+.opponentFlagCallable {
+  background: #e53935;
+  color: #fff;
+  cursor: pointer;
+  animation: uno-shake 0.6s infinite;
+}
+
+@keyframes uno-shake {
+  0%,
+  100% {
+    transform: rotate(8deg);
+  }
+  50% {
+    transform: rotate(-4deg) scale(1.05);
+  }
+}
+
+/* Center piles */
+
+.piles {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 1.25rem;
+  flex: 1;
+  position: relative;
+}
+
+.piles::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse at center,
+    color-mix(in oklch, var(--arcade-accent) 14%, transparent),
+    transparent 60%
+  );
+  pointer-events: none;
+}
+
+.pile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pileLabel {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--arcade-ink-mute);
+  text-align: center;
+}
+
+.drawStack {
+  position: relative;
+  width: 96px;
+  height: 144px;
+  cursor: pointer;
+}
+
+.drawStack > .cardBack {
+  position: absolute;
+  inset: 0;
+  transition: transform 0.2s;
+}
+
+.drawStack > .cardBack:nth-child(1) {
+  transform: translate(0, 0);
+}
+
+.drawStack > .cardBack:nth-child(2) {
+  transform: translate(2px, 2px);
+  z-index: -1;
+}
+
+.drawStack > .cardBack:nth-child(3) {
+  transform: translate(4px, 4px);
+  z-index: -2;
+}
+
+.drawStack:hover > .cardBack:nth-child(1) {
+  transform: translate(-2px, -4px) rotate(-2deg);
+}
+
+.drawStackDisabled {
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.drawStackMustDraw > .cardBack:nth-child(1) {
+  animation: uno-bob 1s infinite;
+}
+
+@keyframes uno-bob {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(0, -6px);
+  }
+}
+
+.drawCount {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--arcade-ink-dim);
+  text-align: center;
+}
+
+.discard {
+  position: relative;
+  width: 96px;
+  height: 144px;
+}
+
+.discard > .pop {
+  position: absolute;
+  inset: 0;
+  animation: uno-pop 0.4s;
+}
+
+@keyframes uno-pop {
+  0% {
+    transform: translate(-40px, -80px) rotate(-12deg) scale(0.8);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(0, 0) rotate(0) scale(1);
+    opacity: 1;
+  }
+}
+
+/* ─── Cards ───────────────────────────────────────────────────────────────── */
+
+.card {
+  width: 96px;
+  height: 144px;
+  border-radius: 10px;
+  position: relative;
+  font-family: var(--font-display);
+  user-select: none;
+  border: 2px solid #1a1a1a;
+  box-shadow: 3px 3px 0 #1a1a1a;
+  display: block;
+  background: #fff;
+  flex-shrink: 0;
+}
+
+.cardSm {
+  width: 56px;
+  height: 84px;
+  border-radius: 8px;
+}
+
+.cardSm .corner {
+  font-size: 0.7rem;
+}
+
+.cardSm .corner.tl {
+  top: 4px;
+  left: 4px;
+}
+
+.cardSm .corner.br {
+  bottom: 4px;
+  right: 4px;
+}
+
+.cardSm .centerNum {
+  font-size: 1.9rem;
+}
+
+.cardMd {
+  width: 76px;
+  height: 114px;
+}
+
+.cardMd .centerNum {
+  font-size: 2.75rem;
+}
+
+.face {
+  position: absolute;
+  inset: 6px;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ellipse {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 110%;
+  height: 60%;
+  transform: translate(-50%, -50%) rotate(-22deg);
+  background: #fff;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.corner {
+  position: absolute;
+  font-weight: 900;
+  font-style: italic;
+  color: #fff;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
+  font-size: 1rem;
+  line-height: 1;
+  z-index: 2;
+}
+
+.corner.tl {
+  top: 8px;
+  left: 8px;
+}
+
+.corner.br {
+  bottom: 8px;
+  right: 8px;
+  transform: rotate(180deg);
+}
+
+.center {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 1;
+}
+
+.centerNum {
+  font-weight: 900;
+  font-style: italic;
+  font-size: 3.5rem;
+  line-height: 1;
+  color: var(--card-color, #e53935);
+  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.15);
+}
+
+.centerIcon {
+  color: var(--card-color, #e53935);
+  display: inline-flex;
+}
+
+.card[data-c='red'] {
+  --card-color: #e53935;
+  background: #e53935;
+}
+
+.card[data-c='yellow'] {
+  --card-color: #fdd835;
+  background: #fdd835;
+}
+
+.card[data-c='yellow'] .corner {
+  color: #1a1a1a;
+  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.card[data-c='green'] {
+  --card-color: #43a047;
+  background: #43a047;
+}
+
+.card[data-c='blue'] {
+  --card-color: #1e88e5;
+  background: #1e88e5;
+}
+
+.card[data-c='wild'] {
+  background: #1a1a1a;
+}
+
+.card[data-c='wild'] .centerIcon {
+  color: #fff;
+}
+
+.card[data-c='wild'] .ellipse {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.quad {
+  position: absolute;
+  width: 50%;
+  height: 50%;
+}
+
+.quadTl {
+  top: 0;
+  left: 0;
+  background: #e53935;
+  border-top-left-radius: 6px;
+}
+
+.quadTr {
+  top: 0;
+  right: 0;
+  background: #fdd835;
+  border-top-right-radius: 6px;
+}
+
+.quadBl {
+  bottom: 0;
+  left: 0;
+  background: #1e88e5;
+  border-bottom-left-radius: 6px;
+}
+
+.quadBr {
+  bottom: 0;
+  right: 0;
+  background: #43a047;
+  border-bottom-right-radius: 6px;
+}
+
+.card[data-c='wild'] .face::before {
+  content: '';
+  position: absolute;
+  inset: 22%;
+  background: #1a1a1a;
+  border-radius: 50%;
+  z-index: 1;
+}
+
+.cardBack {
+  width: 96px;
+  height: 144px;
+  border-radius: 10px;
+  border: 2px solid #1a1a1a;
+  background: #1a1a1a;
+  position: relative;
+  box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.cardBack::before {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border: 2px solid #fff;
+  border-radius: 6px;
+}
+
+.cardBack::after {
+  content: 'UNO';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) rotate(-22deg);
+  background: #e53935;
+  color: #fff;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 900;
+  font-size: 1.4rem;
+  padding: 0.36rem 0.85rem;
+  border-radius: 30px / 50%;
+  border: 2px solid #fff;
+  letter-spacing: -0.02em;
+}
+
+/* ─── Hand ────────────────────────────────────────────────────────────────── */
+
+.handArea {
+  border-top: 1px solid var(--arcade-line);
+  background: var(--arcade-bg-2);
+  padding: 1.1rem 1.5rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.handMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--arcade-ink-mute);
+}
+
+.handMetaName {
+  color: var(--arcade-ink);
+  font-weight: 700;
+}
+
+.handMetaCount {
+  color: var(--arcade-ink);
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.callBtn {
+  background: #fdd835;
+  color: #1a1a1a;
+  border: 1px solid #1a1a1a;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 900;
+  font-size: 0.88rem;
+  letter-spacing: -0.01em;
+  padding: 0.36rem 1rem;
+  cursor: pointer;
+  transform: rotate(-2deg);
+  box-shadow: 3px 3px 0 #1a1a1a;
+  text-transform: uppercase;
+  transition: all 0.1s;
+}
+
+.callBtnUrgent {
+  animation: uno-shake 0.4s infinite;
+}
+
+.callBtn:hover {
+  transform: rotate(-2deg) translate(-1px, -1px);
+  box-shadow: 4px 4px 0 #1a1a1a;
+}
+
+.callBtnConfirmed {
+  background: #43a047;
+  color: #fff;
+  border-color: #1a1a1a;
+  animation: none;
+  cursor: default;
+}
+
+.hand {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  min-height: 10rem;
+  position: relative;
+  padding: 1rem 0 0;
+  perspective: 1000px;
+  flex-wrap: wrap;
+}
+
+.handCard {
+  margin-left: -32px;
+  transition:
+    transform 0.2s,
+    filter 0.2s,
+    margin 0.2s;
+  cursor: pointer;
+  transform-origin: bottom center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  position: relative;
+}
+
+.handCard:first-child {
+  margin-left: 0;
+}
+
+.handCard:hover {
+  transform: translateY(-14px);
+  z-index: 5;
+}
+
+.handCardUnplayable {
+  filter: grayscale(0.7) brightness(0.6);
+  cursor: not-allowed;
+}
+
+.handCardUnplayable:hover {
+  transform: translateY(-4px);
+}
+
+.handCardPlayable::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -10px;
+  height: 4px;
+  background: var(--arcade-accent);
+  border-radius: 2px;
+}
+
+.handCardDrawn {
+  animation: uno-deal-in 0.4s;
+}
+
+@keyframes uno-deal-in {
+  0% {
+    transform: translate(80px, -40px) rotate(20deg);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(0, 0) rotate(0);
+    opacity: 1;
+  }
+}
+
+.handActions {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  background: var(--arcade-bg);
+  color: var(--arcade-ink);
+  border: 1px solid var(--arcade-ink);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.1s;
+}
+
+.action:hover {
+  background: var(--arcade-ink);
+  color: var(--arcade-bg);
+}
+
+.action:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.actionPrimary {
   background: var(--arcade-accent);
   color: var(--arcade-accent-ink);
 }
 
-.roomMeta {
-  margin-top: auto;
-  opacity: 0.55;
+.actionPrimary:hover {
+  background: var(--arcade-ink);
+  color: var(--arcade-bg);
 }
 
-.lobbySide {
-  grid-area: side;
-  min-height: 0;
-}
+/* ─── Color picker overlay ────────────────────────────────────────────────── */
 
-.playersPanel {
-  display: flex;
-  min-height: 0;
-  height: 100%;
-  flex-direction: column;
-  overflow: hidden;
-  padding: 1.1rem 1.2rem;
-}
-
-.panelHead {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding-bottom: 0.8rem;
-  border-bottom: 1px solid var(--arcade-line);
-  color: var(--arcade-ink-mute);
-}
-
-.playerList {
-  margin-top: 0.9rem;
-  display: flex;
-  min-height: 0;
-  flex-direction: column;
-  gap: 0.55rem;
-  overflow-y: auto;
-  padding-right: 0.25rem;
-}
-
-.playerRow {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  border: 1px solid var(--arcade-line);
-  background: #fff;
-  padding: 0.75rem 0.85rem;
-}
-
-.playerRowYou {
-  border-color: var(--arcade-accent);
-}
-
-.playerAvatar {
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: color-mix(in oklch, var(--arcade-bg) 50%, transparent);
+  backdrop-filter: blur(6px);
   display: grid;
-  width: 2.4rem;
-  height: 2.4rem;
   place-items: center;
-  background: var(--arcade-bg-2);
-}
-
-.playerInfo {
-  min-width: 0;
-  flex: 1;
-}
-
-.playerName {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-weight: 700;
-}
-
-.playerMeta {
-  margin-top: 0.15rem;
-  color: var(--arcade-ink-mute);
-  font-size: 0.76rem;
-}
-
-.playerTags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.playerTag {
-  border: 1px solid var(--arcade-line);
-  padding: 0.2rem 0.35rem;
-  color: var(--arcade-ink-mute);
-  font-size: 0.62rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.playerTagHost {
-  border-color: var(--arcade-highlight);
-  color: var(--arcade-highlight);
-}
-
-.lobbyFooter {
-  grid-area: footer;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.2rem;
-}
-
-.waiting {
-  color: var(--arcade-ink-mute);
-}
-
-.board {
-  width: 100%;
-  display: grid;
-  grid-template-columns: 17rem minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
-}
-
-.tablePanel {
-  min-height: 36rem;
   padding: 1rem;
 }
 
-.scoreHead {
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--arcade-line);
-  padding-bottom: 0.8rem;
-  color: var(--arcade-ink-mute);
-}
-
-.opponents {
-  margin-top: 0.9rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-}
-
-.opponentRow {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.5rem;
-  align-items: center;
-  border: 1px solid var(--arcade-line);
+.picker {
   background: #fff;
-  padding: 0.75rem 0.85rem;
-}
-
-.opponentTurn {
-  border-color: var(--arcade-ink);
-  box-shadow: 3px 3px 0 var(--arcade-accent);
-}
-
-.opponentMeta {
-  color: var(--arcade-ink-mute);
-  font-size: 0.74rem;
-}
-
-.mainColumn {
+  border: 1px solid var(--arcade-ink);
+  padding: 1.75rem 2rem;
   display: flex;
-  min-width: 0;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
+  align-items: center;
+  box-shadow: 6px 6px 0 var(--arcade-ink);
+  max-width: 28.75rem;
+  width: 100%;
 }
 
-.statusBar {
-  padding: 0.85rem 1rem;
+.pickerTitle {
+  font-family: var(--font-display);
   font-weight: 800;
-  text-align: center;
+  font-size: 1.75rem;
+  letter-spacing: -0.02em;
+  margin: 0;
 }
 
-.playArea {
-  position: relative;
+.pickerSubtitle {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--arcade-ink-mute);
+  margin: 0;
+}
+
+.pickerGrid {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 1.2rem;
-  padding: 2rem;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+  width: 100%;
 }
 
-.direction {
+.pickerBtn {
+  height: 5rem;
+  border: 2px solid var(--arcade-ink);
+  cursor: pointer;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 900;
+  font-size: 1.4rem;
+  text-transform: uppercase;
+  color: #fff;
+  letter-spacing: -0.01em;
+  box-shadow: 3px 3px 0 var(--arcade-ink);
+  transition: all 0.1s;
+}
+
+.pickerBtn:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 5px 5px 0 var(--arcade-ink);
+}
+
+.pickerBtn[data-c='red'] {
+  background: #e53935;
+}
+
+.pickerBtn[data-c='yellow'] {
+  background: #fdd835;
+  color: #1a1a1a;
+}
+
+.pickerBtn[data-c='green'] {
+  background: #43a047;
+}
+
+.pickerBtn[data-c='blue'] {
+  background: #1e88e5;
+}
+
+/* ─── Toast banner ────────────────────────────────────────────────────────── */
+
+.toast {
   position: absolute;
-  top: 0.75rem;
-  right: 0.9rem;
-  color: var(--arcade-ink-mute);
+  left: 50%;
+  top: 30%;
+  transform: translate(-50%, 0) rotate(-3deg);
+  background: var(--arcade-ink);
+  color: var(--arcade-accent);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 900;
+  font-size: clamp(1.75rem, 5vw, 3.5rem);
+  padding: 0.5rem 1.75rem;
+  border: 2px solid var(--arcade-ink);
+  pointer-events: none;
+  z-index: 60;
+  animation: uno-toast 1.4s forwards;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
 }
 
-.pile {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.55rem;
+@keyframes uno-toast {
+  0% {
+    transform: translate(-50%, 0) rotate(-3deg) scale(0.6);
+    opacity: 0;
+  }
+  20% {
+    transform: translate(-50%, 0) rotate(-3deg) scale(1.15);
+    opacity: 1;
+  }
+  60% {
+    transform: translate(-50%, 0) rotate(-3deg) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -40px) rotate(-3deg) scale(1);
+    opacity: 0;
+  }
 }
 
-.colorPuck {
-  width: 3rem;
-  height: 3rem;
-  border: 2px solid #fff;
-  box-shadow: 0 0 0 1px var(--arcade-line-strong);
+.toastDanger {
+  background: #e53935;
+  color: #fff;
+  border-color: #fff;
 }
 
-.actionPanel,
-.handPanel {
-  padding: 1rem;
+.toastWin {
+  background: #fdd835;
+  color: #1a1a1a;
 }
 
-.handTitle {
-  margin-bottom: 0.7rem;
-  color: var(--arcade-ink-mute);
-  text-align: center;
-}
+/* ─── Finished screen ─────────────────────────────────────────────────────── */
 
 .endShell {
   width: 100%;
-  max-width: 44rem;
+  max-width: 40rem;
   margin-inline: auto;
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 1.4rem;
-  padding: 2rem;
+  align-items: center;
 }
 
-.endMeta,
-.endCountdown {
+.endTitle {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-style: italic;
+  font-size: clamp(2.6rem, 6vw, 3.75rem);
+  letter-spacing: -0.03em;
+  margin: 0;
+  text-align: center;
+  line-height: 1;
+}
+
+.endSub {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
   color: var(--arcade-ink-mute);
 }
 
-.endWord {
-  color: var(--arcade-ink-dim);
-}
-
-.endWordAccent {
-  color: var(--arcade-highlight);
-  font-weight: 800;
-}
-
-.resultsTable {
+.endBoard {
   width: 100%;
   border: 1px solid var(--arcade-line);
   background: #fff;
 }
 
-.resultRow {
+.endRow {
   display: grid;
-  grid-template-columns: 3rem minmax(0, 1fr) auto auto;
+  grid-template-columns: 2.5rem minmax(0, 1fr) auto auto;
+  gap: 0.85rem;
   align-items: center;
-  gap: 0.8rem;
+  padding: 0.85rem 1.1rem;
   border-bottom: 1px solid var(--arcade-line);
-  padding: 0.8rem 0.95rem;
+  font-family: var(--font-display);
 }
 
-.resultRowWinner {
-  background: color-mix(in oklch, var(--arcade-accent) 15%, #fff);
+.endRow:last-child {
+  border-bottom: 0;
 }
 
-.resultPlayer {
-  min-width: 0;
+.endRowWin {
+  background: #fdd835;
+  color: #1a1a1a;
+}
+
+.endRank {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
   font-weight: 700;
 }
 
-.resultDelta {
+.endName {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.endCardsLeft {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--arcade-ink-mute);
+  text-transform: uppercase;
+}
+
+.endRowWin .endCardsLeft {
+  color: #1a1a1a;
+  opacity: 0.7;
+}
+
+.endScore {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-style: italic;
+  font-size: 1.4rem;
+}
+
+.endActions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+}
+
+.endCountdown {
+  font-family: var(--font-mono);
   color: var(--arcade-ink-mute);
 }
 
-.resultTotal {
-  font-weight: 800;
-}
+/* ─── Responsive ──────────────────────────────────────────────────────────── */
 
 @media (max-width: 960px) {
   .hero,
-  .lobby,
-  .board {
-    grid-template-columns: 1fr;
-    grid-template-areas: none;
-    max-height: none;
-  }
-
-  .roomCard,
-  .lobbySide,
-  .lobbyFooter {
-    grid-area: auto;
-  }
-
-  .playArea {
+  .lobbyGrid,
+  .entryChoiceGrid,
+  .steps {
     grid-template-columns: 1fr;
   }
 
-  .steps,
-  .entryChoiceGrid {
+  .hud {
     grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+
+  .hudLeft,
+  .hudRight {
+    justify-content: center;
+  }
+
+  .hudCenter {
+    text-align: center;
+  }
+
+  .opponents {
+    gap: 0.75rem;
+  }
+
+  .opponent {
+    min-width: 6.875rem;
+  }
+
+  .piles {
+    gap: 1.1rem;
+  }
+
+  .card,
+  .cardBack,
+  .drawStack,
+  .discard {
+    width: 76px;
+    height: 114px;
+  }
+
+  .card .centerNum {
+    font-size: 2.75rem;
+  }
+
+  .handCard {
+    margin-left: -42px;
   }
 }

--- a/src/games/uno/UnoGame.module.css
+++ b/src/games/uno/UnoGame.module.css
@@ -387,22 +387,23 @@
   font-weight: 900;
   font-size: clamp(2.6rem, 6vw, 3.6rem);
   letter-spacing: 0.05em;
-  display: flex;
-  justify-content: center;
-  gap: 0.55rem;
+  text-align: center;
   cursor: pointer;
   user-select: none;
+  white-space: nowrap;
 }
 
 .roomCodeDisplay span {
-  display: inline-grid;
-  place-items: center;
+  display: inline-block;
   width: 3rem;
   height: 3.6rem;
+  line-height: 3.6rem;
+  margin: 0 0.275rem;
   background: var(--arcade-bg-2);
   border: 1px solid var(--arcade-line);
   color: var(--arcade-ink);
   text-shadow: 2px 2px 0 color-mix(in oklch, var(--arcade-accent) 35%, transparent);
+  vertical-align: middle;
 }
 
 .roomShare {
@@ -1554,6 +1555,7 @@
   margin: 0;
   text-align: center;
   line-height: 1;
+  text-transform: uppercase;
 }
 
 .endSub {

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -1059,12 +1059,11 @@ function GameBoard({
         </div>
 
         <div className={styles.piles}>
-          <div className={styles.pile}>
+          <div data-testid="uno-draw-pile" className={styles.pile}>
             <span className={styles.pileLabel}>
               Draw {gameState.pendingDrawCount > 0 && `· must take +${gameState.pendingDrawCount}`}
             </span>
             <div
-              data-testid="uno-draw-pile"
               className={cn(
                 styles.drawStack,
                 (!isMyTurn || hasDrawnCard) && styles.drawStackDisabled,
@@ -1080,12 +1079,12 @@ function GameBoard({
               <span className={styles.cardBack} />
               <span className={styles.cardBack} />
             </div>
-            <span className={styles.drawCount}>{gameState.drawPile.length} left</span>
+            <span className={styles.drawCount}>{gameState.drawPile.length} cards</span>
           </div>
 
-          <div className={styles.pile}>
-            <span className={styles.pileLabel}>Discard</span>
-            <div data-testid="uno-discard-pile" className={styles.discard}>
+          <div data-testid="uno-discard-pile" className={styles.pile}>
+            <span className={styles.pileLabel}>discard</span>
+            <div className={styles.discard}>
               {topCard && (
                 <div key={discardKey} className={styles.pop}>
                   <UnoCard card={topCard} size="lg" />
@@ -1250,7 +1249,7 @@ function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedS
       {isWinner && showConfetti && <ConfettiEffect />}
       <span className={styles.endSub}>/ ROUND OVER · FINAL STANDINGS</span>
       <h2 data-testid="uno-winner-banner" className={styles.endTitle}>
-        {isWinner ? 'YOU WIN' : `${winner?.name?.toUpperCase() ?? 'WINNER'}\n WINS THE ROUND`}
+        {isWinner ? 'You win' : `${winner?.name ?? 'Winner'} wins the round`}
       </h2>
 
       <div className={styles.endBoard}>

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -7,10 +7,7 @@ import { isSupabaseConfigured } from '@/lib/supabase'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { ArcadeShell, arcadeShellStyles } from '@/components/multiplayer/ArcadeShell'
 import { LobbyActions } from '@/components/multiplayer/LobbyActions'
-import { PlayerRoster } from '@/components/multiplayer/PlayerRoster'
-import { ResultsTable } from '@/components/multiplayer/ResultsTable'
 import { ResumeSessionCard } from '@/components/multiplayer/ResumeSessionCard'
-import { RoomInviteCard } from '@/components/multiplayer/RoomInviteCard'
 import type { SavedSessionSummary } from '@/components/multiplayer/ResumeSessionButton'
 import { useUnoRoom } from './useUnoRoom'
 import {
@@ -20,168 +17,217 @@ import {
   redactForPlayer,
   type Card,
   type CardColor,
+  type CardValue,
   type GameState,
+  type Player,
 } from './logic'
 import styles from './UnoGame.module.css'
 
-// ─── Animations (injected once) ─────────────────────────────────────────────
+// ─── Animations not in the CSS module ───────────────────────────────────────
 
 function UnoStyles() {
   return (
     <style>{`
-      @keyframes uno-fade-in {
-        from { opacity: 0; transform: scale(0.9); }
-        to { opacity: 1; transform: scale(1); }
-      }
-      @keyframes uno-slide-up {
-        from { opacity: 0; transform: translateY(20px); }
-        to { opacity: 1; transform: translateY(0); }
-      }
-      @keyframes uno-card-deal {
-        from { opacity: 0; transform: translateY(-30px) rotate(-5deg); }
-        to { opacity: 1; transform: translateY(0) rotate(0deg); }
-      }
-      @keyframes uno-pulse-ring {
-        0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.5); }
-        50% { box-shadow: 0 0 0 8px rgba(239, 68, 68, 0); }
-      }
-      @keyframes uno-bounce-sm {
-        0%, 100% { transform: translateY(0); }
-        50% { transform: translateY(-4px); }
-      }
-      @keyframes uno-discard-pop {
-        0% { transform: scale(0.8) rotate(-8deg); opacity: 0.5; }
-        60% { transform: scale(1.05) rotate(1deg); }
-        100% { transform: scale(1) rotate(0deg); opacity: 1; }
-      }
       @keyframes confetti-fall {
         0% { transform: translateY(-10vh) rotate(0deg); opacity: 1; }
         100% { transform: translateY(100vh) rotate(720deg); opacity: 0; }
       }
-      .animate-uno-fade-in { animation: uno-fade-in 0.3s ease-out; }
-      .animate-uno-slide-up { animation: uno-slide-up 0.35s ease-out; }
-      .animate-uno-card-deal { animation: uno-card-deal 0.3s ease-out both; }
-      .animate-uno-pulse-ring { animation: uno-pulse-ring 1.5s ease-in-out infinite; }
-      .animate-uno-bounce-sm { animation: uno-bounce-sm 0.6s ease-in-out infinite; }
-      .animate-uno-discard-pop { animation: uno-discard-pop 0.35s ease-out; }
-      .uno-hand-scroll { overflow-x: auto; -ms-overflow-style: none; scrollbar-width: none; }
-      .uno-hand-scroll::-webkit-scrollbar { display: none; }
     `}</style>
   )
 }
 
-// ─── Card rendering (sprite-based) ──────────────────────────────────────────
+// ─── Card rendering (markup-based, no sprite sheet) ─────────────────────────
 
-const SPRITE_URL = '/library-games/uno-cards-deck.svg'
+const COLORS: CardColor[] = ['red', 'yellow', 'green', 'blue']
 
-const ACTIVE_COLOR_BG: Record<CardColor, string> = {
-  red: 'bg-red-500',
-  yellow: 'bg-yellow-400',
-  green: 'bg-emerald-500',
-  blue: 'bg-blue-500',
+function cornerLabel(value: CardValue): string {
+  if (typeof value === 'number') return String(value)
+  if (value === 'skip') return 'Ø'
+  if (value === 'reverse') return '⇄'
+  if (value === 'draw2') return '+2'
+  if (value === 'wild') return '★'
+  if (value === 'wild4') return '+4'
+  return ''
 }
 
-/** Map a card to its {row, col} in the sprite grid (14 cols × 8 rows). */
-function getCardSpritePos(card: Card): { row: number; col: number } {
-  const colorRow: Record<string, number> = { red: 0, yellow: 1, green: 2, blue: 3 }
-
-  // Wild cards: row 0, col 13; Wild Draw 4: row 4, col 13
-  if (card.value === 'wild') return { row: 0, col: 13 }
-  if (card.value === 'wild4') return { row: 4, col: 13 }
-
-  const row = colorRow[card.color] ?? 0
-  if (typeof card.value === 'number') {
-    return { row, col: card.value }
+function CardSymbol({ value }: { value: CardValue }) {
+  if (typeof value === 'number') return <span className={styles.centerNum}>{value}</span>
+  if (value === 'skip') {
+    return (
+      <span className={styles.centerIcon}>
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 48 48"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="5"
+        >
+          <circle cx="24" cy="24" r="18" />
+          <path d="M 11 11 L 37 37" />
+        </svg>
+      </span>
+    )
   }
-  const actionCol: Record<string, number> = { skip: 10, reverse: 11, draw2: 12 }
-  return { row, col: actionCol[card.value] ?? 0 }
-}
-
-/** CSS background properties to show a single card from the sprite sheet. */
-function spriteStyle(card: Card): React.CSSProperties {
-  const { row, col } = getCardSpritePos(card)
-  // percentage-based positioning: x = col/(cols-1)*100, y = row/(rows-1)*100
-  const x = (col / 13) * 100
-  const y = (row / 7) * 100
-  return {
-    backgroundImage: `url(${SPRITE_URL})`,
-    backgroundSize: '1400% 800%',
-    backgroundPosition: `${x}% ${y}%`,
-    backgroundRepeat: 'no-repeat',
+  if (value === 'reverse') {
+    return (
+      <span className={styles.centerIcon}>
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 48 48"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="4"
+          strokeLinecap="round"
+        >
+          <path d="M 8 16 L 18 8 L 18 14 L 32 14 Q 40 14 40 22" />
+          <path d="M 40 32 L 30 40 L 30 34 L 16 34 Q 8 34 8 26" />
+        </svg>
+      </span>
+    )
   }
+  if (value === 'draw2') {
+    return (
+      <span className={styles.centerNum} style={{ fontSize: '2.4rem' }}>
+        +2
+      </span>
+    )
+  }
+  if (value === 'wild') {
+    return (
+      <span className={styles.centerIcon} style={{ position: 'relative', zIndex: 2 }}>
+        <svg width="40" height="40" viewBox="0 0 40 40" fill="currentColor">
+          <circle cx="20" cy="20" r="6" />
+        </svg>
+      </span>
+    )
+  }
+  if (value === 'wild4') {
+    return (
+      <span
+        className={styles.centerNum}
+        style={{ fontSize: '2.25rem', color: '#fff', position: 'relative', zIndex: 2 }}
+      >
+        +4
+      </span>
+    )
+  }
+  return null
 }
 
 interface UnoCardProps {
   card: Card
   size?: 'sm' | 'md' | 'lg'
   playable?: boolean
-  selected?: boolean
   faceDown?: boolean
   onClick?: () => void
   className?: string
-  style?: React.CSSProperties
+  testid?: string
+  title?: string
 }
 
 function UnoCard({
   card,
-  size = 'md',
+  size = 'lg',
   playable,
-  selected,
   faceDown,
   onClick,
   className,
-  style,
+  testid,
+  title,
 }: UnoCardProps) {
-  // 2:3 aspect ratio sizes matching actual card proportions
-  const sizeClasses = {
-    sm: 'w-9 h-[3.375rem] rounded-md',
-    md: 'w-[3.25rem] h-[4.875rem] sm:w-14 sm:h-[5.25rem] rounded-lg',
-    lg: 'w-16 h-24 sm:w-[4.75rem] sm:h-[7.125rem] rounded-xl',
+  const sizeClass = size === 'sm' ? styles.cardSm : size === 'md' ? styles.cardMd : ''
+
+  if (faceDown) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(styles.cardBack, sizeClass, className)}
+        title={title ?? 'Face-down card'}
+        data-testid={testid}
+        aria-label="Face-down card"
+      />
+    )
   }
 
+  const Component = onClick ? 'button' : 'div'
   return (
-    <button
-      data-testid={!faceDown && onClick ? 'uno-hand-card' : undefined}
+    <Component
+      type={onClick ? 'button' : undefined}
       onClick={onClick}
-      disabled={!playable && !faceDown && onClick !== undefined}
-      className={cn(
-        'relative overflow-hidden shadow-md transition-all duration-200 select-none',
-        sizeClasses[size],
-        playable &&
-          !selected &&
-          'cursor-pointer hover:-translate-y-2 hover:shadow-xl hover:brightness-110 active:scale-95',
-        selected &&
-          '-translate-y-3 scale-105 cursor-pointer shadow-xl ring-2 ring-white ring-offset-2 ring-offset-black/50',
-        !playable && !faceDown && onClick !== undefined && 'cursor-not-allowed opacity-40',
-        faceDown && 'cursor-default',
-        className
-      )}
-      style={faceDown ? style : { ...spriteStyle(card), ...style }}
-      title={faceDown ? 'Draw pile' : `${card.color} ${card.value}`}
+      disabled={onClick && !playable ? true : undefined}
+      className={cn(styles.card, sizeClass, className)}
+      data-c={card.color}
+      data-testid={testid}
+      title={title ?? `${card.color} ${card.value}`}
     >
-      {faceDown && (
-        <div className="flex h-full w-full items-center justify-center rounded-[inherit] border-2 border-gray-800 bg-gray-900">
-          <div className="absolute inset-[3px] rounded-[inherit] border border-gray-700" />
-          <div className="relative flex h-[55%] w-[65%] items-center justify-center rounded-[50%] bg-red-600 shadow-inner">
-            <span
-              className="text-xs font-black tracking-tight text-yellow-300 sm:text-sm"
-              style={{
-                transform: 'rotate(-15deg)',
-                textShadow: '1px 1px 2px rgba(0,0,0,0.5)',
-              }}
-            >
-              UNO
-            </span>
-          </div>
+      <div className={styles.face}>
+        {card.color === 'wild' ? (
+          <>
+            <span className={cn(styles.quad, styles.quadTl)} />
+            <span className={cn(styles.quad, styles.quadTr)} />
+            <span className={cn(styles.quad, styles.quadBl)} />
+            <span className={cn(styles.quad, styles.quadBr)} />
+          </>
+        ) : (
+          <span className={styles.ellipse} />
+        )}
+        <span className={cn(styles.corner, styles.tl)}>{cornerLabel(card.value)}</span>
+        <div className={styles.center}>
+          <CardSymbol value={card.value} />
         </div>
-      )}
-    </button>
+        <span className={cn(styles.corner, styles.br)}>{cornerLabel(card.value)}</span>
+      </div>
+    </Component>
   )
 }
 
-// ─── Color picker ────────────────────────────────────────────────────────────
+// ─── Color picker overlay ────────────────────────────────────────────────────
 
-const COLORS: CardColor[] = ['red', 'yellow', 'green', 'blue']
+function ColorPicker({
+  onPick,
+  onCancel,
+}: {
+  onPick: (color: CardColor) => void
+  onCancel: () => void
+}) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.picker}>
+        <h3 className={styles.pickerTitle}>Pick a color</h3>
+        <p className={styles.pickerSubtitle}>/ wild card · choose new active color</p>
+        <div className={styles.pickerGrid}>
+          {COLORS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              className={styles.pickerBtn}
+              data-c={c}
+              onClick={() => onPick(c)}
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className={cn(
+            arcadeShellStyles.button,
+            arcadeShellStyles.buttonGhost,
+            arcadeShellStyles.buttonSmall
+          )}
+          onClick={onCancel}
+        >
+          ← Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Crumb ──────────────────────────────────────────────────────────────────
 
 function makeCrumb(
   gameState: GameState | null,
@@ -210,70 +256,30 @@ function makeCrumb(
 
   if (gameState.phase === 'playing') {
     const currentPlayer = getCurrentPlayer(gameState)
+    const turnLabel =
+      currentPlayer?.id === playerId ? 'Your turn' : `${currentPlayer?.name ?? 'Player'}’s turn`
     return (
       <>
-        /{' '}
-        <span className={arcadeShellStyles.crumbAccent}>
-          {currentPlayer?.id === playerId
-            ? 'Your turn'
-            : `${currentPlayer?.name ?? 'Player'}\u2019s turn`}
-        </span>
+        / <span className={arcadeShellStyles.crumbAccent}>{turnLabel}</span>
+        {roomCode && <> · room {roomCode}</>}
       </>
     )
   }
 
   return (
     <>
-      / <span className={arcadeShellStyles.crumbAccent}>Game over</span>
+      / <span className={arcadeShellStyles.crumbAccent}>Round over</span>
+      {roomCode && <> · room {roomCode}</>}
     </>
   )
 }
 
-const COLOR_PICKER_STYLES: Record<CardColor, string> = {
-  red: 'bg-red-500 hover:bg-red-400',
-  yellow: 'bg-yellow-400 hover:bg-yellow-300',
-  green: 'bg-emerald-500 hover:bg-emerald-400',
-  blue: 'bg-blue-500 hover:bg-blue-400',
-}
-
-interface ColorPickerProps {
-  onPick: (color: CardColor) => void
-}
-
-function ColorPicker({ onPick }: ColorPickerProps) {
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="animate-uno-fade-in flex flex-col items-center gap-5 rounded-3xl bg-gray-900/95 p-7 shadow-2xl ring-1 ring-white/10">
-        <p className="text-base font-bold text-white">Choose a color</p>
-        <div className="grid grid-cols-2 gap-4">
-          {COLORS.map((color) => (
-            <button
-              key={color}
-              onClick={() => onPick(color)}
-              className={cn(
-                'h-16 w-16 rounded-full border-[3px] border-white/30 shadow-lg sm:h-20 sm:w-20',
-                'transition-all duration-150 hover:scale-110 hover:border-white/60 active:scale-95',
-                COLOR_PICKER_STYLES[color]
-              )}
-              title={color}
-            >
-              <span className="text-sm font-bold text-white capitalize drop-shadow sm:text-base">
-                {color}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// ─── Screens ─────────────────────────────────────────────────────────────────
+// ─── Setup / loading screens ─────────────────────────────────────────────────
 
 function SetupRequired() {
   return (
     <div className={styles.setup}>
-      <div className="mb-4 text-5xl">🔧</div>
+      <div className="text-5xl">🔧</div>
       <h2>Supabase setup required</h2>
       <p>
         Online multiplayer rooms still run through Supabase. The redesign is ready, but the game
@@ -295,11 +301,97 @@ function InviteResolvingScreen() {
   )
 }
 
+// ─── How-to screen ──────────────────────────────────────────────────────────
+
+const HOWTO_STEPS: Array<{
+  number: string
+  title: string
+  copy: string
+  accent?: boolean
+  icon: React.ReactNode
+}> = [
+  {
+    number: '01 · MATCH',
+    title: 'Color or number',
+    copy: "Play any card sharing the top card's color or face value. Wilds go anytime.",
+    icon: (
+      <svg
+        viewBox="0 0 32 32"
+        width="24"
+        height="24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <rect x="5" y="5" width="11" height="16" rx="1.5" />
+        <rect x="16" y="11" width="11" height="16" rx="1.5" />
+      </svg>
+    ),
+  },
+  {
+    number: '02 · ATTACK',
+    title: 'Skip · Reverse · +2',
+    copy: 'Action cards skip a turn, flip direction, or force a draw. Wild +4 hits hardest.',
+    accent: true,
+    icon: (
+      <svg
+        viewBox="0 0 32 32"
+        width="24"
+        height="24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      >
+        <path d="M 6 16 L 14 8 L 14 13 L 26 13 Q 28 13 28 15" />
+        <path d="M 26 16 L 22 12 M 26 16 L 22 20" />
+      </svg>
+    ),
+  },
+  {
+    number: '03 · CALL UNO',
+    title: 'One card left',
+    copy: 'Call UNO before someone catches you — or draw two as penalty.',
+    icon: (
+      <svg
+        viewBox="0 0 32 32"
+        width="24"
+        height="24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+      >
+        <path d="M 8 22 L 8 10 L 14 22 L 14 10" />
+        <path d="M 18 10 L 18 18 Q 18 22 22 22 Q 26 22 26 18 L 26 10" />
+      </svg>
+    ),
+  },
+  {
+    number: '04 · WIN',
+    title: 'Empty your hand',
+    copy: "First to zero cards wins the round — and adds opponents' card values to their score.",
+    icon: (
+      <svg
+        viewBox="0 0 32 32"
+        width="24"
+        height="24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M 10 6 L 22 6 L 22 14 Q 22 20 16 20 Q 10 20 10 14 Z" />
+        <path d="M 13 22 L 19 22 L 20 26 L 12 26 Z" />
+      </svg>
+    ),
+  },
+]
+
 function HowToScreen({ onStart }: { onStart: () => void }) {
   return (
     <div className={styles.hero}>
       <div className={styles.heroLeft}>
-        <span className={cn(styles.tag, arcadeShellStyles.mono)}>Multiplayer · 2-10 players</span>
+        <span className={cn(styles.tag, arcadeShellStyles.mono)}>Cards · 2–10 players</span>
         <h1 className={styles.heroTitle}>
           Match it.
           <br />
@@ -308,8 +400,8 @@ function HowToScreen({ onStart }: { onStart: () => void }) {
           <span className={styles.heroTitleAccent}>UNO it.</span>
         </h1>
         <p className={styles.heroCopy}>
-          Race to empty your hand in a private online room. Match colors or numbers, drop action
-          cards, call UNO before your friends catch you, and survive the draw piles.
+          Drop cards that match the top of the pile by color or number. Stack action cards to dunk
+          on the next player. First to empty their hand wins the round.
         </p>
         <div className={styles.heroActions}>
           <button
@@ -321,44 +413,26 @@ function HowToScreen({ onStart }: { onStart: () => void }) {
             Play now →
           </button>
           <span className={cn(styles.heroMeta, arcadeShellStyles.mono)}>
-            realtime · private rooms · chaos encouraged
+            ~5 min · 2–10 players · 108 cards
           </span>
         </div>
       </div>
 
       <div className={styles.steps}>
-        {[
-          [
-            '01 · Join',
-            'Grab a room',
-            'Host a private room or enter a four-character invite code.',
-            '▣',
-          ],
-          [
-            '02 · Match',
-            'Play smart',
-            'Match the active color or value. Wilds let you bend the table.',
-            '◆',
-          ],
-          [
-            '03 · Punish',
-            'Stack pressure',
-            'Skip, reverse, and draw cards keep everyone sweating.',
-            '↯',
-          ],
-          ['04 · UNO', 'Say it fast', 'One card left? Call UNO before somebody catches you.', '!'],
-        ].map(([number, title, copy, icon], index) => (
-          <article key={number} className={cn(styles.step, index === 1 && styles.stepAccent)}>
-            <span className={cn(styles.stepNumber, arcadeShellStyles.mono)}>{number}</span>
-            <div className={styles.stepIcon}>{icon}</div>
-            <div className={styles.stepTitle}>{title}</div>
-            <div className={styles.stepDescription}>{copy}</div>
+        {HOWTO_STEPS.map((step) => (
+          <article key={step.number} className={cn(styles.step, step.accent && styles.stepAccent)}>
+            <span className={cn(styles.stepNumber, arcadeShellStyles.mono)}>{step.number}</span>
+            <div className={styles.stepIcon}>{step.icon}</div>
+            <div className={styles.stepTitle}>{step.title}</div>
+            <div className={styles.stepDescription}>{step.copy}</div>
           </article>
         ))}
       </div>
     </div>
   )
 }
+
+// ─── Entry screen ───────────────────────────────────────────────────────────
 
 interface EntryScreenProps {
   onCreate: (name: string) => void
@@ -368,6 +442,7 @@ interface EntryScreenProps {
   loading: boolean
   error: string | null
   initialCode?: string | null
+  onBackToHowTo?: () => void
 }
 
 function EntryScreen({
@@ -379,7 +454,7 @@ function EntryScreen({
   error,
   initialCode,
   onBackToHowTo,
-}: EntryScreenProps & { onBackToHowTo?: () => void }) {
+}: EntryScreenProps) {
   const [name, setName] = useState(getSavedPlayerName)
   const [joinCode, setJoinCode] = useState(initialCode ?? '')
   const [mode, setMode] = useState<'choose' | 'create' | 'join'>(initialCode ? 'join' : 'choose')
@@ -396,12 +471,10 @@ function EntryScreen({
     if (!canSubmit) return
     const trimmedName = name.trim()
     savePlayerName(trimmedName)
-
     if (mode === 'create') {
       onCreate(trimmedName)
       return
     }
-
     onJoin(joinCode.trim().toUpperCase(), trimmedName)
   }
 
@@ -409,8 +482,8 @@ function EntryScreen({
     return (
       <div className={styles.entryShell}>
         <div className={styles.entryHead}>
-          <h2>Ready to play?</h2>
-          <p>Host a new room or jump into a friend&apos;s game with a code.</p>
+          <h2>Ready to deal?</h2>
+          <p>Host a private table or join a friend&apos;s room with a code.</p>
         </div>
 
         {savedSession && onRestore && (
@@ -431,9 +504,23 @@ function EntryScreen({
             className={cn(styles.entryCard, styles.entryCardAccent)}
             onClick={() => setMode('create')}
           >
-            <div className={styles.entryCardTitle}>Create Room</div>
-            <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
-              Host a private game
+            <span className={styles.entryCardIcon}>
+              <svg
+                viewBox="0 0 40 40"
+                width="22"
+                height="22"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+              >
+                <path d="M 20 8 L 20 32 M 8 20 L 32 20" />
+              </svg>
+            </span>
+            <div>
+              <div className={styles.entryCardTitle}>Create Table</div>
+              <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
+                Host a private game
+              </div>
             </div>
           </button>
 
@@ -443,9 +530,23 @@ function EntryScreen({
             className={styles.entryCard}
             onClick={() => setMode('join')}
           >
-            <div className={styles.entryCardTitle}>Join Room</div>
-            <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
-              Enter a 4-char code
+            <span className={styles.entryCardIcon}>
+              <svg
+                viewBox="0 0 40 40"
+                width="22"
+                height="22"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+              >
+                <path d="M 8 20 L 32 20 M 24 12 L 32 20 L 24 28" />
+              </svg>
+            </span>
+            <div>
+              <div className={styles.entryCardTitle}>Join Table</div>
+              <div className={cn(styles.entryCardCopy, arcadeShellStyles.mono)}>
+                Enter a 4-char code
+              </div>
             </div>
           </button>
         </div>
@@ -461,7 +562,7 @@ function EntryScreen({
               )}
               onClick={onBackToHowTo}
             >
-              ← Back to how it works
+              ← Back to how to play
             </button>
           </div>
         )}
@@ -473,8 +574,8 @@ function EntryScreen({
   return (
     <div className={styles.entryShell}>
       <div className={styles.entryHead}>
-        <h2>{isCreate ? 'Create a room' : 'Join a room'}</h2>
-        <p>{isCreate ? "You'll be the host." : 'Ask the host for the room code.'}</p>
+        <h2>{isCreate ? 'New table' : 'Join a table'}</h2>
+        <p>{isCreate ? "You'll get a code to share." : 'Enter the code your friend shared.'}</p>
       </div>
 
       <div className={styles.entryForm}>
@@ -485,13 +586,13 @@ function EntryScreen({
         )}
 
         <label className={styles.field}>
-          <span className={cn(styles.label, arcadeShellStyles.mono)}>Your name</span>
+          <span className={cn(styles.label, arcadeShellStyles.mono)}>Your nickname</span>
           <input
             data-testid="player-name-input"
             value={name}
-            onChange={(event) => setName(event.target.value)}
-            placeholder="e.g. Marble"
-            maxLength={16}
+            onChange={(e) => setName(e.target.value.slice(0, 16))}
+            placeholder="e.g. queen of clubs"
+            autoFocus
             className={arcadeShellStyles.input}
           />
         </label>
@@ -502,17 +603,22 @@ function EntryScreen({
             <input
               data-testid="room-code-input"
               value={joinCode}
-              onChange={(event) =>
-                setJoinCode(event.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))
+              onChange={(e) =>
+                setJoinCode(
+                  e.target.value
+                    .toUpperCase()
+                    .replace(/[^A-Z0-9]/g, '')
+                    .slice(0, 4)
+                )
               }
-              placeholder="AB23"
+              placeholder="X7K2"
               maxLength={4}
               className={cn(arcadeShellStyles.input, styles.codeInput)}
             />
           </label>
         )}
 
-        <div className={styles.entryActions}>
+        <div className={cn(styles.entryActions, styles.entryActionsBetween)}>
           <button
             type="button"
             className={cn(
@@ -531,13 +637,15 @@ function EntryScreen({
             onClick={submit}
             className={arcadeShellStyles.button}
           >
-            {loading ? 'Connecting...' : isCreate ? 'Create room' : 'Join room'}
+            {loading ? 'Connecting…' : isCreate ? 'Create →' : 'Join →'}
           </button>
         </div>
       </div>
     </div>
   )
 }
+
+// ─── Lobby screen ───────────────────────────────────────────────────────────
 
 interface LobbyScreenProps {
   gameState: GameState
@@ -558,54 +666,138 @@ function LobbyScreen({
 }: LobbyScreenProps) {
   const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
   const [copied, setCopied] = useState<'code' | 'link' | null>(null)
+  const inviteLink = getInviteLink('uno', roomCode)
 
   function copyValue(value: string, kind: 'code' | 'link') {
-    navigator.clipboard?.writeText(value).then(
+    if (!navigator.clipboard) return
+    navigator.clipboard.writeText(value).then(
       () => {
         setCopied(kind)
-        window.setTimeout(() => setCopied(null), 1800)
+        window.setTimeout(() => setCopied(null), 1400)
       },
       () => {}
     )
   }
 
-  const rosterPlayers = gameState.players.map((player, index) => ({ ...player, avatar: index % 8 }))
+  const players = gameState.players
+  const slots = Math.max(0, 4 - players.length)
 
   return (
     <div className={styles.lobby}>
-      <RoomInviteCard
-        roomCode={roomCode}
-        inviteLink={getInviteLink('uno', roomCode)}
-        copied={copied}
-        onCopy={copyValue}
-        className={styles.roomCard}
-        titleClassName={cn(styles.roomLabel, arcadeShellStyles.mono)}
-        roomCodeClassName={styles.roomCode}
-        actionsClassName={styles.roomActions}
-        actionClassName={cn(styles.roomAction, arcadeShellStyles.mono)}
-        metaClassName={cn(styles.roomMeta, arcadeShellStyles.mono)}
-      />
+      <div className={styles.lobbyGrid}>
+        <section className={styles.lobbyCard}>
+          <div className={cn(styles.lobbyCardHead, arcadeShellStyles.mono)}>
+            <span>/ ROOM CODE</span>
+          </div>
+          <div
+            data-testid="room-code"
+            className={styles.roomCodeDisplay}
+            role="button"
+            title="Click to copy"
+            onClick={() => copyValue(roomCode, 'code')}
+          >
+            {roomCode.split('').map((c, i) => (
+              <span key={i}>{c}</span>
+            ))}
+          </div>
+          <div className={styles.roomShare}>
+            <button
+              type="button"
+              data-testid="invite-link"
+              data-invite-link={inviteLink}
+              className={cn(styles.roomLinkBtn, arcadeShellStyles.mono)}
+              onClick={() => copyValue(inviteLink, 'link')}
+            >
+              {copied === 'link'
+                ? '✓ link copied!'
+                : copied === 'code'
+                  ? '✓ code copied!'
+                  : 'Copy invite link →'}
+            </button>
+          </div>
+        </section>
 
-      <div className={styles.lobbySide}>
-        <PlayerRoster
-          players={rosterPlayers}
-          currentPlayerId={playerId}
-          onlinePlayerIds={onlinePlayerIds}
-          maxPlayers={10}
-          currentPlayerIsHost={isHost}
-          className={styles.playersPanel}
-          headerClassName={cn(styles.panelHead, arcadeShellStyles.mono)}
-          listClassName={styles.playerList}
-          rowClassName={styles.playerRow}
-          currentPlayerRowClassName={styles.playerRowYou}
-          avatarClassName={styles.playerAvatar}
-          infoClassName={styles.playerInfo}
-          nameClassName={styles.playerName}
-          metaClassName={styles.playerMeta}
-          tagsClassName={styles.playerTags}
-          tagClassName={styles.playerTag}
-          hostTagClassName={styles.playerTagHost}
-        />
+        <section data-testid="player-roster" className={styles.lobbyCard}>
+          <div className={cn(styles.lobbyCardHead, arcadeShellStyles.mono)}>
+            <span>/ TABLE · {players.length}/10</span>
+            <span className={styles.lobbyCardLive}>● LIVE</span>
+          </div>
+          <div className={styles.players}>
+            {players.map((p, i) => {
+              const isYou = p.id === playerId
+              const isOnline = onlinePlayerIds.includes(p.id)
+              return (
+                <div
+                  key={p.id}
+                  className={cn(
+                    styles.player,
+                    p.isHost && styles.playerHost,
+                    isYou && styles.playerYou
+                  )}
+                >
+                  <span className={styles.playerNum}>{String(i + 1).padStart(2, '0')}</span>
+                  <span
+                    className={styles.playerAvatar}
+                    style={{ background: `oklch(0.7 0.18 ${(i * 47) % 360})` }}
+                  >
+                    {p.name.slice(0, 1).toUpperCase()}
+                  </span>
+                  <span className={styles.playerName}>{p.name}</span>
+                  {p.isHost && <span className={styles.playerPill}>HOST</span>}
+                  {isYou && !p.isHost && <span className={styles.playerPill}>YOU</span>}
+                  {!isOnline && (
+                    <span className={cn(styles.playerPill, styles.playerPillGhost)}>OFFLINE</span>
+                  )}
+                </div>
+              )
+            })}
+            {Array.from({ length: slots }).map((_, i) => (
+              <div key={`e${i}`} className={cn(styles.player, styles.playerEmpty)}>
+                <span className={styles.playerNum}>
+                  {String(players.length + i + 1).padStart(2, '0')}
+                </span>
+                <span className={cn(styles.playerAvatar, styles.playerAvatarEmpty)} />
+                <span className={styles.playerName}>waiting…</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.lobbyCard}>
+          <div className={cn(styles.lobbyCardHead, arcadeShellStyles.mono)}>
+            <span>/ HOUSE RULES</span>
+          </div>
+          <div className={styles.settings}>
+            <div className={styles.setting}>
+              <span className={styles.settingLabel}>STACKING</span>
+              <div className={styles.segmented}>
+                <button type="button" className={styles.segmentedOn}>
+                  ON
+                </button>
+                <button type="button">OFF</button>
+              </div>
+            </div>
+            <div className={styles.setting}>
+              <span className={styles.settingLabel}>DRAW UNTIL PLAY</span>
+              <div className={styles.segmented}>
+                <button type="button">ON</button>
+                <button type="button" className={styles.segmentedOn}>
+                  OFF
+                </button>
+              </div>
+            </div>
+            <div className={styles.setting}>
+              <span className={styles.settingLabel}>TARGET</span>
+              <div className={styles.segmented}>
+                <button type="button">250</button>
+                <button type="button" className={styles.segmentedOn}>
+                  500
+                </button>
+                <button type="button">1000</button>
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
 
       <LobbyActions
@@ -613,8 +805,12 @@ function LobbyScreen({
         canStart={gameState.players.length >= 2}
         onLeave={onLeave}
         onStart={onStart}
-        className={styles.lobbyFooter}
-        statusClassName={cn(styles.waiting, arcadeShellStyles.mono)}
+        leaveLabel="← Leave table"
+        startLabel={`Deal ${gameState.players.length} hands →`}
+        hostLabel=""
+        guestLabel="Waiting for host to deal"
+        className={styles.lobbyCta}
+        statusClassName={cn(styles.lobbyHostHint, arcadeShellStyles.mono)}
         actionsClassName={styles.entryActions}
         leaveButtonClassName={cn(
           arcadeShellStyles.button,
@@ -627,7 +823,7 @@ function LobbyScreen({
   )
 }
 
-// ─── Game Board ──────────────────────────────────────────────────────────────
+// ─── Game board ─────────────────────────────────────────────────────────────
 
 interface GameBoardProps {
   gameState: GameState
@@ -639,6 +835,13 @@ interface GameBoardProps {
   onSayUno: () => void
   onCatchUno: (targetId: string) => void
   onLeave: () => void
+}
+
+const ACTION_TOAST: Partial<Record<CardValue, { msg: string; kind: '' | 'danger' | 'win' }>> = {
+  skip: { msg: 'SKIPPED!', kind: 'danger' },
+  reverse: { msg: 'REVERSED!', kind: '' },
+  draw2: { msg: '+2!', kind: 'danger' },
+  wild4: { msg: 'WILD +4!', kind: 'danger' },
 }
 
 function GameBoard({
@@ -654,8 +857,15 @@ function GameBoard({
 }: GameBoardProps) {
   const [pendingWild, setPendingWild] = useState<string | null>(null)
   const [discardKey, setDiscardKey] = useState(0)
+  const [toast, setToast] = useState<{
+    msg: string
+    kind: '' | 'danger' | 'win'
+    k: number
+  } | null>(null)
   const prevTopCardRef = useRef<string | null>(null)
+  const isFirstRenderRef = useRef(true)
 
+  const me = gameState.players.find((p) => p.id === playerId)
   const currentPlayer = getCurrentPlayer(gameState)
   const isMyTurn = currentPlayer?.id === playerId
   const myHand = gameState.hands[playerId] ?? []
@@ -667,10 +877,21 @@ function GameBoard({
   const topCardId = topCard?.id ?? null
   useEffect(() => {
     if (topCardId !== prevTopCardRef.current) {
-      setDiscardKey((k) => k + 1)
+      const wasFirst = isFirstRenderRef.current
+      isFirstRenderRef.current = false
       prevTopCardRef.current = topCardId
+
+      if (!wasFirst && topCard) {
+        setDiscardKey((k) => k + 1)
+        const t = ACTION_TOAST[topCard.value]
+        if (t) {
+          setToast({ msg: t.msg, kind: t.kind, k: Math.random() })
+          const timer = window.setTimeout(() => setToast(null), 1400)
+          return () => window.clearTimeout(timer)
+        }
+      }
     }
-  }, [topCardId])
+  }, [topCardId, topCard])
 
   const playableIds =
     isMyTurn && topCard
@@ -699,22 +920,15 @@ function GameBoard({
     }
   }
 
-  const statusText = !isMyTurn
-    ? `${currentPlayer?.name ?? '?'}'s turn`
-    : mustDraw
-      ? `You must draw ${gameState.pendingDrawCount} cards`
-      : hasDrawnCard
-        ? 'Play the drawn card or pass'
-        : 'Your turn — play a card or draw'
-
+  // catch-uno window watcher
   const [now, setNow] = useState(Date.now)
   useEffect(() => {
     const windows = Object.values(gameState.unoWindow)
     const nextExpiry = windows.filter((w) => w > Date.now()).sort((a, b) => a - b)[0]
     if (!nextExpiry) return
     const delay = nextExpiry - Date.now()
-    const timer = setTimeout(() => setNow(Date.now()), delay + 50)
-    return () => clearTimeout(timer)
+    const timer = window.setTimeout(() => setNow(Date.now()), delay + 50)
+    return () => window.clearTimeout(timer)
   }, [gameState.unoWindow])
 
   const catchableTargets = otherPlayers.filter((p) => {
@@ -723,188 +937,271 @@ function GameBoard({
     return hand.length === 1 && !gameState.calledUno.includes(p.id) && now >= windowUntil
   })
 
-  return (
-    <div className={styles.board}>
-      {pendingWild && <ColorPicker onPick={handleColorPick} />}
+  const turnLabel = isMyTurn ? 'YOUR TURN' : `${(currentPlayer?.name ?? '').toUpperCase()}'S TURN`
+  const directionClass = gameState.direction === 1 ? styles.directionCw : styles.directionCcw
+  const calledMyself = gameState.calledUno.includes(playerId)
 
-      <aside className={styles.tablePanel}>
-        <div className={cn(styles.scoreHead, arcadeShellStyles.mono)}>
-          <span>Players</span>
-          <span>{gameState.players.length} / 10</span>
+  const statusText = !isMyTurn
+    ? 'wait for your turn'
+    : mustDraw
+      ? `must take +${gameState.pendingDrawCount}`
+      : hasDrawnCard
+        ? 'play drawn card or pass'
+        : playableIds.size > 0
+          ? `${playableIds.size} playable`
+          : 'no plays — must draw'
+
+  return (
+    <div className={styles.table}>
+      {pendingWild && (
+        <ColorPicker onPick={handleColorPick} onCancel={() => setPendingWild(null)} />
+      )}
+
+      <div className={styles.hud}>
+        <div className={styles.hudLeft}>
+          <div className={cn(styles.turn, isMyTurn && styles.turnIsMe)}>
+            <span className={styles.turnLabel}>{isMyTurn ? '▶ YOU' : '▶'}</span>
+            <span className={styles.turnName}>{turnLabel}</span>
+          </div>
+          <div className={cn(styles.direction, directionClass)}>
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <path d="M 4 10 Q 4 4 10 4 Q 16 4 16 10" />
+              <path d="M 14 6 L 16 4 L 18 6" />
+            </svg>
+            <span>{gameState.direction === 1 ? 'clockwise' : 'reversed'}</span>
+          </div>
         </div>
+
+        <div className={styles.hudCenter}>
+          <div className={styles.colorPill} data-c={gameState.currentColor}>
+            <span>active color</span>
+            <span className={styles.colorPillStrong}>{gameState.currentColor}</span>
+          </div>
+        </div>
+
+        <div className={styles.hudRight}>
+          {gameState.pendingDrawCount > 0 && (
+            <span className={styles.pending}>
+              +{gameState.pendingDrawCount} pending — must draw
+            </span>
+          )}
+          <button
+            type="button"
+            className={styles.action}
+            onClick={onLeave}
+            data-testid="leave-room-button"
+          >
+            Leave
+          </button>
+        </div>
+      </div>
+
+      <div data-testid="uno-status" className="sr-only">
+        {isMyTurn ? 'Your turn' : `${currentPlayer?.name ?? '?'}'s turn`}
+      </div>
+
+      <div className={styles.felt}>
         <div className={styles.opponents}>
-          {otherPlayers.map((p) => {
+          {otherPlayers.map((p, i) => {
             const hand = gameState.hands[p.id] ?? []
             const isTurn = currentPlayer?.id === p.id
             const calledUno = gameState.calledUno.includes(p.id)
             const isCatchable = catchableTargets.includes(p)
             const isOnline = onlinePlayerIds.includes(p.id)
-
+            const showFlag = hand.length === 1 && calledUno
             return (
-              <div key={p.id} className={cn(styles.opponentRow, isTurn && styles.opponentTurn)}>
-                <div>
-                  <div className={styles.playerName}>{p.name}</div>
-                  <div className={styles.opponentMeta}>
-                    {isOnline ? 'online' : 'offline'} · {hand.length} cards
-                  </div>
+              <div key={p.id} className={cn(styles.opponent, isTurn && styles.opponentActive)}>
+                <div className={styles.opponentHead}>
+                  <span
+                    className={styles.opponentAvatar}
+                    style={{ background: `oklch(0.7 0.18 ${(i * 47 + 90) % 360})` }}
+                  >
+                    {p.name.slice(0, 1).toUpperCase()}
+                  </span>
+                  <span className={styles.opponentName} title={isOnline ? 'online' : 'offline'}>
+                    {p.name}
+                  </span>
+                  <span className={styles.opponentCount}>{hand.length}</span>
                 </div>
-                <div className={styles.playerTags}>
-                  {isTurn && (
-                    <span className={cn(styles.playerTag, styles.playerTagHost)}>turn</span>
-                  )}
-                  {calledUno && <span className={styles.playerTag}>UNO</span>}
-                  {isCatchable && (
-                    <button
-                      type="button"
-                      onClick={() => onCatchUno(p.id)}
-                      className={cn(styles.playerTag, styles.playerTagHost)}
-                    >
-                      catch
-                    </button>
-                  )}
+                <div className={styles.opponentMiniHand}>
+                  {Array.from({ length: Math.min(hand.length, 7) }).map((_, j) => (
+                    <div
+                      key={j}
+                      className={cn(
+                        styles.opponentMini,
+                        hand.length > 5 && styles.opponentMiniLots
+                      )}
+                    />
+                  ))}
                 </div>
+                {showFlag && <span className={styles.opponentFlag}>UNO!</span>}
+                {isCatchable && (
+                  <span
+                    role="button"
+                    title="Catch them!"
+                    className={cn(styles.opponentFlag, styles.opponentFlagCallable)}
+                    onClick={() => onCatchUno(p.id)}
+                  >
+                    CATCH +2
+                  </span>
+                )}
               </div>
             )
           })}
         </div>
-      </aside>
 
-      <div className={styles.mainColumn}>
-        <div data-testid="uno-status" className={cn(styles.statusBar, arcadeShellStyles.mono)}>
-          {isMyTurn && (
-            <span className="mr-2 inline-block h-2 w-2 animate-pulse rounded-full bg-current" />
-          )}
-          {statusText}
-        </div>
-
-        <div className={styles.playArea}>
-          <div className={cn(styles.direction, arcadeShellStyles.mono)}>
-            <span style={{ transform: gameState.direction === 1 ? 'scaleX(1)' : 'scaleX(-1)' }}>
-              →
-            </span>{' '}
-            {gameState.direction === 1 ? 'clockwise' : 'counter-clockwise'}
-          </div>
-
-          <div data-testid="uno-draw-pile" className={styles.pile}>
-            <div className="relative">
-              <div className="absolute -top-0.5 -right-0.5 h-full w-full border-2 border-gray-300 bg-gray-200" />
-              <div className="relative">
-                <UnoCard
-                  card={{ id: 'draw', color: 'wild', value: 'wild' }}
-                  size="lg"
-                  faceDown
-                  playable={isMyTurn && !hasDrawnCard}
-                  onClick={isMyTurn && !hasDrawnCard ? onDraw : undefined}
-                />
-              </div>
+        <div className={styles.piles}>
+          <div className={styles.pile}>
+            <span className={styles.pileLabel}>
+              Draw {gameState.pendingDrawCount > 0 && `· must take +${gameState.pendingDrawCount}`}
+            </span>
+            <div
+              data-testid="uno-draw-pile"
+              className={cn(
+                styles.drawStack,
+                (!isMyTurn || hasDrawnCard) && styles.drawStackDisabled,
+                mustDraw && styles.drawStackMustDraw
+              )}
+              onClick={() => {
+                if (!isMyTurn || hasDrawnCard) return
+                onDraw()
+              }}
+              role="button"
+            >
+              <span className={styles.cardBack} />
+              <span className={styles.cardBack} />
+              <span className={styles.cardBack} />
             </div>
-            <span className={arcadeShellStyles.mono}>{gameState.drawPile.length} cards</span>
+            <span className={styles.drawCount}>{gameState.drawPile.length} left</span>
           </div>
 
           <div className={styles.pile}>
-            <div
-              className={cn(styles.colorPuck, ACTIVE_COLOR_BG[gameState.currentColor])}
-              title={`Current color: ${gameState.currentColor}`}
-            />
-            <span className={cn(styles.label, arcadeShellStyles.mono)}>
-              {gameState.currentColor}
-            </span>
-          </div>
-
-          <div data-testid="uno-discard-pile" className={styles.pile}>
-            {topCard && (
-              <div key={discardKey} className="animate-uno-discard-pop">
-                <UnoCard card={topCard} size="lg" />
-              </div>
-            )}
-            <span className={cn(styles.label, arcadeShellStyles.mono)}>discard</span>
+            <span className={styles.pileLabel}>Discard</span>
+            <div data-testid="uno-discard-pile" className={styles.discard}>
+              {topCard && (
+                <div key={discardKey} className={styles.pop}>
+                  <UnoCard card={topCard} size="lg" />
+                </div>
+              )}
+            </div>
+            <span className={styles.drawCount}>{gameState.discardPile.length} cards</span>
           </div>
         </div>
 
-        <div className={styles.actionPanel}>
-          <div className={styles.entryActions}>
-            {isMyTurn && !hasDrawnCard && (
-              <button
-                type="button"
-                onClick={onDraw}
-                className={cn(
-                  arcadeShellStyles.button,
-                  arcadeShellStyles.buttonSmall,
-                  mustDraw && 'animate-uno-bounce-sm'
-                )}
-              >
-                {mustDraw ? `Draw ${gameState.pendingDrawCount}` : 'Draw card'}
-              </button>
+        {toast && (
+          <div
+            key={toast.k}
+            className={cn(
+              styles.toast,
+              toast.kind === 'danger' && styles.toastDanger,
+              toast.kind === 'win' && styles.toastWin
             )}
+          >
+            {toast.msg}
+          </div>
+        )}
+      </div>
 
-            {hasDrawnCard && (
-              <button
-                type="button"
-                onClick={onPassAfterDraw}
-                className={cn(arcadeShellStyles.button, arcadeShellStyles.buttonSmall)}
-              >
-                Pass
-              </button>
-            )}
-
-            {myHand.length === 1 && !gameState.calledUno.includes(playerId) && (
-              <button type="button" onClick={onSayUno} className={arcadeShellStyles.button}>
-                UNO!
-              </button>
-            )}
-
+      <div className={styles.handArea}>
+        <div className={styles.handMeta}>
+          <span>
+            <span className={styles.handMetaName}>{me?.name ?? 'You'}</span> ·{' '}
+            <span className={styles.handMetaCount}>{myHand.length}</span> cards
+          </span>
+          <span>{statusText}</span>
+          {myHand.length === 2 && !calledMyself && (
             <button
-              data-testid="leave-room-button"
               type="button"
-              onClick={onLeave}
-              className={cn(
-                arcadeShellStyles.button,
-                arcadeShellStyles.buttonGhost,
-                arcadeShellStyles.buttonSmall
-              )}
+              className={cn(styles.callBtn, styles.callBtnUrgent)}
+              onClick={onSayUno}
             >
-              Leave
+              UNO!
+            </button>
+          )}
+          {myHand.length === 1 && !calledMyself && (
+            <button
+              type="button"
+              className={cn(styles.callBtn, styles.callBtnUrgent)}
+              onClick={onSayUno}
+            >
+              SAY UNO!
+            </button>
+          )}
+          {myHand.length === 1 && calledMyself && (
+            <button type="button" className={cn(styles.callBtn, styles.callBtnConfirmed)} disabled>
+              UNO ✓
+            </button>
+          )}
+        </div>
+
+        <div className={styles.hand}>
+          {myHand.map((card) => {
+            const ok = playableIds.has(card.id)
+            const isDrawn = card.id === gameState.drawnCardId
+            return (
+              <button
+                key={card.id}
+                type="button"
+                data-testid="uno-hand-card"
+                className={cn(
+                  styles.handCard,
+                  ok && styles.handCardPlayable,
+                  !ok && styles.handCardUnplayable,
+                  isDrawn && styles.handCardDrawn
+                )}
+                onClick={() => handleCardClick(card)}
+              >
+                <UnoCard card={card} size="lg" />
+              </button>
+            )
+          })}
+        </div>
+
+        {isMyTurn && hasDrawnCard && (
+          <div className={styles.handActions}>
+            <button
+              type="button"
+              className={cn(styles.action, styles.actionPrimary)}
+              onClick={onPassAfterDraw}
+            >
+              Keep & pass turn →
             </button>
           </div>
-        </div>
-
-        <div className={styles.handPanel}>
-          <p className={cn(styles.handTitle, arcadeShellStyles.mono)}>
-            Your hand ({myHand.length}){hasDrawnCard && <span> — play drawn card or pass</span>}
-          </p>
-          <div className="uno-hand-scroll p-4 pt-5">
-            <div className="mx-auto flex w-fit items-end justify-center">
-              {myHand.map((card, i) => {
-                const isDrawn = card.id === gameState.drawnCardId
-                return (
-                  <div
-                    key={card.id}
-                    className={cn(
-                      'transition-all duration-200',
-                      i > 0 && '-ml-2 sm:-ml-3',
-                      isDrawn && 'relative z-10'
-                    )}
-                    style={{ animationDelay: `${i * 30}ms` }}
-                  >
-                    <UnoCard
-                      card={card}
-                      size="md"
-                      playable={isMyTurn && playableIds.has(card.id)}
-                      onClick={() => handleCardClick(card)}
-                      className={cn(isDrawn && 'ring-2 ring-[var(--arcade-accent)] ring-offset-1')}
-                    />
-                  </div>
-                )
-              })}
+        )}
+        {isMyTurn &&
+          !hasDrawnCard &&
+          playableIds.size === 0 &&
+          gameState.pendingDrawCount === 0 && (
+            <div className={styles.handActions}>
+              <button
+                type="button"
+                className={cn(styles.action, styles.actionPrimary)}
+                onClick={onDraw}
+              >
+                Draw a card →
+              </button>
             </div>
-          </div>
-        </div>
+          )}
       </div>
     </div>
   )
 }
 
-// ─── Finished screen ─────────────────────────────────────────────────────────
+// ─── Finished screen ────────────────────────────────────────────────────────
+
+function cardScoreValue(card: Card): number {
+  if (typeof card.value === 'number') return card.value
+  if (card.value === 'skip' || card.value === 'reverse' || card.value === 'draw2') return 20
+  return 50
+}
 
 interface FinishedScreenProps {
   gameState: GameState
@@ -914,65 +1211,77 @@ interface FinishedScreenProps {
 }
 
 function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedScreenProps) {
-  const sortedPlayers = [...gameState.players].sort(
-    (left, right) =>
-      (gameState.hands[left.id]?.length ?? 0) - (gameState.hands[right.id]?.length ?? 0)
-  )
-  const winner = gameState.players.find((p) => p.id === gameState.winnerId) ?? sortedPlayers[0]
+  const winner: Player | undefined =
+    gameState.players.find((p) => p.id === gameState.winnerId) ?? gameState.players[0]
   const isWinner = gameState.winnerId === playerId
   const isHost = gameState.players.find((p) => p.id === playerId)?.isHost ?? false
   const [showConfetti, setShowConfetti] = useState(true)
 
   useEffect(() => {
-    const t = setTimeout(() => setShowConfetti(false), 3000)
-    return () => clearTimeout(t)
+    const t = window.setTimeout(() => setShowConfetti(false), 3000)
+    return () => window.clearTimeout(t)
   }, [])
+
+  const winnerScore = useMemo(() => {
+    if (!winner) return 0
+    return Object.entries(gameState.hands)
+      .filter(([id]) => id !== winner.id)
+      .reduce((sum, [, hand]) => sum + hand.reduce((a, c) => a + cardScoreValue(c), 0), 0)
+  }, [gameState.hands, winner])
+
+  const sortedRows = useMemo(() => {
+    const rows = gameState.players.map((p) => ({
+      id: p.id,
+      name: p.name,
+      isHost: p.isHost,
+      cards: gameState.hands[p.id]?.length ?? 0,
+      score: p.id === winner?.id ? winnerScore : 0,
+      isWinner: p.id === winner?.id,
+    }))
+    rows.sort((a, b) => {
+      if (a.isWinner !== b.isWinner) return a.isWinner ? -1 : 1
+      return a.cards - b.cards
+    })
+    return rows
+  }, [gameState.players, gameState.hands, winner, winnerScore])
 
   return (
     <div className={styles.endShell}>
       {isWinner && showConfetti && <ConfettiEffect />}
-      <p className={cn(styles.endMeta, arcadeShellStyles.mono)}>Game over · final standings</p>
+      <span className={styles.endSub}>/ ROUND OVER · FINAL STANDINGS</span>
       <h2 data-testid="uno-winner-banner" className={styles.endTitle}>
-        {isWinner ? 'You win' : `${winner?.name ?? 'Winner'} wins`}
+        {isWinner ? 'YOU WIN' : `${winner?.name?.toUpperCase() ?? 'WINNER'}\n WINS THE ROUND`}
       </h2>
-      <p className={styles.endWord}>
-        with <span className={styles.endWordAccent}>zero cards</span> left
-      </p>
 
-      <ResultsTable
-        rows={sortedPlayers.map((player, index) => ({
-          id: player.id,
-          rankLabel: player.id === winner?.id ? '👑' : index + 1,
-          name: player.name,
-          avatar: index % 8,
-          secondaryLabel: player.id === winner?.id ? 'Winner' : '',
-          totalLabel: gameState.hands[player.id]?.length ?? 0,
-          isWinner: player.id === winner?.id,
-        }))}
-        className={styles.resultsTable}
-        rowClassName={styles.resultRow}
-        winnerRowClassName={styles.resultRowWinner}
-        rankClassName={cn(styles.resultTotal, arcadeShellStyles.mono)}
-        playerClassName={styles.resultPlayer}
-        secondaryClassName={styles.resultDelta}
-        totalClassName={styles.resultTotal}
-      />
+      <div className={styles.endBoard}>
+        {sortedRows.map((row, i) => (
+          <div key={row.id} className={cn(styles.endRow, row.isWinner && styles.endRowWin)}>
+            <span className={styles.endRank}>{String(i + 1).padStart(2, '0')}</span>
+            <span className={styles.endName}>{row.name}</span>
+            <span className={styles.endCardsLeft}>
+              {row.cards} card{row.cards === 1 ? '' : 's'} left
+            </span>
+            <span className={styles.endScore}>+{row.score}</span>
+          </div>
+        ))}
+      </div>
 
       <div className={styles.endActions}>
         <button
           type="button"
           onClick={onLeave}
+          data-testid="leave-room-button"
           className={cn(
             arcadeShellStyles.button,
             arcadeShellStyles.buttonGhost,
             arcadeShellStyles.buttonSmall
           )}
         >
-          Back to library
+          ← Back to Library
         </button>
         {isHost ? (
           <button type="button" onClick={onPlayAgain} className={arcadeShellStyles.button}>
-            Play again
+            Deal again →
           </button>
         ) : (
           <span className={cn(styles.endCountdown, arcadeShellStyles.mono)}>waiting for host</span>
@@ -982,26 +1291,24 @@ function FinishedScreen({ gameState, playerId, onPlayAgain, onLeave }: FinishedS
   )
 }
 
-function generateConfettiParticles() {
-  return Array.from({ length: 30 }, (_, i) => ({
-    id: i,
-    left: Math.random() * 100,
-    delay: Math.random() * 0.5,
-    duration: 1.5 + Math.random() * 1.5,
-    color: ['#ef4444', '#eab308', '#22c55e', '#3b82f6'][i % 4],
-    size: 4 + Math.random() * 6,
-  }))
-}
-
 function ConfettiEffect() {
-  const [particles] = useState(generateConfettiParticles)
+  const [particles] = useState(() =>
+    Array.from({ length: 30 }, (_, i) => ({
+      id: i,
+      left: Math.random() * 100,
+      delay: Math.random() * 0.5,
+      duration: 1.5 + Math.random() * 1.5,
+      color: ['#e53935', '#fdd835', '#43a047', '#1e88e5'][i % 4],
+      size: 4 + Math.random() * 6,
+    }))
+  )
 
   return (
     <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden">
       {particles.map((p) => (
         <div
           key={p.id}
-          className="absolute rounded-sm"
+          className="absolute"
           style={{
             left: `${p.left}%`,
             width: p.size,
@@ -1015,7 +1322,7 @@ function ConfettiEffect() {
   )
 }
 
-// ─── Main component ──────────────────────────────────────────────────────────
+// ─── Main component ─────────────────────────────────────────────────────────
 
 export function UnoGame() {
   const inviteCode = useInviteCode()
@@ -1051,27 +1358,17 @@ export function UnoGame() {
   const isLoading = status === 'creating' || status === 'joining' || status === 'restoring'
   const isEntryState = !gameState || !playerId || !roomCode
   const isResolvingInvite = isEntryState && !inviteCodeResolved
+  const inGame = !isEntryState && gameState.phase === 'playing'
 
-  const handleCreate = useCallback(
-    (name: string) => {
-      void createRoom(name)
-    },
-    [createRoom]
-  )
-
+  const handleCreate = useCallback((name: string) => void createRoom(name), [createRoom])
   const handleJoin = useCallback(
-    (code: string, name: string) => {
-      void joinRoom(code, name)
-    },
+    (code: string, name: string) => void joinRoom(code, name),
     [joinRoom]
   )
-
-  const handleLeave = useCallback(() => {
-    void leaveRoom()
-  }, [leaveRoom])
+  const handleLeave = useCallback(() => void leaveRoom(), [leaveRoom])
 
   return (
-    <ArcadeShell title="Uno" crumb={crumb} centered>
+    <ArcadeShell title="Uno" crumb={crumb} centered={!inGame}>
       <UnoStyles />
       {!isSupabaseConfigured ? (
         <SetupRequired />


### PR DESCRIPTION
## Summary

- Port the new Uno design ([Anthropic Design handoff](https://api.anthropic.com/v1/design/h/Mzgm_16HBg0aR2XaXX-jsQ?open_file=Uno.html)) onto the existing Supabase-backed Uno game.
- Visual layer only — game logic (`logic.ts`), schema, `useUnoRoom` hook, route, and game metadata are unchanged.
- All `data-testid`s preserved (`uno-status`, `uno-hand-card`, `uno-draw-pile`, `uno-discard-pile`, `uno-winner-banner`, `room-code`, `player-roster`, `invite-link`, `play-game-button`, `create-room-button`, `join-room-button`, `room-code-input`, `player-name-input`, `room-error`, `start-game-button`, `leave-room-button`).

## What changed

**`src/games/uno/UnoGame.module.css`** — replaced with a port of the design's `uno-styles.css`. Adds card geometry, table-felt board layout, and end-of-round leaderboard. Keeps `var(--arcade-*)` tokens so theme switching still works.

**`src/games/uno/UnoGame.tsx`** — every screen rebuilt to match the design:
- **HowTo**: 2-col hero ("Match it. Stack it. UNO it.") + 4 step cards (MATCH / ATTACK / CALL UNO / WIN) with mono numbers and SVG icons.
- **Entry**: choose → create/join with two big tile buttons; nickname + 4-char monospace room-code input; resume-session card retained.
- **Lobby**: 3-column grid — stylized room-code tiles (click-to-copy), live player roster with numbered slots and OKLCH avatars, segmented house-rule toggles (visual-only); host CTA "Deal {N} hands →".
- **GameBoard**: HUD (turn pill + direction indicator + active-color pill + flashing pending banner + Leave); felt with opponent cards (avatar / name / count / mini face-down stack / UNO! flag / red shake CATCH +2); centered piles with radial acid glow + draw-stack triple-card depth + discard pop animation; toast announcer (`SKIPPED!` / `REVERSED!` / `+2!` / `WILD +4!`); fanned hand with -32px overlap, hover lift, acid playable underline, greyed unplayable, rotated yellow UNO! / SAY UNO! / UNO ✓ button; modal color picker for wilds.
- **Finished**: italic round-over headline + leaderboard with winner highlight + score totals.

Switched the GameBoard to fullbleed (`centered={false}`) only while in `playing`. Replaced the SVG sprite-sheet card renderer with markup-based cards (italic UNO logo + ellipse + corner labels + action SVGs / striped wild quadrants).

## Out of scope

- The design's prototype Tweaks panel (theme/hue/bot speed sliders) — would need schema changes.
- The lobby segmented toggles are visual-only placeholders.
- The unused `public/uno-cards-deck.svg` sprite is left in place (separate cleanup).

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 605/605 pass across 30 suites (including `UnoGame.test.tsx`, `logic.test.ts`, `schema.test.ts`)
- [x] `pnpm exec tsc --noEmit` — clean for Uno code (one pre-existing error in `e2e/games/skribbl.spec.ts` is unrelated)
- [x] `pnpm dev` — `/games/uno` compiles and serves 200
- [ ] Manual: HowTo → Entry → Create Room → second tab joins via invite link → host deals → play through skip/reverse/+2/wild/wild4 (toast banner, color picker, catch +2 flow) → win → leaderboard → host plays again

🤖 Generated with [Claude Code](https://claude.com/claude-code)