### PR TITLE
fix: move invite codes to URL fragments

### DIFF
--- a/docs/plans/2026-05-03-invite-code-url-fragment.md
+++ b/docs/plans/2026-05-03-invite-code-url-fragment.md
@@ -1,0 +1,66 @@
+# Invite Code URL Fragment Implementation Plan
+
+> **For Hermes:** Implement directly with strict TDD. Keep the change scoped to invite-code URL handling and tests.
+
+**Goal:** Fix GitHub issue #130 by moving invite codes from query strings to URL fragments so room codes are not sent in HTTP referers or server logs.
+
+**Architecture:** `getInviteLink()` should generate `/library-games/games/<slug>#code=<roomCode>`. `useInviteCode()` should read `code` from `window.location.hash`, with backward-compatible query-string fallback for old links.
+
+**Tech Stack:** Next.js 15, React hook, Jest + Testing Library.
+
+---
+
+### Task 1: Update tests for fragment-based invite links
+
+**Objective:** Add failing coverage that proves new invite links use `#code=` and that the hook reads fragment codes.
+
+**Files:**
+
+- Modify: `src/hooks/useInviteCode.test.ts`
+
+**Steps:**
+
+1. Change `getInviteLink` expectation from `?code=ABC123` to `#code=ABC123`.
+2. Add/adjust `useInviteCode` tests so the primary case uses `/#code=abc123`.
+3. Keep query-string fallback coverage for old links.
+4. Run `pnpm test -- src/hooks/useInviteCode.test.ts`; expected failure before implementation.
+
+### Task 2: Implement fragment parsing and link generation
+
+**Objective:** Generate fragment invite URLs and parse fragment codes first.
+
+**Files:**
+
+- Modify: `src/hooks/useInviteCode.ts`
+
+**Steps:**
+
+1. Add a small helper to normalize a raw code: trim, uppercase, return null for empty.
+2. Read `code` from `window.location.hash` first using `new URLSearchParams(hashWithoutHash)`.
+3. If no fragment code exists, fall back to `window.location.search` for backward compatibility.
+4. Change `getInviteLink` to return `#code=${encodeURIComponent(roomCode)}`.
+5. Run `pnpm test -- src/hooks/useInviteCode.test.ts`; expected pass.
+
+### Task 3: Update E2E contract expectation
+
+**Objective:** Keep Playwright invite-link contract aligned with fragment URLs.
+
+**Files:**
+
+- Modify: `e2e/multiplayer-room-contract.spec.ts`
+
+**Steps:**
+
+1. Change invite link expectation from `?code=` to `#code=`.
+2. Run targeted unit test and lint.
+
+### Task 4: Verify and open PR
+
+**Objective:** Commit, push, and open a PR closing #130.
+
+**Steps:**
+
+1. Run `pnpm lint`.
+2. Run `pnpm test -- src/hooks/useInviteCode.test.ts`.
+3. Commit only touched files.
+4. Push branch and create PR with title `fix: move invite codes to URL fragments`.

--- a/e2e/multiplayer-room-contract.spec.ts
+++ b/e2e/multiplayer-room-contract.spec.ts
@@ -26,7 +26,7 @@ test.describe('multiplayer room contract', () => {
       await lobby.expectPlayerVisible(hostName)
 
       const inviteLink = await lobby.readInviteLink()
-      expect(inviteLink).toContain(`/library-games/games/${slug}?code=${roomCode}`)
+      expect(inviteLink).toContain(`/library-games/games/${slug}#code=${roomCode}`)
     })
 
     test(`${slug} allows a second player to join and sync roster`, async ({ page, browser }) => {

--- a/src/hooks/useInviteCode.test.ts
+++ b/src/hooks/useInviteCode.test.ts
@@ -3,9 +3,9 @@ import { renderHook } from '@testing-library/react'
 import { useInviteCode } from './useInviteCode'
 
 describe('getInviteLink', () => {
-  it('builds a correct invite URL', () => {
+  it('builds a fragment-based invite URL', () => {
     const link = getInviteLink('uno', 'ABC123')
-    expect(link).toBe('http://localhost/library-games/games/uno?code=ABC123')
+    expect(link).toBe('http://localhost/library-games/games/uno#code=ABC123')
   })
 })
 
@@ -22,10 +22,16 @@ describe('useInviteCode', () => {
     expect(result.current).toBeNull()
   })
 
-  it('returns uppercased code from URL', () => {
-    window.history.replaceState({}, '', '/?code=abc123')
+  it('returns uppercased code from URL fragment', () => {
+    window.history.replaceState({}, '', '/#code=abc123')
     const { result } = renderHook(() => useInviteCode())
     expect(result.current).toBe('ABC123')
+  })
+
+  it('falls back to query string code for old invite links', () => {
+    window.history.replaceState({}, '', '/?code=legacy')
+    const { result } = renderHook(() => useInviteCode())
+    expect(result.current).toBe('LEGACY')
   })
 
   it('returns null for empty code param', () => {

--- a/src/hooks/useInviteCode.ts
+++ b/src/hooks/useInviteCode.ts
@@ -3,16 +3,23 @@
 import { useEffect, useState } from 'react'
 
 /**
- * Reads `?code=XXXX` from the current URL after mount.
+ * Reads `#code=XXXX` from the current URL after mount, falling back to legacy `?code=XXXX` links.
  * Returns the uppercased code, null if absent, or undefined until resolved.
  */
+function normalizeInviteCode(raw: string | null): string | null {
+  const trimmed = raw?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed.toUpperCase() : null
+}
+
 export function useInviteCode(): string | null | undefined {
   const [code, setCode] = useState<string | null | undefined>(undefined)
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const raw = params.get('code')
-    setCode(raw && raw.trim().length > 0 ? raw.trim().toUpperCase() : null)
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+    const searchParams = new URLSearchParams(window.location.search)
+    setCode(
+      normalizeInviteCode(hashParams.get('code')) ?? normalizeInviteCode(searchParams.get('code'))
+    )
   }, [])
 
   return code
@@ -24,5 +31,5 @@ export function useInviteCode(): string | null | undefined {
  */
 export function getInviteLink(slug: string, roomCode: string): string {
   const origin = typeof window !== 'undefined' ? window.location.origin : ''
-  return `${origin}/library-games/games/${slug}?code=${roomCode}`
+  return `${origin}/library-games/games/${slug}#code=${encodeURIComponent(roomCode)}`
 }


### PR DESCRIPTION
## Summary
- Move generated invite links from `?code=` query strings to `#code=` URL fragments
- Read fragment invite codes first while preserving legacy query-string fallback
- Update unit and E2E contract coverage for fragment-based invite links

Closes #130

## Test Plan
- `pnpm lint`
- `pnpm test`
