### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,24 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# Keep Dependabot noise low by batching updates into one grouped PR per ecosystem.
+# Dependabot groups cannot span ecosystems, so npm and GitHub Actions each get
+# their own rolling PR.
 version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 1
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/docs/plans/2026-05-03-group-dependabot-updates.md
+++ b/docs/plans/2026-05-03-group-dependabot-updates.md
@@ -1,0 +1,43 @@
+# Group Dependabot Updates Implementation Plan
+
+> **For Hermes:** Implement directly. This is a repository configuration change, so verification is config review plus lint where applicable.
+
+**Goal:** Configure Dependabot so dependency bumps are batched into grouped PRs instead of one PR per tiny package update.
+
+**Architecture:** Use Dependabot `groups` in `.github/dependabot.yml`. Dependabot groups are scoped per `package-ecosystem`, so npm dependencies and GitHub Actions updates must be separate grouped PRs. Set `open-pull-requests-limit: 1` per ecosystem so Dependabot keeps at most one active grouped PR for npm and one for actions; after a group PR is merged, the next scheduled run can open the next group.
+
+**Tech Stack:** GitHub Dependabot version updates, npm/pnpm, GitHub Actions.
+
+---
+
+### Task 1: Update Dependabot config
+
+**Objective:** Replace default one-PR-per-dependency behavior with grouped updates.
+
+**Files:**
+
+- Modify: `.github/dependabot.yml`
+
+**Steps:**
+
+1. Keep the existing weekly schedule for npm and GitHub Actions.
+2. Add `open-pull-requests-limit: 1` to each ecosystem.
+3. Add one npm group matching all dependency patterns.
+4. Add one GitHub Actions group matching all action patterns.
+5. Use clear group identifiers so PR titles are understandable.
+
+### Task 2: Verify configuration
+
+**Objective:** Ensure the YAML is valid and no repo formatting checks are broken.
+
+**Steps:**
+
+1. Run a YAML parser against `.github/dependabot.yml`.
+2. Run `pnpm prettier --check .github/dependabot.yml docs/plans/2026-05-03-group-dependabot-updates.md`.
+3. Commit and open a PR.
+
+### Expected behavior after merge
+
+- Dependabot npm updates become one grouped PR named around `npm-dependencies`.
+- Dependabot GitHub Actions updates become one grouped PR named around `github-actions`.
+- Dependabot cannot create one cross-ecosystem PR; GitHub scopes groups by ecosystem. This is the closest native setup without replacing Dependabot with Renovate.


### PR DESCRIPTION
## Summary
- Configure Dependabot to batch npm updates into one grouped PR
- Configure Dependabot to batch GitHub Actions updates into one grouped PR
- Limit each ecosystem to one open Dependabot PR at a time so the next group opens after the current one is merged

Note: Dependabot groups cannot span package ecosystems, so native Dependabot can create one npm PR and one GitHub Actions PR, not one combined cross-ecosystem PR.

## Test Plan
- `python3` YAML parse/assertion check for `.github/dependabot.yml`
- `pnpm prettier --check .github/dependabot.yml docs/plans/2026-05-03-group-dependabot-updates.md`
- `pnpm lint`
