### PR TITLE
Security hardening: room-code entropy + member-scoped RPCs, broadcast delivery & server-side validation

### DIFF
--- a/e2e/fake-supabase/server.mjs
+++ b/e2e/fake-supabase/server.mjs
@@ -97,6 +97,20 @@ async function handleQuery(req, res) {
 
   if (op === 'insert') {
     const inputRows = Array.isArray(values) ? values : [values]
+    for (const value of inputRows) {
+      if (value.code != null && rows.some((r) => r.code === value.code)) {
+        sendJson(res, 200, {
+          data: null,
+          error: {
+            code: '23505',
+            message: 'duplicate key value violates unique constraint',
+            details: `Key (code)=(${value.code}) already exists.`,
+            hint: null,
+          },
+        })
+        return
+      }
+    }
     const inserted = inputRows.map((value) => ({ version: 1, ...value }))
     rows.push(...inserted)
     sendJson(res, 200, { data: inserted.map((row) => selectedRow(row, columns)), error: null })
@@ -129,6 +143,19 @@ async function handleQuery(req, res) {
       rows[index] = next
       updated.push(next)
       emit({ type: 'postgres_changes', table, old: row, new: next })
+      // Mirror the real `after update` trigger (plan 02-01): EVERY row UPDATE on a
+      // room table fires broadcast_room_state(), which sends {state,version} on
+      // room:CODE / event=state. The hook is now broadcast-only for state sync, so a
+      // direct table UPDATE (e.g. an E2E state seed) must broadcast too — otherwise
+      // already-subscribed peers never observe the change. Gate on a room-shaped row.
+      if (next.code != null && next.state !== undefined && next.version !== undefined) {
+        emit({
+          type: 'broadcast',
+          channel: 'room:' + next.code,
+          event: 'state',
+          payload: { state: next.state, version: next.version },
+        })
+      }
     }
 
     sendJson(res, 200, { data: updated.map((row) => selectedRow(row, columns)), error: null })
@@ -136,6 +163,225 @@ async function handleQuery(req, res) {
   }
 
   sendJson(res, 400, { data: null, error: { message: `Unsupported op: ${op}` } })
+}
+
+// Crockford 6-char room-code regex, mirroring ROOM_CODE_REGEX_SQL in
+// src/lib/room-code.ts (this file lives outside src/, no @ import).
+const ROOM_CODE_RE = /^[0-9A-HJKMNP-TV-Z]{6}$/
+
+// Server-side name predicate mirroring the DB is_valid_player_name(text):
+// trim → require 1..20 code points → reject control / zero-width / bidi.
+function isValidPlayerName(name) {
+  if (typeof name !== 'string') return false
+  const trimmed = name.trim()
+  const len = [...trimmed].length
+  if (len < 1 || len > 20) return false
+  for (const ch of trimmed) {
+    const cp = ch.codePointAt(0)
+    // Cc control chars
+    if (cp <= 0x1f || (cp >= 0x7f && cp <= 0x9f)) return false
+    // Cf / Zl / Zp / zero-width / bidi / BOM
+    if (
+      cp === 0x200b ||
+      cp === 0x200c ||
+      cp === 0x200d ||
+      cp === 0x200e ||
+      cp === 0x200f ||
+      cp === 0x2028 ||
+      cp === 0x2029 ||
+      (cp >= 0x202a && cp <= 0x202e) ||
+      (cp >= 0x2066 && cp <= 0x2069) ||
+      cp === 0xfeff
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+function rpcError(res, code, message) {
+  sendJson(res, 200, { data: null, error: { code, message } })
+}
+
+// Derive the room table from the RPC name suffix: `<op>_<game>` → `<game>_rooms`.
+function tableForFn(fn) {
+  const match = /^(create|join|restore|dispatch)_(.+)$/.exec(fn)
+  if (!match) return null
+  return { op: match[1], table: `${match[2]}_rooms` }
+}
+
+function statePlayerNames(stateValue) {
+  const players = stateValue?.players
+  if (!Array.isArray(players)) return []
+  return players.map((p) => p?.name)
+}
+
+// Mirrors the DB SECURITY DEFINER RPCs from plan 02-01: create/join/restore/dispatch.
+// Return shapes match `returns table(...)` (array `data`) and stable errcodes
+// 22023 (bad code/name), 42501 (token/membership), 40001 (CAS conflict).
+async function handleRpc(req, res) {
+  const body = await readBody(req)
+  const { fn, args = {} } = body
+  const parsed = tableForFn(fn)
+  if (!parsed) {
+    rpcError(res, '42883', `unknown rpc: ${fn}`)
+    return
+  }
+  const { op, table } = parsed
+  const rows = tableRows(table)
+
+  if (op === 'create') {
+    const code = args.p_code
+    if (typeof code !== 'string' || !ROOM_CODE_RE.test(code)) {
+      rpcError(res, '22023', 'invalid code')
+      return
+    }
+    for (const name of statePlayerNames(args.p_state)) {
+      if (!isValidPlayerName(name)) {
+        rpcError(res, '22023', 'invalid name')
+        return
+      }
+    }
+    if (rows.some((r) => r.code === code)) {
+      sendJson(res, 200, {
+        data: null,
+        error: {
+          code: '23505',
+          message: 'duplicate key value violates unique constraint',
+          details: `Key (code)=(${code}) already exists.`,
+          hint: null,
+        },
+      })
+      return
+    }
+    const room_token = crypto.randomUUID()
+    const row = { code, state: args.p_state, version: 1, room_token }
+    rows.push(row)
+    sendJson(res, 200, {
+      data: [{ state: row.state, version: 1, room_token }],
+      error: null,
+    })
+    return
+  }
+
+  if (op === 'join') {
+    const code = args.p_code
+    if (typeof code !== 'string' || !ROOM_CODE_RE.test(code)) {
+      rpcError(res, '22023', 'invalid code')
+      return
+    }
+    for (const name of statePlayerNames(args.p_new_state)) {
+      if (!isValidPlayerName(name)) {
+        rpcError(res, '22023', 'invalid name')
+        return
+      }
+    }
+    const row = rows.find((r) => r.code === code)
+    if (!row) {
+      rpcError(res, '42501', 'unauthorized')
+      return
+    }
+    // Version (CAS) conflict is checked BEFORE the invariant so a concurrent join that
+    // lost the race reports 40001 (retryable conflict), not a spurious 42501.
+    if (row.version !== args.p_expected_version) {
+      rpcError(res, '40001', 'conflict')
+      return
+    }
+    // CR-02: mirror the DB join invariant — join is only valid in lobby and must add
+    // exactly one player without dropping an existing member. Without this, join is a
+    // token-less full-state overwrite primitive.
+    const oldPlayers = Array.isArray(row.state?.players) ? row.state.players : []
+    const newPlayers = Array.isArray(args.p_new_state?.players) ? args.p_new_state.players : []
+    const oldIds = new Set(oldPlayers.map((p) => p?.id))
+    const preservesRoster = [...oldIds].every((id) => newPlayers.some((p) => p?.id === id))
+    if (
+      row.state?.phase !== 'lobby' ||
+      newPlayers.length !== oldPlayers.length + 1 ||
+      !preservesRoster
+    ) {
+      rpcError(res, '42501', 'unauthorized')
+      return
+    }
+    row.state = args.p_new_state
+    row.version = row.version + 1
+    // Mirror the real `after update` broadcast trigger (plan 02-01): a join is a
+    // row UPDATE, so it must broadcast the new state on room:CODE the same way
+    // dispatch does — otherwise already-subscribed peers never see the new player.
+    emit({
+      type: 'broadcast',
+      channel: 'room:' + code,
+      event: 'state',
+      payload: { state: row.state, version: row.version },
+    })
+    sendJson(res, 200, {
+      data: [{ state: row.state, version: row.version, room_token: row.room_token }],
+      error: null,
+    })
+    return
+  }
+
+  if (op === 'restore') {
+    const code = args.p_code
+    if (typeof code !== 'string' || !ROOM_CODE_RE.test(code)) {
+      rpcError(res, '22023', 'invalid code')
+      return
+    }
+    const row = rows.find((r) => r.code === code)
+    if (!row) {
+      rpcError(res, '42501', 'unauthorized')
+      return
+    }
+    const ids = Array.isArray(row.state?.players) ? row.state.players.map((p) => p?.id) : []
+    if (!ids.includes(args.p_player_id)) {
+      rpcError(res, '42501', 'unauthorized')
+      return
+    }
+    sendJson(res, 200, {
+      data: [{ state: row.state, version: row.version, room_token: row.room_token }],
+      error: null,
+    })
+    return
+  }
+
+  if (op === 'dispatch') {
+    const code = args.p_code
+    if (typeof code !== 'string' || !ROOM_CODE_RE.test(code)) {
+      rpcError(res, '22023', 'invalid code')
+      return
+    }
+    const row = rows.find((r) => r.code === code)
+    if (!row || row.room_token !== args.p_room_token) {
+      rpcError(res, '42501', 'unauthorized')
+      return
+    }
+    if (row.version !== args.p_expected_version) {
+      rpcError(res, '40001', 'conflict')
+      return
+    }
+    // CR-04: mirror the DB dispatch_<game> server-side name validation — INPUT-01
+    // is enforced on the steady-state write path too, not only create/join.
+    for (const name of statePlayerNames(args.p_new_state)) {
+      if (!isValidPlayerName(name)) {
+        rpcError(res, '22023', 'invalid name')
+        return
+      }
+    }
+    row.state = args.p_new_state
+    row.version = row.version + 1
+    emit({
+      type: 'broadcast',
+      channel: 'room:' + code,
+      event: 'state',
+      payload: { state: row.state, version: row.version },
+    })
+    sendJson(res, 200, {
+      data: [{ state: row.state, version: row.version }],
+      error: null,
+    })
+    return
+  }
+
+  rpcError(res, '42883', `unsupported op: ${op}`)
 }
 
 async function handleEvents(req, res) {
@@ -194,6 +440,11 @@ const server = http.createServer(async (req, res) => {
 
     if (req.method === 'POST' && url.pathname === '/query') {
       await handleQuery(req, res)
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/rpc') {
+      await handleRpc(req, res)
       return
     }
 

--- a/e2e/games/uno.spec.ts
+++ b/e2e/games/uno.spec.ts
@@ -126,6 +126,41 @@ function seededNearWinState(players: UnoPlayer[]): UnoState {
   }
 }
 
+test.describe('Uno room creation collision retry', () => {
+  test('regenerates and creates a room when the first code collides (23505)', async ({ page }) => {
+    // A valid 6-char Crockford code we will both seed into the fake DB AND force
+    // the in-browser generator to return on its FIRST createRoom attempt, so the
+    // insert hits the unique `code` constraint (23505) and must retry. See the
+    // E2E forced-code seam in src/lib/room-code.ts (Open Question Q3 option a).
+    const collidingCode = 'ABC123'
+
+    // 1. Pre-seed a row occupying `collidingCode` so the first insert collides.
+    const seeded = await fakeSupabaseQuery({
+      op: 'insert',
+      table: 'uno_rooms',
+      values: { code: collidingCode, state: { phase: 'lobby', players: [] } },
+    })
+    expect(seeded.error).toBeNull()
+
+    // 2. Force the page's generator to return the colliding code once, then fall
+    //    back to the real CSPRNG (queue drains after the first call).
+    await page.addInitScript((code) => {
+      ;(globalThis as { __E2E_FORCED_ROOM_CODES__?: string[] }).__E2E_FORCED_ROOM_CODES__ = [code]
+    }, collidingCode)
+
+    const hostPage = new UnoPage(page)
+    await hostPage.goto()
+
+    // 3. Create succeeds via retry — no flat 'Failed to create room' — with a
+    //    DIFFERENT 6-char code than the seeded colliding one.
+    const roomCode = await hostPage.createRoom('Collision Host')
+
+    await expect(hostPage.errorBanner).toHaveCount(0)
+    expect(roomCode).toMatch(/^[0-9A-HJKMNP-TV-Z]{6}$/)
+    expect(roomCode).not.toBe(collidingCode)
+  })
+})
+
 test.describe('Uno gameplay smoke', () => {
   test('plays a deterministic turn and syncs a final-card win to both players', async ({
     page,

--- a/e2e/integration/supabase-access.spec.ts
+++ b/e2e/integration/supabase-access.spec.ts
@@ -1,0 +1,140 @@
+// Opt-in real-Supabase integration canary (TEST-02 / D-13, D-14).
+//
+// This is the ONLY test that crosses the real network boundary to a live
+// Supabase project. It proves the two production-path security properties the
+// in-memory fake cannot:
+//
+//   1. ACCESS-05 — a second subscriber receives the `{ state, version }`
+//      broadcast on the public topic `room:CODE` (the `realtime.send(..., false)`
+//      delivery path; the fake has no real Realtime, so only this catches a
+//      `broadcast_changes()`/`private:true` misuse — Pitfall 1).
+//   2. ACCESS-03 — a `dispatch_<game>` RPC called with a wrong/missing
+//      `room_token` is rejected with Postgres errcode `42501`.
+//
+// Self-skips when SUPABASE_TEST_URL is unset (including CI), so it never adds
+// CI cost or a standing project dependency. Run on demand:
+//
+//   SUPABASE_TEST_URL=... SUPABASE_TEST_ANON_KEY=... pnpm test:supabase
+//
+// Required env vars:
+//   - SUPABASE_TEST_URL       real Supabase project URL
+//   - SUPABASE_TEST_ANON_KEY  that project's anon key
+//
+// NOTE — Phase-3 deferral (D-14): the enumeration-prevention assertion (that a
+// non-member cannot SELECT/enumerate rooms) is intentionally NOT asserted here.
+// In this additive phase the table SELECT policy is still `using (true)`
+// (permissive), so enumeration is still possible by design until Phase 3 seals
+// SELECT. That assertion belongs to Phase 3 and is added there.
+
+import { test, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { generateRoomCode } from '../../src/lib/room-code'
+
+const SUPABASE_TEST_URL = process.env.SUPABASE_TEST_URL
+const SUPABASE_TEST_ANON_KEY = process.env.SUPABASE_TEST_ANON_KEY
+
+// Self-skip with no real backend configured (including in CI). Never red.
+test.skip(!SUPABASE_TEST_URL, 'real Supabase env not set (SUPABASE_TEST_URL)')
+
+// A minimal valid uno game state: the create RPC validates every name in
+// `state.players` via is_valid_player_name, so a single valid player suffices.
+function freshUnoState(playerId: string) {
+  return {
+    players: [{ id: playerId, name: 'Roman' }],
+  }
+}
+
+test.describe('real Supabase access control (canary)', () => {
+  test('a second subscriber receives the broadcast on room:CODE (ACCESS-05)', async () => {
+    const url = SUPABASE_TEST_URL!
+    const key = SUPABASE_TEST_ANON_KEY!
+
+    const writer = createClient(url, key)
+    const subscriber = createClient(url, key)
+
+    const code = generateRoomCode()
+    const playerId = `p_${Math.random().toString(36).slice(2, 10)}`
+
+    // Subscribe a SECOND client to the public room topic BEFORE the write so we
+    // do not race the broadcast. Subscribe WITHOUT `private: true` (public topic).
+    const received = new Promise<{ state: unknown; version: number }>((resolve, reject) => {
+      const channel = subscriber.channel(`room:${code}`)
+      const timer = setTimeout(() => {
+        subscriber.removeChannel(channel)
+        reject(new Error('did not receive a broadcast on room:CODE within timeout'))
+      }, 8000)
+      channel
+        .on('broadcast', { event: 'state' }, (msg) => {
+          clearTimeout(timer)
+          subscriber.removeChannel(channel)
+          resolve(msg.payload as { state: unknown; version: number })
+        })
+        .subscribe()
+    })
+
+    // Give the subscription a moment to attach before the write triggers the broadcast.
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const { data: created, error: createErr } = await writer.rpc('create_uno', {
+      p_code: code,
+      p_state: freshUnoState(playerId),
+    })
+    expect(createErr).toBeNull()
+    const room = Array.isArray(created) ? created[0] : created
+    expect(room?.room_token).toBeTruthy()
+
+    // A dispatch (UPDATE) fires the AFTER UPDATE broadcast trigger.
+    const nextState = {
+      players: [
+        { id: playerId, name: 'Roman' },
+        { id: 'x', name: 'Two' },
+      ],
+    }
+    const { error: dispatchErr } = await writer.rpc('dispatch_uno', {
+      p_code: code,
+      p_room_token: room.room_token,
+      p_new_state: nextState,
+      p_expected_version: room.version,
+    })
+    expect(dispatchErr).toBeNull()
+
+    const payload = await received
+    expect(payload).toBeTruthy()
+    expect(typeof payload.version).toBe('number')
+    expect(payload.state).toBeTruthy()
+
+    await writer.removeAllChannels()
+    await subscriber.removeAllChannels()
+  })
+
+  test('dispatch rejects a wrong/missing room_token (ACCESS-03)', async () => {
+    const url = SUPABASE_TEST_URL!
+    const key = SUPABASE_TEST_ANON_KEY!
+    const client = createClient(url, key)
+
+    const code = generateRoomCode()
+    const playerId = `p_${Math.random().toString(36).slice(2, 10)}`
+
+    const { data: created, error: createErr } = await client.rpc('create_uno', {
+      p_code: code,
+      p_state: freshUnoState(playerId),
+    })
+    expect(createErr).toBeNull()
+    const room = Array.isArray(created) ? created[0] : created
+    expect(room?.version).toBeDefined()
+
+    // Dispatch with a random (wrong) room_token must be rejected by the token gate.
+    const wrongToken = '00000000-0000-0000-0000-000000000000'
+    const { error } = await client.rpc('dispatch_uno', {
+      p_code: code,
+      p_room_token: wrongToken,
+      p_new_state: { players: [{ id: playerId, name: 'Roman' }] },
+      p_expected_version: room.version,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe('42501')
+
+    await client.removeAllChannels()
+  })
+})

--- a/e2e/multiplayer-room-contract.spec.ts
+++ b/e2e/multiplayer-room-contract.spec.ts
@@ -22,7 +22,7 @@ test.describe('multiplayer room contract', () => {
       const hostName = `Host ${slug.slice(0, 6)}`
       const roomCode = await lobby.createRoom(hostName)
 
-      expect(roomCode).toMatch(/^[A-Z0-9]{4}$/)
+      expect(roomCode).toMatch(/^[0-9A-HJKMNP-TV-Z]{6}$/)
       await lobby.expectPlayerVisible(hostName)
 
       const inviteLink = await lobby.readInviteLink()
@@ -57,7 +57,7 @@ test.describe('multiplayer room edge states', () => {
   test('uno shows error for invalid room code', async ({ page }) => {
     const lobby = new RoomLobbyPage(page, 'uno')
     await lobby.goto()
-    await lobby.joinRoomExpectingError('NOPE', 'Late Guest')
+    await lobby.joinRoomExpectingError('7H2K9F', 'Late Guest')
     await lobby.expectError('Room not found. Check the code and try again.')
   })
 

--- a/e2e/pages/RoomLobbyPage.ts
+++ b/e2e/pages/RoomLobbyPage.ts
@@ -1,7 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 import { gotoGame } from '../helpers/navigation'
 
-const ROOM_CODE_PATTERN = /[A-Z0-9]{4}/
+const ROOM_CODE_PATTERN = /[0-9A-HJKMNP-TV-Z]{6}/
 
 export type MultiplayerSlug =
   | 'skribbl'
@@ -135,7 +135,7 @@ export class RoomLobbyPage {
     const text = (await this.roomCodeDisplay.innerText()).trim()
     const match = text.match(ROOM_CODE_PATTERN)
     if (!match) {
-      throw new Error(`Could not find a 4-character room code in: ${text}`)
+      throw new Error(`Could not find a 6-character room code in: ${text}`)
     }
     return match[0]
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "e2e:ui": "playwright test --ui",
     "e2e:debug": "playwright test --debug",
     "e2e:ci": "playwright test --reporter=github,line",
+    "test:supabase": "playwright test --config=playwright.integration.config.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,11 @@ const baseURL = `http://${HOST}:${PORT}/library-games`
 
 export default defineConfig({
   testDir: './e2e',
+  // The opt-in real-Supabase canary (e2e/integration/**) is excluded from the
+  // default `pnpm e2e` / `e2e:ci` run. It talks to a real Supabase project and
+  // self-skips when SUPABASE_TEST_URL is unset; run it on demand via
+  // `pnpm test:supabase`, never as part of the CI chain (D-13).
+  testIgnore: ['**/integration/**'],
   // The fake-Supabase server holds a single shared state and resets it before
   // each test, so any parallelism across the suite produces resets that race
   // with in-flight tests. Run serially.

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Opt-in real-Supabase integration canary config (D-13).
+//
+// This config runs ONLY `e2e/integration/**` and is invoked on demand via
+// `pnpm test:supabase`. It is deliberately separate from `playwright.config.ts`
+// so that:
+//   - the default `pnpm e2e` / `e2e:ci` run never picks up the canary
+//     (that config sets `testIgnore: ['**/integration/**']`), and
+//   - the canary does NOT spin up the fake-Supabase server or the Next dev
+//     server — it talks directly to a real Supabase project over the network.
+//
+// The spec self-skips when `SUPABASE_TEST_URL` is unset (including in CI), so
+// this command is safe to run anywhere; it simply reports skipped without the
+// required env. Required env vars: SUPABASE_TEST_URL, SUPABASE_TEST_ANON_KEY.
+export default defineConfig({
+  testDir: './e2e/integration',
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  reporter: [['list']],
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
+import { normalizeRoomCode } from '@/lib/room-code'
 import { useAgarioRoom } from './useAgarioRoom'
 import {
   MAP_WIDTH,
@@ -1537,10 +1538,10 @@ export function AgarioGame() {
           <input
             data-testid="room-code-input"
             type="text"
-            placeholder="Room code"
+            placeholder="7H2K9F"
             value={codeInput}
-            onChange={(e) => setCodeInput(e.target.value.toUpperCase())}
-            maxLength={4}
+            onChange={(e) => setCodeInput(normalizeRoomCode(e.target.value))}
+            maxLength={6}
             className="border-input bg-background rounded-lg border px-3 py-2 text-center font-mono text-lg tracking-widest"
           />
           <div className="flex gap-2">
@@ -1554,7 +1555,7 @@ export function AgarioGame() {
             <button
               type="submit"
               data-testid="join-room-button"
-              disabled={!nameInput.trim() || codeInput.length < 4}
+              disabled={!nameInput.trim() || codeInput.length < 6}
               className="bg-primary text-primary-foreground hover:bg-primary/90 flex-1 rounded-lg px-4 py-2 text-sm font-semibold transition disabled:opacity-50"
             >
               Join

--- a/src/games/agario/schema.test.ts
+++ b/src/games/agario/schema.test.ts
@@ -28,6 +28,22 @@ describe('agario GameStateSchema', () => {
     }
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
   })
+
+  it('accepts a player name with an emoji', () => {
+    const state = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'player 🎮', isHost: true, color: '#FF073A' }],
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a 21-char player name', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true, color: '#FF073A' }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
 })
 
 describe('agario BroadcastMessageSchema', () => {

--- a/src/games/agario/schema.ts
+++ b/src/games/agario/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { playerNameSchema } from '@/lib/player-name'
+
 const PositionSchema = z.object({
   x: z.number(),
   y: z.number(),
@@ -7,7 +9,7 @@ const PositionSchema = z.object({
 
 const LobbyPlayerSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: playerNameSchema,
   isHost: z.boolean(),
   color: z.string(),
 })
@@ -20,7 +22,7 @@ export const GameStateSchema = z.object({
 
 const SnakeStateSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: playerNameSchema,
   color: z.string(),
   segments: z.array(PositionSchema),
   angle: z.number(),

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -9,6 +9,7 @@ import {
   ResumeSessionButton,
   type SavedSessionSummary,
 } from '@/components/multiplayer/ResumeSessionButton'
+import { normalizeRoomCode } from '@/lib/room-code'
 import { useCAHRoom } from './useCAHRoom'
 import {
   getCzar,
@@ -373,16 +374,16 @@ function EntryScreen({
           <input
             data-testid="room-code-input"
             value={joinCode}
-            onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
-            placeholder="e.g. AB12"
-            maxLength={4}
+            onChange={(e) => setJoinCode(normalizeRoomCode(e.target.value))}
+            placeholder="e.g. 7H2K9F"
+            maxLength={6}
             className="bg-background focus:ring-primary/30 rounded-xl border px-4 py-2.5 text-center text-lg font-black tracking-[0.3em] uppercase transition-shadow outline-none focus:ring-2"
           />
         </label>
       )}
       <button
         data-testid={isCreate ? 'create-room-button' : 'join-room-button'}
-        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
+        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 6)}
         onClick={() => {
           savePlayerName(name.trim())
           if (isCreate) onCreate(name.trim())

--- a/src/games/cards-against-humanity/schema.test.ts
+++ b/src/games/cards-against-humanity/schema.test.ts
@@ -49,4 +49,17 @@ describe('CAH GameStateSchema', () => {
     }
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
   })
+
+  it('accepts a player name with an emoji', () => {
+    const state = { ...validGameState, players: [{ id: 'p1', name: 'player 🎮', isHost: true }] }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a 21-char player name', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
 })

--- a/src/games/cards-against-humanity/schema.ts
+++ b/src/games/cards-against-humanity/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 
+import { playerNameSchema } from '@/lib/player-name'
+
 const PlayerSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: playerNameSchema,
   isHost: z.boolean(),
 })
 

--- a/src/games/codenames/CodenamesGame.tsx
+++ b/src/games/codenames/CodenamesGame.tsx
@@ -9,6 +9,7 @@ import {
   ResumeSessionButton,
   type SavedSessionSummary,
 } from '@/components/multiplayer/ResumeSessionButton'
+import { normalizeRoomCode } from '@/lib/room-code'
 import { useCodenamesRoom } from './useCodenamesRoom'
 import {
   canStartGame,
@@ -165,16 +166,16 @@ function EntryScreen({
           <input
             data-testid="room-code-input"
             value={joinCode}
-            onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
-            placeholder="e.g. AB12"
-            maxLength={4}
+            onChange={(e) => setJoinCode(normalizeRoomCode(e.target.value))}
+            placeholder="e.g. 7H2K9F"
+            maxLength={6}
             className="bg-background focus:ring-primary/40 rounded-lg border px-3 py-2 text-sm tracking-widest uppercase outline-none focus:ring-2"
           />
         </label>
       )}
       <button
         data-testid={isCreate ? 'create-room-button' : 'join-room-button'}
-        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
+        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 6)}
         onClick={() => {
           savePlayerName(name.trim())
           if (isCreate) onCreate(name.trim())

--- a/src/games/codenames/schema.test.ts
+++ b/src/games/codenames/schema.test.ts
@@ -1,0 +1,66 @@
+import { GameStateSchema } from './schema'
+
+const validGameState = {
+  phase: 'lobby' as const,
+  players: [
+    { id: 'p1', name: 'Alice', isHost: true, team: 'red' as const, role: 'spymaster' as const },
+  ],
+  board: [],
+  currentTeam: 'red' as const,
+  turnPhase: 'giving_clue' as const,
+  currentClue: null,
+  redRemaining: 9,
+  blueRemaining: 8,
+  winningTeam: null,
+  log: [],
+}
+
+describe('codenames GameStateSchema', () => {
+  it('accepts a valid lobby state', () => {
+    expect(GameStateSchema.safeParse(validGameState).success).toBe(true)
+  })
+
+  it('accepts a player with null team/role (unassigned)', () => {
+    const state = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'Alice', isHost: true, team: null, role: null }],
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects an unknown phase', () => {
+    expect(GameStateSchema.safeParse({ ...validGameState, phase: 'waiting' }).success).toBe(false)
+  })
+
+  it('rejects an invalid team enum', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'Alice', isHost: true, team: 'green', role: null }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  it('accepts a player name with an emoji', () => {
+    const state = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'player 🎮', isHost: true, team: 'red' as const, role: null }],
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a blank player name', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: '   ', isHost: true, team: 'red' as const, role: null }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  it('rejects a 21-char player name', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true, team: 'red' as const, role: null }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+})

--- a/src/games/codenames/schema.ts
+++ b/src/games/codenames/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 
+import { playerNameSchema } from '@/lib/player-name'
+
 const PlayerSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: playerNameSchema,
   isHost: z.boolean(),
   team: z.enum(['red', 'blue']).nullable(),
   role: z.enum(['spymaster', 'operative']).nullable(),

--- a/src/games/mindmeld/MindmeldGame.tsx
+++ b/src/games/mindmeld/MindmeldGame.tsx
@@ -9,6 +9,7 @@ import {
   ResumeSessionButton,
   type SavedSessionSummary,
 } from '@/components/multiplayer/ResumeSessionButton'
+import { normalizeRoomCode } from '@/lib/room-code'
 import { useMindmeldRoom } from './useMindmeldRoom'
 import {
   BULLSEYE_RADIUS,
@@ -188,16 +189,16 @@ function EntryScreen({
           <input
             data-testid="room-code-input"
             value={joinCode}
-            onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
-            placeholder="e.g. AB12"
-            maxLength={4}
+            onChange={(e) => setJoinCode(normalizeRoomCode(e.target.value))}
+            placeholder="e.g. 7H2K9F"
+            maxLength={6}
             className="bg-background focus:ring-primary/40 rounded-xl border px-3 py-2.5 text-sm tracking-[0.35em] uppercase outline-none focus:ring-2"
           />
         </label>
       )}
       <button
         data-testid={isCreate ? 'create-room-button' : 'join-room-button'}
-        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 4)}
+        disabled={loading || !name.trim() || (!isCreate && joinCode.length < 6)}
         onClick={() => {
           savePlayerName(name.trim())
           if (isCreate) onCreate(name.trim())

--- a/src/games/mindmeld/schema.test.ts
+++ b/src/games/mindmeld/schema.test.ts
@@ -1,0 +1,73 @@
+import { GameStateSchema } from './schema'
+
+const validGameState = {
+  phase: 'lobby' as const,
+  players: [{ id: 'p1', name: 'Alice', isHost: true, score: 0 }],
+  totalRounds: 5,
+  roundNumber: 0,
+  currentRound: null,
+  log: [],
+}
+
+describe('mindmeld GameStateSchema', () => {
+  it('accepts a valid lobby state', () => {
+    expect(GameStateSchema.safeParse(validGameState).success).toBe(true)
+  })
+
+  it('accepts a playing state with a current round', () => {
+    const state = {
+      ...validGameState,
+      phase: 'playing' as const,
+      roundNumber: 1,
+      currentRound: {
+        number: 1,
+        psychicId: 'p1',
+        spectrum: { left: 'Cold', right: 'Hot' },
+        target: 50,
+        clue: null,
+        teamGuess: null,
+        guessLockedBy: null,
+        guesses: {},
+        roundScores: {},
+        phase: 'clue' as const,
+      },
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects an unknown phase', () => {
+    expect(GameStateSchema.safeParse({ ...validGameState, phase: 'waiting' }).success).toBe(false)
+  })
+
+  it('rejects a player missing score', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'Alice', isHost: true }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  it('accepts a player name with an emoji', () => {
+    const state = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'player 🎮', isHost: true, score: 0 }],
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a blank player name', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: '   ', isHost: true, score: 0 }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  it('rejects a 21-char player name', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true, score: 0 }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+})

--- a/src/games/mindmeld/schema.ts
+++ b/src/games/mindmeld/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 
+import { playerNameSchema } from '@/lib/player-name'
+
 const PlayerSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: playerNameSchema,
   isHost: z.boolean(),
   score: z.number().int(),
 })

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -14,6 +14,7 @@ import { PlayerRoster } from '@/components/multiplayer/PlayerRoster'
 import { ResultsTable } from '@/components/multiplayer/ResultsTable'
 import { ResumeSessionCard } from '@/components/multiplayer/ResumeSessionCard'
 import { RoomInviteCard } from '@/components/multiplayer/RoomInviteCard'
+import { normalizeRoomCode } from '@/lib/room-code'
 import { useSkribblRoom, type UseSkribblRoomReturn } from './useSkribblRoom'
 import {
   decodeWord,
@@ -653,7 +654,7 @@ function EntryScreen({
     setCode(initialCode)
   }, [initialCode])
 
-  const canSubmit = name.trim().length >= 2 && (mode === 'create' || code.trim().length >= 4)
+  const canSubmit = name.trim().length >= 2 && (mode === 'create' || code.trim().length >= 6)
 
   function submit() {
     if (!canSubmit) return
@@ -777,11 +778,9 @@ function EntryScreen({
             <input
               data-testid="room-code-input"
               value={code}
-              onChange={(event) =>
-                setCode(event.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))
-              }
-              maxLength={4}
-              placeholder="AB23"
+              onChange={(event) => setCode(normalizeRoomCode(event.target.value))}
+              maxLength={6}
+              placeholder="7H2K9F"
               className={cn(arcadeShellStyles.input, styles.codeInput)}
             />
           </label>

--- a/src/games/skribbl/schema.test.ts
+++ b/src/games/skribbl/schema.test.ts
@@ -64,4 +64,20 @@ describe('skribbl GameStateSchema', () => {
     }
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
   })
+
+  it('accepts a player name with an emoji', () => {
+    const state = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'player 🎮', isHost: true, score: 0, avatar: 0 }],
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a 21-char player name', () => {
+    const invalid = {
+      ...validGameState,
+      players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true, score: 0, avatar: 0 }],
+    }
+    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
 })

--- a/src/games/skribbl/schema.ts
+++ b/src/games/skribbl/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 
+import { playerNameSchema } from '@/lib/player-name'
+
 const PlayerSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: playerNameSchema,
   isHost: z.boolean(),
   score: z.number(),
   avatar: z.number().int().min(0).max(7).default(0),

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -9,6 +9,7 @@ import { ArcadeShell, arcadeShellStyles } from '@/components/multiplayer/ArcadeS
 import { LobbyActions } from '@/components/multiplayer/LobbyActions'
 import { ResumeSessionCard } from '@/components/multiplayer/ResumeSessionCard'
 import type { SavedSessionSummary } from '@/components/multiplayer/ResumeSessionButton'
+import { normalizeRoomCode } from '@/lib/room-code'
 import { useUnoRoom } from './useUnoRoom'
 import {
   getPlayableCards,
@@ -465,7 +466,7 @@ function EntryScreen({
     setJoinCode(initialCode)
   }, [initialCode])
 
-  const canSubmit = name.trim().length >= 2 && (mode === 'create' || joinCode.trim().length >= 4)
+  const canSubmit = name.trim().length >= 2 && (mode === 'create' || joinCode.trim().length >= 6)
 
   function submit() {
     if (!canSubmit) return
@@ -603,16 +604,9 @@ function EntryScreen({
             <input
               data-testid="room-code-input"
               value={joinCode}
-              onChange={(e) =>
-                setJoinCode(
-                  e.target.value
-                    .toUpperCase()
-                    .replace(/[^A-Z0-9]/g, '')
-                    .slice(0, 4)
-                )
-              }
-              placeholder="X7K2"
-              maxLength={4}
+              onChange={(e) => setJoinCode(normalizeRoomCode(e.target.value))}
+              placeholder="7H2K9F"
+              maxLength={6}
               className={cn(arcadeShellStyles.input, styles.codeInput)}
             />
           </label>

--- a/src/games/uno/schema.test.ts
+++ b/src/games/uno/schema.test.ts
@@ -58,4 +58,19 @@ describe('UNO GameStateSchema', () => {
     }
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
   })
+
+  it('accepts a player name with an emoji', () => {
+    const state = { ...validGameState, players: [{ id: 'p1', name: 'player 🎮', isHost: true }] }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a blank player name', () => {
+    const state = { ...validGameState, players: [{ id: 'p1', name: '   ', isHost: true }] }
+    expect(GameStateSchema.safeParse(state).success).toBe(false)
+  })
+
+  it('rejects a 21-char player name', () => {
+    const state = { ...validGameState, players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true }] }
+    expect(GameStateSchema.safeParse(state).success).toBe(false)
+  })
 })

--- a/src/games/uno/schema.ts
+++ b/src/games/uno/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 
+import { playerNameSchema } from '@/lib/player-name'
+
 const PlayerSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: playerNameSchema,
   isHost: z.boolean(),
 })
 

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { supabase } from '@/lib/supabase'
+import { generateRoomCode } from '@/lib/room-code'
 import type { ZodType } from 'zod'
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000
@@ -10,6 +11,9 @@ interface Session {
   roomCode: string
   playerId: string
   playerName: string
+  // Per-room write capability minted by create/join/restore (Phase 2, D-01..D-04).
+  // Pre-Phase-2 sessions persisted without it; treated as '' on load and re-issued by restore.
+  roomToken: string
   ts: number
 }
 
@@ -25,9 +29,35 @@ function loadSession(key: string): Session | null {
     if (!raw) return null
     const data: Session = JSON.parse(raw)
     if (Date.now() - data.ts > SESSION_TTL_MS) return null
+    // A legacy session minted before Phase 2 has no roomToken; never let that crash
+    // a restore — default to '' and rely on restore_<game> to re-issue it (D-04).
+    if (typeof data.roomToken !== 'string') data.roomToken = ''
     return data
   } catch {
     return null
+  }
+}
+
+// Derive a Phase-2 RPC name from a room table: `<game>_rooms` + op -> `<op>_<game>`
+// e.g. rpcName('uno_rooms', 'dispatch') === 'dispatch_uno'. (ACCESS-02)
+function rpcName(tableName: string, op: 'create' | 'join' | 'restore' | 'dispatch'): string {
+  return `${op}_${tableName.replace('_rooms', '')}`
+}
+
+// Map stable Postgres errcodes from the SECURITY DEFINER RPCs (plan 01) to the existing
+// friendly UI strings. No raw DB `error.message` is ever surfaced to the player (INPUT-03,
+// Pitfall 6). Returns null when the code is not a recognized RPC errcode so callers can fall
+// back to their own context-specific message.
+function mapRpcError(code: string | undefined): string | null {
+  switch (code) {
+    case '42501':
+      return 'You are not a member of this room.'
+    case '40001':
+      return 'Action failed due to a conflict. Please try again.'
+    case '22023':
+      return 'Room data is invalid. Try again.'
+    default:
+      return null
   }
 }
 
@@ -35,10 +65,6 @@ function clearSession(key: string) {
   try {
     localStorage.removeItem(key)
   } catch {}
-}
-
-function generateRoomCode(): string {
-  return crypto.randomUUID().replace(/-/g, '').substring(0, 4).toUpperCase()
 }
 
 export type RoomStatus = 'idle' | 'restoring' | 'creating' | 'joining' | 'connected' | 'error'
@@ -109,7 +135,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
   const [error, setError] = useState<string | null>(null)
   const [savedSession, setSavedSession] = useState<Session | null>(null)
   const [onlinePlayerIds, setOnlinePlayerIds] = useState<string[]>([])
-  const dbChannelRef = useRef<ReturnType<NonNullable<typeof supabase>['channel']> | null>(null)
+  const stateChannelRef = useRef<ReturnType<NonNullable<typeof supabase>['channel']> | null>(null)
   const broadcastChannelRef = useRef<ReturnType<NonNullable<typeof supabase>['channel']> | null>(
     null
   )
@@ -119,6 +145,8 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
   const onBroadcastRef = useRef<((message: TBroadcast) => void) | null>(null)
   const gameStateRef = useRef<TState | null>(null)
   const versionRef = useRef(0)
+  // Per-room write capability for the dispatch RPC; set by create/join/restore (D-01..D-04).
+  const roomTokenRef = useRef('')
 
   // Store config in ref to avoid dependency issues
   const configRef = useRef(config)
@@ -166,27 +194,53 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       if (!supabase) return
       const { channelPrefix, tableName, stateSchema, broadcast: broadcastCfg } = configRef.current
 
-      dbChannelRef.current?.unsubscribe()
-      dbChannelRef.current = supabase
-        .channel(`${channelPrefix}-db:${code}`)
-        .on(
-          'postgres_changes',
-          {
-            event: 'UPDATE',
-            schema: 'public',
-            table: tableName,
-            filter: `code=eq.${code}`,
-          },
-          (payload: { new: { state: unknown; version: unknown } }) => {
-            const parsed = stateSchema.safeParse(payload.new.state)
-            if (!parsed.success) {
-              console.error(`[${channelPrefix}] Invalid GameState payload:`, parsed.error)
-              return
-            }
-            setStateAndRef(parsed.data, payload.new.version as number)
-          }
-        )
-        .subscribe()
+      // Apply an incoming {state, version} only when it is strictly newer than what we hold
+      // (Pitfall 5: strictly `>` drops stale/replayed payloads). The state is re-validated via
+      // the Zod schema because the broadcast topic is public and attacker-influencable (T-02-10).
+      const applyIfNewer = (rawState: unknown, version: unknown) => {
+        if (typeof version !== 'number' || version <= versionRef.current) return
+        const parsed = stateSchema.safeParse(rawState)
+        if (!parsed.success) {
+          console.error(`[${channelPrefix}] Invalid GameState payload:`, parsed.error)
+          return
+        }
+        setStateAndRef(parsed.data, version)
+      }
+
+      const supabaseClient = supabase
+
+      // CR-03: the `room:CODE` topic is public, so any code-knowing client can forge a
+      // `state` broadcast. Never trust the broadcast payload as authoritative state —
+      // treat the broadcast purely as a change signal and re-read {state, version}
+      // through the SELECT path, applying that under the version guard. A forged payload
+      // then costs at most one extra read: it cannot poison peers' state, and a forged
+      // huge version can't freeze the room because the forged version is never written
+      // to versionRef (only the value returned by the authoritative SELECT is).
+      const refetchAuthoritativeState = async () => {
+        const { data } = await supabaseClient
+          .from(tableName)
+          .select('state, version')
+          .eq('code', code)
+          .single()
+        if (data) applyIfNewer(data.state, data.version)
+      }
+
+      // State sync is broadcast-signalled now (ACCESS-05, D-08): the postgres_changes UPDATE
+      // arm is gone. Subscribe to the plan-01 trigger's public `room:CODE` topic, event
+      // 'state', and use it only as a wakeup to refetch authoritative state.
+      stateChannelRef.current?.unsubscribe()
+      stateChannelRef.current = supabaseClient
+        .channel(`room:${code}`)
+        .on('broadcast', { event: 'state' }, () => {
+          void refetchAuthoritativeState()
+        })
+        // Refetch-on-reconnect (D-10): on (re)subscribe, re-read the current {state, version}
+        // through the still-permissive SELECT (additive window), recovering any signal
+        // missed while disconnected. No postgres_changes backstop.
+        .subscribe(async (s: string) => {
+          if (s !== 'SUBSCRIBED') return
+          await refetchAuthoritativeState()
+        })
 
       if (broadcastCfg) {
         broadcastChannelRef.current?.unsubscribe()
@@ -224,7 +278,6 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       setError(null)
 
       const id = crypto.randomUUID()
-      const code = generateRoomCode()
       const hostPlayer = cfg.createPlayer({
         id,
         name: playerName,
@@ -234,23 +287,46 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       })
       const initialState = cfg.createLobbyState(hostPlayer)
 
-      const { data: inserted, error: err } = await supabase
-        .from(cfg.tableName)
-        .insert({ code, state: initialState })
-        .select('version')
+      // Mint a fresh code each attempt; the create_<game> RPC owns the insert and raises a
+      // unique_violation (23505) when the chosen code already exists, so regenerate and retry —
+      // bounded to 3 attempts, mirroring the dispatch() CAS retry idiom (MAX_RETRIES = 3). Any
+      // other error (network/22023 invalid name) fails fast. (CODE-02, ACCESS-02)
+      const MAX_CREATE_ATTEMPTS = 3
+      let inserted: Record<string, unknown> | null = null
+      let landedCode = ''
+      let lastErrCode: string | undefined
 
-      if (err || !inserted || inserted.length === 0) {
-        setError('Failed to create room. Try again.')
+      for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
+        const code = generateRoomCode()
+        const { data, error: err } = await supabase.rpc(rpcName(cfg.tableName, 'create'), {
+          p_code: code,
+          p_state: initialState,
+        })
+
+        if (data && data.length > 0) {
+          inserted = data[0]
+          landedCode = code
+          break
+        }
+        lastErrCode = err?.code
+        // Only a unique-violation is worth retrying with a fresh code.
+        if (err?.code !== '23505') break
+      }
+
+      if (!inserted) {
+        setError(mapRpcError(lastErrCode) ?? 'Failed to create room. Try again.')
         setStatus('error')
         return
       }
 
+      const roomToken = (inserted.room_token as string) ?? ''
+      roomTokenRef.current = roomToken
       setPlayerId(id)
-      setRoomCode(code)
-      setStateAndRef(initialState, inserted[0].version as number)
+      setRoomCode(landedCode)
+      setStateAndRef(initialState, inserted.version as number)
       setStatus('connected')
-      saveSession(cfg.sessionKey, { roomCode: code, playerId: id, playerName })
-      subscribeToRoom(code)
+      saveSession(cfg.sessionKey, { roomCode: landedCode, playerId: id, playerName, roomToken })
+      subscribeToRoom(landedCode)
     },
     [subscribeToRoom, setStateAndRef]
   )
@@ -306,25 +382,42 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         return
       }
 
+      // Additive window: the SELECT above (still-permissive policy) computes newState/version,
+      // but the WRITE goes through the join_<game> RPC, which CAS-updates and returns the
+      // room_token (D-02). (ACCESS-02)
       const currentVersion = data.version as number
-      const { data: updated, error: updateErr } = await supabase
-        .from(cfg.tableName)
-        .update({ state: newState, version: currentVersion + 1 })
-        .eq('code', normalizedCode)
-        .eq('version', currentVersion)
-        .select('version')
+      const { data: updated, error: updateErr } = await supabase.rpc(
+        rpcName(cfg.tableName, 'join'),
+        {
+          p_code: normalizedCode,
+          p_new_state: newState,
+          p_expected_version: currentVersion,
+        }
+      )
 
       if (updateErr || !updated || updated.length === 0) {
-        setError('Failed to join room. Try again.')
+        // A 40001 here means another player won the join CAS race for this version.
+        // Unlike dispatch (which can re-read and replay the same action), a join's
+        // newState was computed against a now-stale roster, so the only safe recovery
+        // is to surface the join-failure string and let the player re-join (which
+        // recomputes the roster). 42501/22023 keep their member/validation strings;
+        // any other error also falls back to the join-failure message. (ACCESS-03)
+        const message =
+          updateErr?.code === '40001'
+            ? 'Failed to join room. Try again.'
+            : (mapRpcError(updateErr?.code) ?? 'Failed to join room. Try again.')
+        setError(message)
         setStatus('error')
         return
       }
 
+      const roomToken = (updated[0].room_token as string) ?? ''
+      roomTokenRef.current = roomToken
       setPlayerId(id)
       setRoomCode(normalizedCode)
-      setStateAndRef(newState, currentVersion + 1)
+      setStateAndRef(newState, (updated[0].version as number) ?? currentVersion + 1)
       setStatus('connected')
-      saveSession(cfg.sessionKey, { roomCode: normalizedCode, playerId: id, playerName })
+      saveSession(cfg.sessionKey, { roomCode: normalizedCode, playerId: id, playerName, roomToken })
       subscribeToRoom(normalizedCode)
     },
     [subscribeToRoom, setStateAndRef]
@@ -336,20 +429,22 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     if (!session || !supabase) return
     setStatus('restoring')
 
-    const { data } = await supabase
-      .from(cfg.tableName)
-      .select('state, version')
-      .eq('code', session.roomCode)
-      .single()
+    // restore_<game> verifies the player is a member (else 42501) and re-issues the room_token,
+    // keeping pre-Phase-2 token-less sessions alive (D-04). (ACCESS-02/ACCESS-03)
+    const { data, error: err } = await supabase.rpc(rpcName(cfg.tableName, 'restore'), {
+      p_code: session.roomCode,
+      p_player_id: session.playerId,
+    })
 
-    if (!data) {
+    if (err || !data || data.length === 0) {
       clearSession(cfg.sessionKey)
       setSavedSession(null)
       setStatus('idle')
       return
     }
 
-    const parsedState = cfg.stateSchema.safeParse(data.state)
+    const row = data[0]
+    const parsedState = cfg.stateSchema.safeParse(row.state)
     if (!parsedState.success) {
       console.error(
         `[${cfg.channelPrefix}] Invalid GameState in restoreSession:`,
@@ -361,17 +456,18 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       return
     }
     const state = parsedState.data
-    const stillInGame = state.players.some((p) => p.id === session.playerId)
-    if (!stillInGame) {
-      clearSession(cfg.sessionKey)
-      setSavedSession(null)
-      setStatus('idle')
-      return
-    }
 
+    const roomToken = (row.room_token as string) ?? ''
+    roomTokenRef.current = roomToken
+    saveSession(cfg.sessionKey, {
+      roomCode: session.roomCode,
+      playerId: session.playerId,
+      playerName: session.playerName,
+      roomToken,
+    })
     setPlayerId(session.playerId)
     setRoomCode(session.roomCode)
-    setStateAndRef(state, data.version as number)
+    setStateAndRef(state, row.version as number)
     setStatus('connected')
     subscribeToRoom(session.roomCode)
   }, [subscribeToRoom, setStateAndRef])
@@ -390,17 +486,28 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         const newState = cfg.applyAction(currentState, action)
         if (newState === currentState) return
 
-        const { data } = await supabase
-          .from(cfg.tableName)
-          .update({ state: newState, version: currentVersion + 1 })
-          .eq('code', roomCode)
-          .eq('version', currentVersion)
-          .select('version')
+        // Token-gated write through the dispatch_<game> RPC (ACCESS-02/ACCESS-03). The server
+        // CAS-updates on p_expected_version and raises 42501 (bad/missing token), 40001 (conflict).
+        const { data, error: dispatchErr } = await supabase.rpc(
+          rpcName(cfg.tableName, 'dispatch'),
+          {
+            p_code: roomCode,
+            p_room_token: roomTokenRef.current,
+            p_new_state: newState,
+            p_expected_version: currentVersion,
+          }
+        )
 
         if (data && data.length > 0) {
           // Apply the accepted state locally right away so controls feel instant
-          // instead of waiting for the realtime echo from Supabase.
-          setStateAndRef(newState, currentVersion + 1)
+          // instead of waiting for the realtime broadcast echo from Supabase.
+          setStateAndRef(newState, (data[0].version as number) ?? currentVersion + 1)
+          return
+        }
+
+        // 42501 (not a member / bad token) is terminal — no retry can fix it.
+        if (dispatchErr?.code === '42501') {
+          setError('You are not a member of this room.')
           return
         }
 
@@ -444,12 +551,13 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         })
       }
     } finally {
-      dbChannelRef.current?.unsubscribe()
-      dbChannelRef.current = null
+      stateChannelRef.current?.unsubscribe()
+      stateChannelRef.current = null
       broadcastChannelRef.current?.unsubscribe()
       broadcastChannelRef.current = null
       presenceChannelRef.current?.unsubscribe()
       presenceChannelRef.current = null
+      roomTokenRef.current = ''
       setStateAndRef(null, 0)
       setPlayerId(null)
       setRoomCode(null)
@@ -463,7 +571,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
 
   useEffect(() => {
     return () => {
-      dbChannelRef.current?.unsubscribe()
+      stateChannelRef.current?.unsubscribe()
       broadcastChannelRef.current?.unsubscribe()
       presenceChannelRef.current?.unsubscribe()
     }

--- a/src/lib/e2e/fake-supabase.ts
+++ b/src/lib/e2e/fake-supabase.ts
@@ -1,5 +1,13 @@
 type QueryResult<T> = { data: T | null; error: { message: string } | null }
 
+// Mirrors the real supabase-js rpc() envelope. Our SECURITY DEFINER RPCs use
+// `returns table(...)`, so `data` is an array the caller reads `[0]` from, and
+// `error` carries a Postgres `code` (22023 / 42501 / 40001 / 23505).
+type RpcResult = {
+  data: Record<string, unknown>[] | null
+  error: { code?: string; message: string } | null
+}
+
 type Filter = { column: string; value: unknown }
 
 type RealtimeStatus = 'SUBSCRIBED'
@@ -245,6 +253,9 @@ export function createFakeSupabaseClient() {
     },
     channel(name: string) {
       return new FakeRealtimeChannel(name)
+    },
+    rpc(fn: string, args?: Record<string, unknown>): Promise<RpcResult> {
+      return post<RpcResult>('/rpc', { fn, args })
     },
   }
 }

--- a/src/lib/player-name.test.ts
+++ b/src/lib/player-name.test.ts
@@ -1,0 +1,47 @@
+import { playerNameSchema, PLAYER_NAME_MIN, PLAYER_NAME_MAX } from './player-name'
+
+describe('playerNameSchema', () => {
+  describe('accepts', () => {
+    it.each([['Roman'], ['ローマン'], ['player 🎮'], ['x_42'], ['a'], ['a'.repeat(20)]])(
+      'accepts %p',
+      (name) => {
+        expect(playerNameSchema.safeParse(name).success).toBe(true)
+      }
+    )
+
+    it('accepts a name that is 1..20 code points after trim', () => {
+      expect(playerNameSchema.safeParse('  Roman  ').success).toBe(true)
+    })
+  })
+
+  describe('rejects', () => {
+    it('rejects an empty string', () => {
+      expect(playerNameSchema.safeParse('').success).toBe(false)
+    })
+
+    it('rejects an all-whitespace string (0 length after trim)', () => {
+      expect(playerNameSchema.safeParse('   ').success).toBe(false)
+    })
+
+    it('rejects 21+ characters', () => {
+      expect(playerNameSchema.safeParse('a'.repeat(21)).success).toBe(false)
+    })
+
+    it('rejects a zero-width character U+200B (Cf)', () => {
+      expect(playerNameSchema.safeParse('ab​cd').success).toBe(false)
+    })
+
+    it('rejects a control character U+0007 (Cc)', () => {
+      expect(playerNameSchema.safeParse('abcd').success).toBe(false)
+    })
+
+    it('rejects a non-string input', () => {
+      expect(playerNameSchema.safeParse(42).success).toBe(false)
+    })
+  })
+
+  it('exposes the 1..20 length bounds', () => {
+    expect(PLAYER_NAME_MIN).toBe(1)
+    expect(PLAYER_NAME_MAX).toBe(20)
+  })
+})

--- a/src/lib/player-name.ts
+++ b/src/lib/player-name.ts
@@ -1,3 +1,66 @@
+import { z } from 'zod'
+
+// Single source of truth for the player-name rule (D-05/D-06). The client Zod
+// validator below is the UX-side mirror of the Postgres `is_valid_player_name`
+// function in supabase-schema.sql. The server is authoritative; this validator
+// MUST be a SUBSET of the Postgres accept-set (INPUT-03 contract: client ⊆
+// Postgres — the client may be stricter, never looser). Both layers agree on
+// the 1..20 length bound (after trim) and on rejecting Unicode Cc/Cf/Zl/Zp.
+
+export const PLAYER_NAME_MIN = 1
+export const PLAYER_NAME_MAX = 20
+
+// Locked accept/reject rule (D-05):
+//   trim → require length 1..20 (counted in code points) → reject any character
+//   in Unicode categories Cc (control), Cf (format / zero-width), Zl (line
+//   separator) or Zp (paragraph separator). Everything else — unicode letters,
+//   digits, punctuation, emoji — is allowed.
+//
+// `\p{Cc}|\p{Cf}|\p{Zl}|\p{Zp}` (with the `u` flag) is at least as strict as the
+// Postgres predicate, which targets Cc plus a curated list of Cf/Zl/Zp code
+// points; rejecting the whole categories keeps client ⊆ Postgres.
+const FORBIDDEN_NAME_CHARS = /\p{Cc}|\p{Cf}|\p{Zl}|\p{Zp}/u
+
+// Documents the equivalent Postgres predicate so the parity is reviewable. This
+// is the INPUT-03 contract anchor (client ⊆ Postgres). Kept in sync with
+// `public.is_valid_player_name` in supabase-schema.sql.
+export const PLAYER_NAME_SQL_PREDICATE =
+  "char_length(btrim(name)) between 1 and 20 and btrim(name) !~ '[[:cntrl:]]' and btrim(name) rejects Cf/Zl/Zp code points"
+
+// Count length in Unicode code points (not UTF-16 units) so an emoji like 🎮
+// counts as 1 — matching Postgres `char_length`, which counts multibyte/emoji
+// as a single character. This keeps the 1..20 bound a true subset of Postgres.
+function codePointLength(value: string): number {
+  return [...value].length
+}
+
+// Strict validator — no `.transform()` that mutates downstream state. Trimming
+// is for validation only (mirror room-code.ts keeping roomCodeSchema strict).
+export const playerNameSchema = z.string().superRefine((raw, ctx) => {
+  const trimmed = raw.trim()
+  const len = codePointLength(trimmed)
+  if (len < PLAYER_NAME_MIN || len > PLAYER_NAME_MAX) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Name must be ${PLAYER_NAME_MIN}-${PLAYER_NAME_MAX} characters after trimming`,
+    })
+    return
+  }
+  if (FORBIDDEN_NAME_CHARS.test(trimmed)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Name must not contain control, format, or separator characters',
+    })
+  }
+})
+
+// Optional helper for the UI when it wants to store the trimmed value. The
+// schema itself validates the raw input; trimming for storage is a separate,
+// explicit choice (mirrors normalizeRoomCode living outside roomCodeSchema).
+export function trimmedPlayerName(raw: string): string {
+  return raw.trim()
+}
+
 const STORAGE_KEY = 'library-games:player-name'
 
 export function getSavedPlayerName(): string {

--- a/src/lib/room-code.test.ts
+++ b/src/lib/room-code.test.ts
@@ -1,0 +1,153 @@
+import fs from 'fs'
+import path from 'path'
+import {
+  ROOM_CODE_ALPHABET,
+  ROOM_CODE_LENGTH,
+  ROOM_CODE_REGEX,
+  ROOM_CODE_REGEX_SQL,
+  generateRoomCode,
+  normalizeRoomCode,
+  roomCodeSchema,
+} from './room-code'
+
+describe('alphabet sanity', () => {
+  it('has exactly 32 symbols', () => {
+    expect(ROOM_CODE_ALPHABET).toHaveLength(32)
+  })
+
+  it('has all-unique characters', () => {
+    expect(new Set(ROOM_CODE_ALPHABET.split('')).size).toBe(32)
+  })
+
+  it('every single alphabet char matches ROOM_CODE_REGEX when repeated to length', () => {
+    for (const ch of ROOM_CODE_ALPHABET) {
+      expect(ROOM_CODE_REGEX.test(ch.repeat(ROOM_CODE_LENGTH))).toBe(true)
+    }
+  })
+
+  it('excludes the Crockford look-alike letters I, L, O, U', () => {
+    for (const ch of ['I', 'L', 'O', 'U']) {
+      expect(ROOM_CODE_ALPHABET.includes(ch)).toBe(false)
+    }
+  })
+})
+
+describe('3-layer agreement', () => {
+  const sqlRegex = new RegExp(ROOM_CODE_REGEX_SQL)
+
+  it('every generated code passes the TS regex, the Zod schema, and the SQL regex', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 2000; i++) {
+      const code = generateRoomCode()
+      expect(code).toHaveLength(ROOM_CODE_LENGTH)
+      expect(ROOM_CODE_REGEX.test(code)).toBe(true)
+      expect(roomCodeSchema.safeParse(code).success).toBe(true)
+      expect(sqlRegex.test(code)).toBe(true)
+      for (const ch of code) seen.add(ch)
+    }
+    // Over 2000 codes (12000 chars) every one of the 32 symbols should appear.
+    expect(seen.size).toBe(32)
+  })
+
+  it('rejects the old 4-char hex format', () => {
+    expect(roomCodeSchema.safeParse('A1B2').success).toBe(false)
+    expect(ROOM_CODE_REGEX.test('A1B2')).toBe(false)
+    expect(sqlRegex.test('A1B2')).toBe(false)
+  })
+
+  it('rejects codes containing excluded look-alike letters', () => {
+    expect(roomCodeSchema.safeParse('IL0OU1').success).toBe(false)
+  })
+})
+
+describe('SQL drift guard', () => {
+  const schemaPath = path.resolve(__dirname, '../../supabase-schema.sql')
+  const sql = fs.readFileSync(schemaPath, 'utf8')
+  const literals = [...sql.matchAll(/code ~ '([^']+)'/g)].map((m) => m[1])
+
+  it('finds exactly 6 insert-CHECK code regex literals', () => {
+    expect(literals).toHaveLength(6)
+  })
+
+  it('every SQL code regex literal is byte-identical to ROOM_CODE_REGEX_SQL', () => {
+    for (const literal of literals) {
+      expect(literal).toBe(ROOM_CODE_REGEX_SQL)
+    }
+  })
+})
+
+// MIGR-03: the access-control / broadcast DB layer is templated identically
+// across all 6 room tables. Each templated element must appear exactly 6×; a
+// future edit that templates only 5 of 6 (or drops one) trips these guards.
+// ACCESS-04: every SECURITY DEFINER body must pin search_path to '' (lint 0011).
+describe('schema templating drift guard (MIGR-03 / ACCESS-04)', () => {
+  const schemaPath = path.resolve(__dirname, '../../supabase-schema.sql')
+  const sql = fs.readFileSync(schemaPath, 'utf8')
+
+  const countMatches = (re: RegExp) => [...sql.matchAll(re)].length
+
+  it('declares the room_token column on all 6 tables', () => {
+    expect(countMatches(/room_token uuid not null default gen_random_uuid\(\)/g)).toBe(6)
+  })
+
+  it('wires the _broadcast_state after-update trigger on all 6 tables', () => {
+    expect(countMatches(/_broadcast_state after update on public\./g)).toBe(6)
+  })
+
+  it.each(['create', 'join', 'restore', 'dispatch'])('defines the %s_<game> RPC 6×', (op) => {
+    expect(countMatches(new RegExp(`create or replace function public\\.${op}_`, 'g'))).toBe(6)
+  })
+
+  it('pins search_path on every `security definer` function (definer hygiene, lint 0011)', () => {
+    // Every SECURITY DEFINER function MUST pin search_path to '' (Advisor 0011). Some
+    // non-definer functions (e.g. protect_immutable_columns) also pin it, so pinned ≥ definer
+    // rather than strict equality — the invariant is that no definer body is left unpinned.
+    const definer = countMatches(/security definer/g)
+    const pinned = countMatches(/set search_path = ''/g)
+    expect(definer).toBeGreaterThan(0)
+    expect(pinned).toBeGreaterThanOrEqual(definer)
+  })
+
+  it('validates player names server-side on create + join + dispatch (18× — CR-04/INPUT-01)', () => {
+    // Each of create/join/dispatch loops over players and calls is_valid_player_name,
+    // templated across all 6 tables → 18 call sites. dispatch (the steady-state write
+    // path) is a trust boundary and must validate too, not only create/join.
+    expect(countMatches(/if not public\.is_valid_player_name\(v_player ->> 'name'\) then/g)).toBe(
+      18
+    )
+  })
+
+  it('enforces the lobby + add-one-player join invariant on all 6 tables (CR-02)', () => {
+    // join_<game> must read the existing row and reject any write that is not a
+    // single-player addition during lobby, so join cannot overwrite live state.
+    expect(countMatches(/join is only valid in lobby/g)).toBe(6)
+    expect(
+      countMatches(
+        /jsonb_array_length\(p_new_state -> 'players'\) <> jsonb_array_length\(v_row\.state -> 'players'\) \+ 1/g
+      )
+    ).toBe(6)
+  })
+})
+
+describe('normalizeRoomCode', () => {
+  it('uppercases lowercase input', () => {
+    expect(normalizeRoomCode('abc234')).toBe('ABC234')
+  })
+
+  it('maps O to 0 and I/L to 1', () => {
+    expect(normalizeRoomCode('oil')).toBe('011')
+  })
+
+  it('strips non-alphabet characters', () => {
+    expect(normalizeRoomCode('a1b-2 c3')).toBe('A1B2C3')
+  })
+
+  it('caps output at ROOM_CODE_LENGTH', () => {
+    expect(normalizeRoomCode('ABCDEFGHJK')).toHaveLength(ROOM_CODE_LENGTH)
+  })
+
+  it('produces a code that validates when given a clean 6-char look-alike input', () => {
+    const normalized = normalizeRoomCode('o1l-abc def'.toUpperCase())
+    expect(ROOM_CODE_REGEX.test(normalized)).toBe(normalized.length === ROOM_CODE_LENGTH)
+  })
+})

--- a/src/lib/room-code.ts
+++ b/src/lib/room-code.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+
+// Single source of truth for the room-code format. The generator, the Zod
+// validator, and the Postgres `with check` regex are all derived from the
+// constants below so the three layers cannot drift (CODE-03).
+
+// 32 Crockford base-32 symbols: 0-9 then A-Z minus I, L, O, U.
+export const ROOM_CODE_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+
+export const ROOM_CODE_LENGTH = 6
+
+// TS regex and the literal SQL string MUST describe the same set.
+export const ROOM_CODE_REGEX = /^[0-9A-HJKMNP-TV-Z]{6}$/
+export const ROOM_CODE_REGEX_SQL = '^[0-9A-HJKMNP-TV-Z]{6}$'
+
+// Test-only seam (E2E): a FIFO queue of codes the next generateRoomCode() calls
+// should return verbatim, so a Playwright test can force a deterministic collision
+// (return an already-seeded code once, then real CSPRNG codes). Honored ONLY when
+// the in-memory fake Supabase is active — it is inert in every real deployment.
+const E2E_FAKE = process.env.NEXT_PUBLIC_E2E_FAKE_SUPABASE === '1'
+
+declare global {
+  var __E2E_FORCED_ROOM_CODES__: string[] | undefined
+}
+
+// Generate a 6-char room code from a CSPRNG. The alphabet is exactly 32 = 2^5,
+// so `byte & 31` is an unbiased index into it (no modulo bias). No Math.random.
+export function generateRoomCode(): string {
+  if (E2E_FAKE && typeof globalThis !== 'undefined') {
+    const forced = globalThis.__E2E_FORCED_ROOM_CODES__
+    if (forced && forced.length > 0) {
+      const next = forced.shift()
+      if (next) return next
+    }
+  }
+  const bytes = new Uint8Array(ROOM_CODE_LENGTH)
+  crypto.getRandomValues(bytes)
+  let code = ''
+  for (let i = 0; i < ROOM_CODE_LENGTH; i++) {
+    code += ROOM_CODE_ALPHABET[bytes[i] & 31]
+  }
+  return code
+}
+
+// Edge normalizer for user-typed codes: uppercase, fold Crockford look-alikes
+// (O->0, I/L->1; U is already excluded from the alphabet), strip anything not in
+// the alphabet, and cap at the code length. This lives OUTSIDE the validator so
+// roomCodeSchema can stay strict (D-03).
+export function normalizeRoomCode(raw: string): string {
+  return raw
+    .toUpperCase()
+    .replace(/O/g, '0')
+    .replace(/[IL]/g, '1')
+    .replace(/[^0-9A-HJKMNP-TV-Z]/g, '')
+    .slice(0, ROOM_CODE_LENGTH)
+}
+
+// Strict validator — no `.transform()`. Its accept-set equals the DB regex's.
+export const roomCodeSchema = z.string().regex(ROOM_CODE_REGEX)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,10 @@
 import { createClient } from '@supabase/supabase-js'
 import { createFakeSupabaseClient } from '@/lib/e2e/fake-supabase'
 
-type QueryResult<T> = Promise<{ data: T | null; error: { message: string } | null }>
+type QueryResult<T> = Promise<{
+  data: T | null
+  error: { message: string; code?: string; details?: string; hint?: string } | null
+}>
 
 type QueryBuilderBoundary = {
   insert(values: unknown): QueryBuilderBoundary
@@ -24,9 +27,17 @@ type ChannelBoundary = {
   unsubscribe(): Promise<unknown>
 }
 
+// SECURITY DEFINER RPCs (plan 02-01) use `returns table(...)`, so `data` is an array the
+// caller reads `[0]` from, and `error` carries a stable Postgres `code` (22023/42501/40001/23505).
+type RpcResult = {
+  data: Record<string, unknown>[] | null
+  error: { message: string; code?: string } | null
+}
+
 type SupabaseBoundary = {
   from(table: string): QueryBuilderBoundary
   channel(name: string): ChannelBoundary
+  rpc(fn: string, args?: Record<string, unknown>): Promise<RpcResult>
 }
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -28,7 +28,9 @@ alter publication supabase_realtime add table uno_rooms;
 -- Prevent mutations to immutable columns (id, code) on UPDATE.
 -- RLS with-check only sees the NEW row, so a trigger is needed to compare OLD vs NEW.
 create or replace function protect_immutable_columns()
-returns trigger language plpgsql as $$
+returns trigger language plpgsql
+set search_path = ''
+as $$
 begin
   if new.id <> old.id then
     raise exception 'cannot change id';
@@ -55,10 +57,10 @@ alter table uno_rooms enable row level security;
 -- enumeration, use Supabase Auth with user-scoped rooms.
 create policy "select rooms" on uno_rooms for select using (true);
 
--- INSERT: enforce 4-char uppercase alphanumeric room code format
+-- INSERT: enforce 6-char Crockford base-32 room code format
 create policy "insert with valid code" on uno_rooms
   for insert with check (
-    code ~ '^[A-Z0-9]{4}$'
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
     and state is not null
   );
 
@@ -97,7 +99,7 @@ create policy "select skribbl rooms" on skribbl_rooms for select using (true);
 
 create policy "insert skribbl rooms" on skribbl_rooms
   for insert with check (
-    code ~ '^[A-Z0-9]{4}$'
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
     and state is not null
   );
 
@@ -131,7 +133,7 @@ create policy "select agario rooms" on agario_rooms for select using (true);
 
 create policy "insert agario rooms" on agario_rooms
   for insert with check (
-    code ~ '^[A-Z0-9]{4}$'
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
     and state is not null
   );
 
@@ -165,7 +167,7 @@ create policy "select cah rooms" on cah_rooms for select using (true);
 
 create policy "insert cah rooms" on cah_rooms
   for insert with check (
-    code ~ '^[A-Z0-9]{4}$'
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
     and state is not null
   );
 
@@ -199,7 +201,7 @@ create policy "select codenames rooms" on codenames_rooms for select using (true
 
 create policy "insert codenames rooms" on codenames_rooms
   for insert with check (
-    code ~ '^[A-Z0-9]{4}$'
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
     and state is not null
   );
 
@@ -233,7 +235,7 @@ create policy "select mindmeld rooms" on mindmeld_rooms for select using (true);
 
 create policy "insert mindmeld rooms" on mindmeld_rooms
   for insert with check (
-    code ~ '^[A-Z0-9]{4}$'
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
     and state is not null
   );
 
@@ -249,3 +251,1146 @@ create policy "update mindmeld rooms" on mindmeld_rooms for update using (true);
 -- alter table skribbl_rooms add column if not exists version integer not null default 1;
 -- alter table agario_rooms  add column if not exists version integer not null default 1;
 -- alter table cah_rooms     add column if not exists version integer not null default 1;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- Phase 2 (ADDITIVE): member-scoped RPCs, broadcast delivery, server-side
+-- validation. Everything below is additive — the permissive `using(true)`
+-- SELECT/UPDATE policies above stay in place (sealing is Phase 3, never this
+-- phase). Each block is independently reversible (drop column / drop trigger /
+-- drop function) and does not break in-flight rooms or stale cached clients.
+-- Applied identically across all 6 room tables from one templated source
+-- (MIGR-03 / D-15).
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- ─── room_token column (×6) ─────────────────────────────────────────────────
+-- The per-room write capability (D-01). UUID v4 = ~122 bits CSPRNG, server-
+-- minted, never in the invite URL. `add column if not exists ... default
+-- gen_random_uuid()` backfills existing rows so live pre-migration rooms get a
+-- token (Runtime State Inventory).
+
+alter table public.uno_rooms       add column if not exists room_token uuid not null default gen_random_uuid();
+alter table public.skribbl_rooms   add column if not exists room_token uuid not null default gen_random_uuid();
+alter table public.agario_rooms    add column if not exists room_token uuid not null default gen_random_uuid();
+alter table public.cah_rooms       add column if not exists room_token uuid not null default gen_random_uuid();
+alter table public.codenames_rooms add column if not exists room_token uuid not null default gen_random_uuid();
+alter table public.mindmeld_rooms  add column if not exists room_token uuid not null default gen_random_uuid();
+
+-- ─── Shared broadcast trigger function ───────────────────────────────────────
+-- Emits the full {state, version} on the PUBLIC topic `room:CODE` after every
+-- state UPDATE (ACCESS-05, D-09 full payload, D-11 secret-topic model). The 4th
+-- arg to realtime.send MUST be `false` → PUBLIC channel that any anon client may
+-- subscribe to without a JWT or RLS on realtime.messages. Do NOT use
+-- realtime.broadcast_changes() (hardwired private) and do NOT pass true here.
+-- search_path = '' forces fully-qualified public./realtime. names (lint 0011).
+
+create or replace function public.broadcast_room_state()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  perform realtime.send(
+    jsonb_build_object('state', new.state, 'version', new.version),
+    'state',                       -- event name (client .on('broadcast',{event:'state'}))
+    'room:' || new.code,           -- topic = the room code (the secret)
+    false                          -- private=false → PUBLIC channel (anon-subscribable)
+  );
+  return null;
+end;
+$$;
+
+-- ─── Per-table broadcast triggers (×6) ───────────────────────────────────────
+
+create or replace trigger uno_rooms_broadcast_state after update on public.uno_rooms
+  for each row execute function public.broadcast_room_state();
+
+create or replace trigger skribbl_rooms_broadcast_state after update on public.skribbl_rooms
+  for each row execute function public.broadcast_room_state();
+
+create or replace trigger agario_rooms_broadcast_state after update on public.agario_rooms
+  for each row execute function public.broadcast_room_state();
+
+create or replace trigger cah_rooms_broadcast_state after update on public.cah_rooms
+  for each row execute function public.broadcast_room_state();
+
+create or replace trigger codenames_rooms_broadcast_state after update on public.codenames_rooms
+  for each row execute function public.broadcast_room_state();
+
+create or replace trigger mindmeld_rooms_broadcast_state after update on public.mindmeld_rooms
+  for each row execute function public.broadcast_room_state();
+
+-- ─── Server-side player-name validation helper (INPUT-01, D-05) ──────────────
+-- A name is valid iff, after trim, its length is 1..20 AND it contains no
+-- character in Unicode categories Cc (control), Cf (format), Zl (line
+-- separator) or Zp (paragraph separator). Everything else — unicode letters,
+-- digits, punctuation, emoji — is allowed (the real risks for a casual arcade
+-- are length-DoS and blank/invisible names; React escapes rendered output).
+-- Client Zod is a SUBSET of this accept-set (INPUT-03: client ⊆ Postgres).
+-- MUST accept "Roman", "ローマン", "player 🎮", "x_42"; MUST reject empty /
+-- all-whitespace, 21+ chars, control and zero-width characters.
+-- search_path = '' → fully-qualified names below.
+create or replace function public.is_valid_player_name(p_name text)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_trimmed text;
+begin
+  if p_name is null then
+    return false;
+  end if;
+  v_trimmed := btrim(p_name);
+  -- length 1..20 after trim (char_length counts multibyte/emoji as 1)
+  if char_length(v_trimmed) < 1 or char_length(v_trimmed) > 20 then
+    return false;
+  end if;
+  -- Reject control characters: Cc = U+0000-001F, U+007F-009F (POSIX [:cntrl:]).
+  if v_trimmed ~ '[[:cntrl:]]' then
+    return false;
+  end if;
+  -- Reject Cf (format / zero-width), Zl, Zp and related invisible code points.
+  -- The bracket class below contains the literal code points (Postgres POSIX
+  -- regex matches the actual characters; \u escapes are not portable here):
+  --   U+00AD soft hyphen, U+200B-200F zero-width + bidi marks, U+2028 line sep
+  --   (Zl), U+2029 para sep (Zp), U+202A-202E bidi embeddings, U+2060-2064
+  --   word-joiner group, U+FEFF BOM/ZWNBSP, U+FFF9-FFFB interlinear annotation.
+  if v_trimmed ~ '[­​-‏  ‪-‮⁠-⁤﻿￹-￻]' then
+    return false;
+  end if;
+  return true;
+end;
+$$;
+
+revoke all on function public.is_valid_player_name(text) from public;
+grant execute on function public.is_valid_player_name(text) to anon;
+
+-- ─── Member-scoped SECURITY DEFINER RPCs (×6 games) ──────────────────────────
+-- Four RPCs per game (create / join / restore / dispatch). Every function:
+--   * security definer + set search_path = '' + fully-qualified public. names
+--     (ACCESS-04, clears Security Advisor lint 0011)
+--   * revoke all from public; grant execute to anon only (scoped EXECUTE)
+--   * re-checks the canonical 6-char Crockford code server-side (INPUT-02)
+--   * validates every player name in the candidate state (INPUT-01, helper)
+-- Errcodes (mapped to friendly UI strings by the hook — no raw DB errors):
+--   22023 invalid code / invalid name | 42501 unauthorized (token / not member)
+--   40001 version conflict (CAS). The reducer stays client-side; dispatch takes
+--   p_new_state + p_expected_version and does the CAS (Open Question 1 RESOLVED).
+-- All writes require code + room_token (D-02/D-03). join issues the token;
+-- restore re-issues it iff p_player_id ∈ state.players (D-04).
+
+-- ── uno_rooms ──────────────────────────────────────────────────────────────────
+
+create or replace function public.create_uno(p_code text, p_state jsonb)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  return query
+  insert into public.uno_rooms (code, state, room_token)
+  values (p_code, p_state, gen_random_uuid())
+  returning public.uno_rooms.state, public.uno_rooms.version, public.uno_rooms.room_token;
+end;
+$$;
+
+revoke all on function public.create_uno(text, jsonb) from public;
+grant execute on function public.create_uno(text, jsonb) to anon;
+
+create or replace function public.join_uno(p_code text, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+  v_row public.uno_rooms;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  select * into v_row from public.uno_rooms where public.uno_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if v_row.version <> p_expected_version then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+  -- CR-02: join is only valid in lobby and must add exactly one player without
+  -- dropping an existing member, so join cannot overwrite live game state.
+  if (v_row.state ->> 'phase') is distinct from 'lobby' then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if jsonb_array_length(p_new_state -> 'players') <> jsonb_array_length(v_row.state -> 'players') + 1 then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as old_p
+     where not exists (
+       select 1 from jsonb_array_elements(p_new_state -> 'players') as new_p
+        where new_p ->> 'id' = old_p ->> 'id'
+     )
+  ) then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- CAS: add the joining player by overwriting state at the expected version.
+  return query
+  update public.uno_rooms
+     set state = p_new_state, version = public.uno_rooms.version + 1
+   where public.uno_rooms.code = p_code
+     and public.uno_rooms.version = p_expected_version
+  returning public.uno_rooms.state, public.uno_rooms.version, public.uno_rooms.room_token;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.join_uno(text, jsonb, integer) from public;
+grant execute on function public.join_uno(text, jsonb, integer) to anon;
+
+create or replace function public.restore_uno(p_code text, p_player_id text)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.uno_rooms;
+  v_present boolean;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.uno_rooms where public.uno_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- verify p_player_id ∈ state.players (jsonb membership) (D-04)
+  select exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as p
+     where p ->> 'id' = p_player_id
+  ) into v_present;
+  if not v_present then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- re-issue (return) the existing token so token-less sessions survive a reload
+  return query select v_row.state, v_row.version, v_row.room_token;
+end;
+$$;
+
+revoke all on function public.restore_uno(text, text) from public;
+grant execute on function public.restore_uno(text, text) to anon;
+
+create or replace function public.dispatch_uno(p_code text, p_room_token uuid, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.uno_rooms;
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.uno_rooms where public.uno_rooms.code = p_code;
+  if not found or v_row.room_token <> p_room_token then
+    raise exception 'unauthorized' using errcode = '42501';   -- token gate (ACCESS-03)
+  end if;
+  -- INPUT-01: validate every player name server-side on the steady-state write
+  -- path too (CR-04), consistent with create/join — dispatch is a trust boundary.
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  -- CAS (optimistic concurrency); 40001 on conflict → client re-reads + retries
+  return query
+  update public.uno_rooms
+     set state = p_new_state, version = public.uno_rooms.version + 1
+   where public.uno_rooms.code = p_code
+     and public.uno_rooms.version = p_expected_version
+  returning public.uno_rooms.state, public.uno_rooms.version;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.dispatch_uno(text, uuid, jsonb, integer) from public;
+grant execute on function public.dispatch_uno(text, uuid, jsonb, integer) to anon;
+
+-- ── skribbl_rooms ──────────────────────────────────────────────────────────────────
+
+create or replace function public.create_skribbl(p_code text, p_state jsonb)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  return query
+  insert into public.skribbl_rooms (code, state, room_token)
+  values (p_code, p_state, gen_random_uuid())
+  returning public.skribbl_rooms.state, public.skribbl_rooms.version, public.skribbl_rooms.room_token;
+end;
+$$;
+
+revoke all on function public.create_skribbl(text, jsonb) from public;
+grant execute on function public.create_skribbl(text, jsonb) to anon;
+
+create or replace function public.join_skribbl(p_code text, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+  v_row public.skribbl_rooms;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  select * into v_row from public.skribbl_rooms where public.skribbl_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if v_row.version <> p_expected_version then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+  -- CR-02: join is only valid in lobby and must add exactly one player without
+  -- dropping an existing member, so join cannot overwrite live game state.
+  if (v_row.state ->> 'phase') is distinct from 'lobby' then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if jsonb_array_length(p_new_state -> 'players') <> jsonb_array_length(v_row.state -> 'players') + 1 then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as old_p
+     where not exists (
+       select 1 from jsonb_array_elements(p_new_state -> 'players') as new_p
+        where new_p ->> 'id' = old_p ->> 'id'
+     )
+  ) then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- CAS: add the joining player by overwriting state at the expected version.
+  return query
+  update public.skribbl_rooms
+     set state = p_new_state, version = public.skribbl_rooms.version + 1
+   where public.skribbl_rooms.code = p_code
+     and public.skribbl_rooms.version = p_expected_version
+  returning public.skribbl_rooms.state, public.skribbl_rooms.version, public.skribbl_rooms.room_token;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.join_skribbl(text, jsonb, integer) from public;
+grant execute on function public.join_skribbl(text, jsonb, integer) to anon;
+
+create or replace function public.restore_skribbl(p_code text, p_player_id text)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.skribbl_rooms;
+  v_present boolean;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.skribbl_rooms where public.skribbl_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- verify p_player_id ∈ state.players (jsonb membership) (D-04)
+  select exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as p
+     where p ->> 'id' = p_player_id
+  ) into v_present;
+  if not v_present then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- re-issue (return) the existing token so token-less sessions survive a reload
+  return query select v_row.state, v_row.version, v_row.room_token;
+end;
+$$;
+
+revoke all on function public.restore_skribbl(text, text) from public;
+grant execute on function public.restore_skribbl(text, text) to anon;
+
+create or replace function public.dispatch_skribbl(p_code text, p_room_token uuid, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.skribbl_rooms;
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.skribbl_rooms where public.skribbl_rooms.code = p_code;
+  if not found or v_row.room_token <> p_room_token then
+    raise exception 'unauthorized' using errcode = '42501';   -- token gate (ACCESS-03)
+  end if;
+  -- INPUT-01: validate every player name server-side on the steady-state write
+  -- path too (CR-04), consistent with create/join — dispatch is a trust boundary.
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  -- CAS (optimistic concurrency); 40001 on conflict → client re-reads + retries
+  return query
+  update public.skribbl_rooms
+     set state = p_new_state, version = public.skribbl_rooms.version + 1
+   where public.skribbl_rooms.code = p_code
+     and public.skribbl_rooms.version = p_expected_version
+  returning public.skribbl_rooms.state, public.skribbl_rooms.version;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.dispatch_skribbl(text, uuid, jsonb, integer) from public;
+grant execute on function public.dispatch_skribbl(text, uuid, jsonb, integer) to anon;
+
+-- ── agario_rooms ──────────────────────────────────────────────────────────────────
+
+create or replace function public.create_agario(p_code text, p_state jsonb)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  return query
+  insert into public.agario_rooms (code, state, room_token)
+  values (p_code, p_state, gen_random_uuid())
+  returning public.agario_rooms.state, public.agario_rooms.version, public.agario_rooms.room_token;
+end;
+$$;
+
+revoke all on function public.create_agario(text, jsonb) from public;
+grant execute on function public.create_agario(text, jsonb) to anon;
+
+create or replace function public.join_agario(p_code text, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+  v_row public.agario_rooms;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  select * into v_row from public.agario_rooms where public.agario_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if v_row.version <> p_expected_version then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+  -- CR-02: join is only valid in lobby and must add exactly one player without
+  -- dropping an existing member, so join cannot overwrite live game state.
+  if (v_row.state ->> 'phase') is distinct from 'lobby' then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if jsonb_array_length(p_new_state -> 'players') <> jsonb_array_length(v_row.state -> 'players') + 1 then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as old_p
+     where not exists (
+       select 1 from jsonb_array_elements(p_new_state -> 'players') as new_p
+        where new_p ->> 'id' = old_p ->> 'id'
+     )
+  ) then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- CAS: add the joining player by overwriting state at the expected version.
+  return query
+  update public.agario_rooms
+     set state = p_new_state, version = public.agario_rooms.version + 1
+   where public.agario_rooms.code = p_code
+     and public.agario_rooms.version = p_expected_version
+  returning public.agario_rooms.state, public.agario_rooms.version, public.agario_rooms.room_token;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.join_agario(text, jsonb, integer) from public;
+grant execute on function public.join_agario(text, jsonb, integer) to anon;
+
+create or replace function public.restore_agario(p_code text, p_player_id text)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.agario_rooms;
+  v_present boolean;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.agario_rooms where public.agario_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- verify p_player_id ∈ state.players (jsonb membership) (D-04)
+  select exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as p
+     where p ->> 'id' = p_player_id
+  ) into v_present;
+  if not v_present then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- re-issue (return) the existing token so token-less sessions survive a reload
+  return query select v_row.state, v_row.version, v_row.room_token;
+end;
+$$;
+
+revoke all on function public.restore_agario(text, text) from public;
+grant execute on function public.restore_agario(text, text) to anon;
+
+create or replace function public.dispatch_agario(p_code text, p_room_token uuid, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.agario_rooms;
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.agario_rooms where public.agario_rooms.code = p_code;
+  if not found or v_row.room_token <> p_room_token then
+    raise exception 'unauthorized' using errcode = '42501';   -- token gate (ACCESS-03)
+  end if;
+  -- INPUT-01: validate every player name server-side on the steady-state write
+  -- path too (CR-04), consistent with create/join — dispatch is a trust boundary.
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  -- CAS (optimistic concurrency); 40001 on conflict → client re-reads + retries
+  return query
+  update public.agario_rooms
+     set state = p_new_state, version = public.agario_rooms.version + 1
+   where public.agario_rooms.code = p_code
+     and public.agario_rooms.version = p_expected_version
+  returning public.agario_rooms.state, public.agario_rooms.version;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.dispatch_agario(text, uuid, jsonb, integer) from public;
+grant execute on function public.dispatch_agario(text, uuid, jsonb, integer) to anon;
+
+-- ── cah_rooms ──────────────────────────────────────────────────────────────────
+
+create or replace function public.create_cah(p_code text, p_state jsonb)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  return query
+  insert into public.cah_rooms (code, state, room_token)
+  values (p_code, p_state, gen_random_uuid())
+  returning public.cah_rooms.state, public.cah_rooms.version, public.cah_rooms.room_token;
+end;
+$$;
+
+revoke all on function public.create_cah(text, jsonb) from public;
+grant execute on function public.create_cah(text, jsonb) to anon;
+
+create or replace function public.join_cah(p_code text, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+  v_row public.cah_rooms;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  select * into v_row from public.cah_rooms where public.cah_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if v_row.version <> p_expected_version then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+  -- CR-02: join is only valid in lobby and must add exactly one player without
+  -- dropping an existing member, so join cannot overwrite live game state.
+  if (v_row.state ->> 'phase') is distinct from 'lobby' then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if jsonb_array_length(p_new_state -> 'players') <> jsonb_array_length(v_row.state -> 'players') + 1 then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as old_p
+     where not exists (
+       select 1 from jsonb_array_elements(p_new_state -> 'players') as new_p
+        where new_p ->> 'id' = old_p ->> 'id'
+     )
+  ) then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- CAS: add the joining player by overwriting state at the expected version.
+  return query
+  update public.cah_rooms
+     set state = p_new_state, version = public.cah_rooms.version + 1
+   where public.cah_rooms.code = p_code
+     and public.cah_rooms.version = p_expected_version
+  returning public.cah_rooms.state, public.cah_rooms.version, public.cah_rooms.room_token;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.join_cah(text, jsonb, integer) from public;
+grant execute on function public.join_cah(text, jsonb, integer) to anon;
+
+create or replace function public.restore_cah(p_code text, p_player_id text)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.cah_rooms;
+  v_present boolean;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.cah_rooms where public.cah_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- verify p_player_id ∈ state.players (jsonb membership) (D-04)
+  select exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as p
+     where p ->> 'id' = p_player_id
+  ) into v_present;
+  if not v_present then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- re-issue (return) the existing token so token-less sessions survive a reload
+  return query select v_row.state, v_row.version, v_row.room_token;
+end;
+$$;
+
+revoke all on function public.restore_cah(text, text) from public;
+grant execute on function public.restore_cah(text, text) to anon;
+
+create or replace function public.dispatch_cah(p_code text, p_room_token uuid, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.cah_rooms;
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.cah_rooms where public.cah_rooms.code = p_code;
+  if not found or v_row.room_token <> p_room_token then
+    raise exception 'unauthorized' using errcode = '42501';   -- token gate (ACCESS-03)
+  end if;
+  -- INPUT-01: validate every player name server-side on the steady-state write
+  -- path too (CR-04), consistent with create/join — dispatch is a trust boundary.
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  -- CAS (optimistic concurrency); 40001 on conflict → client re-reads + retries
+  return query
+  update public.cah_rooms
+     set state = p_new_state, version = public.cah_rooms.version + 1
+   where public.cah_rooms.code = p_code
+     and public.cah_rooms.version = p_expected_version
+  returning public.cah_rooms.state, public.cah_rooms.version;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.dispatch_cah(text, uuid, jsonb, integer) from public;
+grant execute on function public.dispatch_cah(text, uuid, jsonb, integer) to anon;
+
+-- ── codenames_rooms ──────────────────────────────────────────────────────────────────
+
+create or replace function public.create_codenames(p_code text, p_state jsonb)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  return query
+  insert into public.codenames_rooms (code, state, room_token)
+  values (p_code, p_state, gen_random_uuid())
+  returning public.codenames_rooms.state, public.codenames_rooms.version, public.codenames_rooms.room_token;
+end;
+$$;
+
+revoke all on function public.create_codenames(text, jsonb) from public;
+grant execute on function public.create_codenames(text, jsonb) to anon;
+
+create or replace function public.join_codenames(p_code text, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+  v_row public.codenames_rooms;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  select * into v_row from public.codenames_rooms where public.codenames_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if v_row.version <> p_expected_version then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+  -- CR-02: join is only valid in lobby and must add exactly one player without
+  -- dropping an existing member, so join cannot overwrite live game state.
+  if (v_row.state ->> 'phase') is distinct from 'lobby' then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if jsonb_array_length(p_new_state -> 'players') <> jsonb_array_length(v_row.state -> 'players') + 1 then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as old_p
+     where not exists (
+       select 1 from jsonb_array_elements(p_new_state -> 'players') as new_p
+        where new_p ->> 'id' = old_p ->> 'id'
+     )
+  ) then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- CAS: add the joining player by overwriting state at the expected version.
+  return query
+  update public.codenames_rooms
+     set state = p_new_state, version = public.codenames_rooms.version + 1
+   where public.codenames_rooms.code = p_code
+     and public.codenames_rooms.version = p_expected_version
+  returning public.codenames_rooms.state, public.codenames_rooms.version, public.codenames_rooms.room_token;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.join_codenames(text, jsonb, integer) from public;
+grant execute on function public.join_codenames(text, jsonb, integer) to anon;
+
+create or replace function public.restore_codenames(p_code text, p_player_id text)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.codenames_rooms;
+  v_present boolean;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.codenames_rooms where public.codenames_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- verify p_player_id ∈ state.players (jsonb membership) (D-04)
+  select exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as p
+     where p ->> 'id' = p_player_id
+  ) into v_present;
+  if not v_present then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- re-issue (return) the existing token so token-less sessions survive a reload
+  return query select v_row.state, v_row.version, v_row.room_token;
+end;
+$$;
+
+revoke all on function public.restore_codenames(text, text) from public;
+grant execute on function public.restore_codenames(text, text) to anon;
+
+create or replace function public.dispatch_codenames(p_code text, p_room_token uuid, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.codenames_rooms;
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.codenames_rooms where public.codenames_rooms.code = p_code;
+  if not found or v_row.room_token <> p_room_token then
+    raise exception 'unauthorized' using errcode = '42501';   -- token gate (ACCESS-03)
+  end if;
+  -- INPUT-01: validate every player name server-side on the steady-state write
+  -- path too (CR-04), consistent with create/join — dispatch is a trust boundary.
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  -- CAS (optimistic concurrency); 40001 on conflict → client re-reads + retries
+  return query
+  update public.codenames_rooms
+     set state = p_new_state, version = public.codenames_rooms.version + 1
+   where public.codenames_rooms.code = p_code
+     and public.codenames_rooms.version = p_expected_version
+  returning public.codenames_rooms.state, public.codenames_rooms.version;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.dispatch_codenames(text, uuid, jsonb, integer) from public;
+grant execute on function public.dispatch_codenames(text, uuid, jsonb, integer) to anon;
+
+-- ── mindmeld_rooms ──────────────────────────────────────────────────────────────────
+
+create or replace function public.create_mindmeld(p_code text, p_state jsonb)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  return query
+  insert into public.mindmeld_rooms (code, state, room_token)
+  values (p_code, p_state, gen_random_uuid())
+  returning public.mindmeld_rooms.state, public.mindmeld_rooms.version, public.mindmeld_rooms.room_token;
+end;
+$$;
+
+revoke all on function public.create_mindmeld(text, jsonb) from public;
+grant execute on function public.create_mindmeld(text, jsonb) to anon;
+
+create or replace function public.join_mindmeld(p_code text, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_player jsonb;
+  v_row public.mindmeld_rooms;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  select * into v_row from public.mindmeld_rooms where public.mindmeld_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if v_row.version <> p_expected_version then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+  -- CR-02: join is only valid in lobby and must add exactly one player without
+  -- dropping an existing member, so join cannot overwrite live game state.
+  if (v_row.state ->> 'phase') is distinct from 'lobby' then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if jsonb_array_length(p_new_state -> 'players') <> jsonb_array_length(v_row.state -> 'players') + 1 then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  if exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as old_p
+     where not exists (
+       select 1 from jsonb_array_elements(p_new_state -> 'players') as new_p
+        where new_p ->> 'id' = old_p ->> 'id'
+     )
+  ) then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- CAS: add the joining player by overwriting state at the expected version.
+  return query
+  update public.mindmeld_rooms
+     set state = p_new_state, version = public.mindmeld_rooms.version + 1
+   where public.mindmeld_rooms.code = p_code
+     and public.mindmeld_rooms.version = p_expected_version
+  returning public.mindmeld_rooms.state, public.mindmeld_rooms.version, public.mindmeld_rooms.room_token;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.join_mindmeld(text, jsonb, integer) from public;
+grant execute on function public.join_mindmeld(text, jsonb, integer) to anon;
+
+create or replace function public.restore_mindmeld(p_code text, p_player_id text)
+returns table(state jsonb, version integer, room_token uuid)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.mindmeld_rooms;
+  v_present boolean;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.mindmeld_rooms where public.mindmeld_rooms.code = p_code;
+  if not found then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- verify p_player_id ∈ state.players (jsonb membership) (D-04)
+  select exists (
+    select 1 from jsonb_array_elements(v_row.state -> 'players') as p
+     where p ->> 'id' = p_player_id
+  ) into v_present;
+  if not v_present then
+    raise exception 'unauthorized' using errcode = '42501';
+  end if;
+  -- re-issue (return) the existing token so token-less sessions survive a reload
+  return query select v_row.state, v_row.version, v_row.room_token;
+end;
+$$;
+
+revoke all on function public.restore_mindmeld(text, text) from public;
+grant execute on function public.restore_mindmeld(text, text) to anon;
+
+create or replace function public.dispatch_mindmeld(p_code text, p_room_token uuid, p_new_state jsonb, p_expected_version integer)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.mindmeld_rooms;
+  v_player jsonb;
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  select * into v_row from public.mindmeld_rooms where public.mindmeld_rooms.code = p_code;
+  if not found or v_row.room_token <> p_room_token then
+    raise exception 'unauthorized' using errcode = '42501';   -- token gate (ACCESS-03)
+  end if;
+  -- INPUT-01: validate every player name server-side on the steady-state write
+  -- path too (CR-04), consistent with create/join — dispatch is a trust boundary.
+  if jsonb_typeof(p_new_state -> 'players') <> 'array' then
+    raise exception 'invalid name' using errcode = '22023';
+  end if;
+  for v_player in select * from jsonb_array_elements(p_new_state -> 'players') loop
+    if not public.is_valid_player_name(v_player ->> 'name') then
+      raise exception 'invalid name' using errcode = '22023';
+    end if;
+  end loop;
+  -- CAS (optimistic concurrency); 40001 on conflict → client re-reads + retries
+  return query
+  update public.mindmeld_rooms
+     set state = p_new_state, version = public.mindmeld_rooms.version + 1
+   where public.mindmeld_rooms.code = p_code
+     and public.mindmeld_rooms.version = p_expected_version
+  returning public.mindmeld_rooms.state, public.mindmeld_rooms.version;
+  if not found then
+    raise exception 'version conflict' using errcode = '40001';
+  end if;
+end;
+$$;
+
+revoke all on function public.dispatch_mindmeld(text, uuid, jsonb, integer) from public;
+grant execute on function public.dispatch_mindmeld(text, uuid, jsonb, integer) to anon;


### PR DESCRIPTION
Code-only PR for the security-hardening work (Phases 1 & 2). **Planning artifacts (`.planning/`) and project docs (`CLAUDE.md`, `AGENTS.md`) are intentionally excluded** — this is code changes only.

## Phase 1 — Room code entropy & collision safety
- Higher-entropy Crockford room codes; generator / DB-regex / Zod kept in lockstep with a SQL drift guard.
- Retry-on-collision; in-memory fake `rpc()` skeleton seeded for E2E.

## Phase 2 — Member-scoped access (additive; permissive `using(true)` policies remain, to be sealed in Phase 3)
- **`supabase-schema.sql`**: `room_token` column (×6), **24 token-gated `SECURITY DEFINER` RPCs** (create/join/restore/dispatch per game), a public `room:CODE` **broadcast trigger**, and a server-side `is_valid_player_name()` validator. Every definer function pins `search_path = ''` (Advisor 0011 clean).
- **Server-enforced invariants**: `join` is lobby-only and must add exactly one player (no token-less full-state overwrite); `dispatch` validates names; bad token → `42501`; CAS conflict → `40001`.
- **`src/lib/player-name.ts`**: single-source validator wired into all 6 online-game Zod schemas.
- **`useGameRoom.ts`**: cut over to the RPCs; state sync via the `room:CODE` broadcast is treated as a *wakeup* that refetches authoritative `{state, version}` (the untrusted public-topic payload is never applied directly); refetch-on-reconnect.
- Fake Supabase server + opt-in real-Supabase canary mirror the real DB semantics; templating drift guards.

## Verification
- ✅ 666 unit tests, 42/42 Playwright E2E (fake backend), `tsc` + lint clean.
- ✅ Schema applied to the live Supabase project; **Security Advisor `function_search_path_mutable` (0011) = 0**; token gate (`42501`) confirmed live.
- ⏳ Live 2-tab realtime broadcast delivery is the one remaining human check (can't drive a WebSocket from CI/CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)