### PR TITLE
Security hardening (Phases 3-4): seal the tables + client resilience

### DIFF
--- a/e2e/fake-supabase/server.mjs
+++ b/e2e/fake-supabase/server.mjs
@@ -90,8 +90,11 @@ function presenceState(channel) {
   return grouped
 }
 
-async function handleQuery(req, res) {
-  const body = await readBody(req)
+// Shared query body (no RLS gate). Both the gated anon `/query` handler and the
+// ungated privileged `/admin/query` fixture handler converge here, so the
+// insert/select/update branches — including the room-row UPDATE broadcast mirror —
+// exist exactly once.
+function runQueryBody(body, res) {
   const { op, table, values, filters = [], columns } = body
   const rows = tableRows(table)
 
@@ -165,6 +168,42 @@ async function handleQuery(req, res) {
   sendJson(res, 400, { data: null, error: { message: `Unsupported op: ${op}` } })
 }
 
+// Anon `/query` handler. Emulates the Phase 3 seal: post-seal, anon direct table
+// access on `*_rooms` tables is RLS default-denied — `select` returns zero rows,
+// `update`/`insert` are no-ops (nothing written, no broadcast). This makes the
+// harness honest: a production-path direct `.from(*_rooms).select()/.update()`
+// regression (BLOCKER-1-style) now hits this sealed path and observes empty,
+// so the suite can FAIL instead of masking it. Non-`_rooms` tables and the RPC
+// path are unaffected. Fixtures route through the ungated `/admin/query` instead.
+async function handleQuery(req, res) {
+  const body = await readBody(req)
+  const { op, table } = body
+  if (
+    typeof table === 'string' &&
+    table.endsWith('_rooms') &&
+    (op === 'select' || op === 'update' || op === 'insert')
+  ) {
+    if (op === 'select' && body.single) {
+      sendJson(res, 200, { data: null, error: null })
+      return
+    }
+    sendJson(res, 200, { data: [], error: null })
+    return
+  }
+  runQueryBody(body, res)
+}
+
+// Privileged, out-of-band fixture endpoint. Serves select/update/insert on ANY
+// table WITHOUT the anon RLS-deny gate, via the same shared `runQueryBody`. This
+// is the test backdoor for seeding room rows and reading state for assertions.
+// The production fake client (src/lib/supabase.ts) only ever posts to `/query`
+// and `/rpc`, never `/admin/query`, so this path cannot re-open the seal for the
+// app under test.
+async function handleAdminQuery(req, res) {
+  const body = await readBody(req)
+  runQueryBody(body, res)
+}
+
 // Crockford 6-char room-code regex, mirroring ROOM_CODE_REGEX_SQL in
 // src/lib/room-code.ts (this file lives outside src/, no @ import).
 const ROOM_CODE_RE = /^[0-9A-HJKMNP-TV-Z]{6}$/
@@ -205,7 +244,7 @@ function rpcError(res, code, message) {
 
 // Derive the room table from the RPC name suffix: `<op>_<game>` → `<game>_rooms`.
 function tableForFn(fn) {
-  const match = /^(create|join|restore|dispatch)_(.+)$/.exec(fn)
+  const match = /^(create|join|restore|dispatch|get)_(.+)$/.exec(fn)
   if (!match) return null
   return { op: match[1], table: `${match[2]}_rooms` }
 }
@@ -343,6 +382,23 @@ async function handleRpc(req, res) {
     return
   }
 
+  if (op === 'get') {
+    const code = args.p_code
+    if (typeof code !== 'string' || !ROOM_CODE_RE.test(code)) {
+      rpcError(res, '22023', 'invalid code')
+      return
+    }
+    const row = rows.find((r) => r.code === code)
+    // Unknown code → empty array (mirrors the real get_<game> RPC's zero-row return),
+    // NOT a 42501 error. This preserves the "Room not found" UX the hook expects and is
+    // the deliberate contrast with the `restore` branch above (which raises 42501).
+    sendJson(res, 200, {
+      data: row ? [{ state: row.state, version: row.version }] : [],
+      error: null,
+    })
+    return
+  }
+
   if (op === 'dispatch') {
     const code = args.p_code
     if (typeof code !== 'string' || !ROOM_CODE_RE.test(code)) {
@@ -440,6 +496,11 @@ const server = http.createServer(async (req, res) => {
 
     if (req.method === 'POST' && url.pathname === '/query') {
       await handleQuery(req, res)
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/admin/query') {
+      await handleAdminQuery(req, res)
       return
     }
 

--- a/e2e/helpers/fakeSupabase.ts
+++ b/e2e/helpers/fakeSupabase.ts
@@ -26,14 +26,14 @@ export async function resetFakeSupabase(): Promise<void> {
 export async function fakeSupabaseQuery<T = unknown>(
   payload: FakeSupabaseQueryPayload
 ): Promise<FakeSupabaseQueryResult<T>> {
-  const response = await fetch(`${fakeSupabaseUrl}/query`, {
+  const response = await fetch(`${fakeSupabaseUrl}/admin/query`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(payload),
   })
 
   if (!response.ok) {
-    throw new Error(`Fake Supabase /query failed: ${response.status} ${response.statusText}`)
+    throw new Error(`Fake Supabase /admin/query failed: ${response.status} ${response.statusText}`)
   }
 
   return (await response.json()) as FakeSupabaseQueryResult<T>

--- a/e2e/integration/supabase-access.spec.ts
+++ b/e2e/integration/supabase-access.spec.ts
@@ -20,11 +20,18 @@
 //   - SUPABASE_TEST_URL       real Supabase project URL
 //   - SUPABASE_TEST_ANON_KEY  that project's anon key
 //
-// NOTE — Phase-3 deferral (D-14): the enumeration-prevention assertion (that a
-// non-member cannot SELECT/enumerate rooms) is intentionally NOT asserted here.
-// In this additive phase the table SELECT policy is still `using (true)`
-// (permissive), so enumeration is still possible by design until Phase 3 seals
-// SELECT. That assertion belongs to Phase 3 and is added there.
+// Phase 3 (ACCESS-01): the enumeration-prevention assertion is now ACTIVE below.
+// After the seal (seal-up.sql drops the permissive SELECT/UPDATE/INSERT policies,
+// RLS stays enabled), a direct anon `.from(table).select()` returns zero rows even
+// though the row exists, while the code-gated get_<game>(p_code) still returns it.
+//
+// Phase 3 (03-05): the in-memory E2E fake now ALSO emulates this seal — an anon
+// direct `/query` `select`/`update`/`insert` on a `*_rooms` table returns empty/
+// no-op (RLS default-deny), so the fake and this live canary finally agree. Test
+// fixtures moved to the privileged out-of-band `/admin/query` endpoint, so a
+// production-path direct-table regression (BLOCKER-1-style) would now FAIL the
+// Playwright suite instead of being masked. These canary tests hit the REAL
+// Supabase project via createClient (not the fake), so they are unchanged.
 
 import { test, expect } from '@playwright/test'
 import { createClient } from '@supabase/supabase-js'
@@ -45,6 +52,36 @@ function freshUnoState(playerId: string) {
 }
 
 test.describe('real Supabase access control (canary)', () => {
+  test('anon cannot enumerate or directly read a sealed room (ACCESS-01)', async () => {
+    const url = SUPABASE_TEST_URL!
+    const key = SUPABASE_TEST_ANON_KEY!
+    const client = createClient(url, key)
+
+    const code = generateRoomCode()
+    const playerId = `p_${Math.random().toString(36).slice(2, 10)}`
+
+    // (1) Create a real room via the definer RPC (succeeds under the seal). Pitfall 6:
+    // the row MUST exist first — an empty-table select would be vacuously empty.
+    const { error: createErr } = await client.rpc('create_uno', {
+      p_code: code,
+      p_state: freshUnoState(playerId),
+    })
+    expect(createErr).toBeNull()
+
+    // (2) Seal proof: a direct anon read of the table returns ZERO rows even though
+    // the row exists — enumeration/world-read is closed (RLS default-deny).
+    const { data: leaked } = await client.from('uno_rooms').select('code, state, version')
+    expect(leaked ?? []).toHaveLength(0)
+
+    // (3) Code-gated read still works for a code-holder via the SECURITY DEFINER RPC.
+    const { data: viaRpc, error: rpcErr } = await client.rpc('get_uno', { p_code: code })
+    expect(rpcErr).toBeNull()
+    const row = Array.isArray(viaRpc) ? viaRpc[0] : viaRpc
+    expect(row?.version).toBeDefined()
+
+    await client.removeAllChannels()
+  })
+
   test('a second subscriber receives the broadcast on room:CODE (ACCESS-05)', async () => {
     const url = SUPABASE_TEST_URL!
     const key = SUPABASE_TEST_ANON_KEY!

--- a/e2e/integration/supabase-access.spec.ts
+++ b/e2e/integration/supabase-access.spec.ts
@@ -21,7 +21,7 @@
 //   - SUPABASE_TEST_ANON_KEY  that project's anon key
 //
 // Phase 3 (ACCESS-01): the enumeration-prevention assertion is now ACTIVE below.
-// After the seal (seal-up.sql drops the permissive SELECT/UPDATE/INSERT policies,
+// After the seal (supabase-migration-seal-rls.sql drops the permissive SELECT/UPDATE/INSERT policies,
 // RLS stays enabled), a direct anon `.from(table).select()` returns zero rows even
 // though the row exists, while the code-gated get_<game>(p_code) still returns it.
 //

--- a/e2e/race-conditions.spec.ts
+++ b/e2e/race-conditions.spec.ts
@@ -15,6 +15,10 @@ type QueryPayload = {
   filters?: Array<{ column: string; value: unknown }>
   columns?: string
   single?: boolean
+  // RPC payloads (posted to /rpc as { fn, args }) — the join pre-read now flows
+  // through the code-gated get_<game> SECURITY DEFINER RPC, not a direct select.
+  fn?: string
+  args?: Record<string, unknown>
 }
 
 type RoomRow<TState> = {
@@ -93,25 +97,30 @@ async function installQueryBarrier(
   const waiting: Route[] = []
   let released = false
 
+  const handler = async (route: Route) => {
+    const payload = route.request().postDataJSON() as QueryPayload
+
+    if (!released && predicate(payload)) {
+      waiting.push(route)
+
+      if (waiting.length === contexts.length) {
+        released = true
+        await Promise.all(waiting.splice(0).map((blocked) => blocked.continue()))
+      }
+
+      return
+    }
+
+    await route.continue()
+  }
+
   await Promise.all(
-    contexts.map((context) =>
-      context.route(`${fakeSupabaseUrl}/query`, async (route) => {
-        const payload = route.request().postDataJSON() as QueryPayload
-
-        if (!released && predicate(payload)) {
-          waiting.push(route)
-
-          if (waiting.length === contexts.length) {
-            released = true
-            await Promise.all(waiting.splice(0).map((blocked) => blocked.continue()))
-          }
-
-          return
-        }
-
-        await route.continue()
-      })
-    )
+    contexts.flatMap((context) => [
+      // The barrier gates both endpoints: `/query` for direct selects/updates and
+      // `/rpc` for the SECURITY DEFINER RPC reads (e.g. the get_<game> join pre-read).
+      context.route(`${fakeSupabaseUrl}/query`, handler),
+      context.route(`${fakeSupabaseUrl}/rpc`, handler),
+    ])
   )
 }
 
@@ -195,12 +204,9 @@ test.describe('multiplayer race conditions and reconnect resilience', () => {
       await guestTwoPage.goto()
 
       await installQueryBarrier([guestOne.context, guestTwo.context], (payload) => {
-        return (
-          payload.op === 'select' &&
-          payload.table === 'uno_rooms' &&
-          payload.single === true &&
-          hasFilter(payload, 'code', roomCode)
-        )
+        // joinRoom's pre-read now goes through the code-gated get_uno RPC
+        // (replacing the old direct .from('uno_rooms').select().single()).
+        return payload.fn === 'get_uno' && payload.args?.p_code === roomCode
       })
 
       await Promise.allSettled([

--- a/src/components/multiplayer/DesyncIndicator.module.css
+++ b/src/components/multiplayer/DesyncIndicator.module.css
@@ -1,0 +1,50 @@
+.indicator {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 16px;
+  background: color-mix(in oklch, var(--bg-2) 92%, transparent);
+  border: 1px solid var(--line);
+  border-radius: var(--radius, 4px);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 2px 8px color-mix(in oklch, var(--ink) 12%, transparent);
+  /* Non-blocking: the pill must never trap clicks on the game UI behind it. */
+  pointer-events: none;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: var(--amber);
+  animation: desync-blink 1.2s infinite;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.5;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  /* Amber fails WCAG AA on --bg-2 in the light theme (L0.82 on L0.93);
+     per 04-UI-SPEC the label uses --ink and amber is kept for dot + border. */
+  color: var(--ink);
+}
+
+@keyframes desync-blink {
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dot {
+    animation: none;
+  }
+}

--- a/src/components/multiplayer/DesyncIndicator.test.tsx
+++ b/src/components/multiplayer/DesyncIndicator.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { DesyncIndicator } from './DesyncIndicator'
+
+describe('DesyncIndicator', () => {
+  it('renders nothing when inactive', () => {
+    render(<DesyncIndicator active={false} />)
+
+    expect(screen.queryByTestId('desync-indicator')).toBeNull()
+  })
+
+  it('renders the default reconnecting pill when active', () => {
+    render(<DesyncIndicator active />)
+
+    const root = screen.getByTestId('desync-indicator')
+    expect(root).toBeInTheDocument()
+    expect(root).toHaveAttribute('role', 'status')
+    expect(root).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText('Reconnecting…')).toBeInTheDocument()
+  })
+
+  it('renders a custom message when provided', () => {
+    render(<DesyncIndicator active message="Out of sync — recovering" />)
+
+    expect(screen.getByText('Out of sync — recovering')).toBeInTheDocument()
+  })
+
+  it('merges a caller-provided className onto the root', () => {
+    render(<DesyncIndicator active className="custom-class" />)
+
+    expect(screen.getByTestId('desync-indicator')).toHaveClass('custom-class')
+  })
+})

--- a/src/components/multiplayer/DesyncIndicator.tsx
+++ b/src/components/multiplayer/DesyncIndicator.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils'
+import styles from './DesyncIndicator.module.css'
+
+interface DesyncIndicatorProps {
+  /** True when connectionStatus === 'desynced'. When false, renders null. */
+  active: boolean
+  /** Override-able label; the shared default used by all 6 games. */
+  message?: string
+  /** cn()-merged onto the root for per-game positioning overrides if ever needed. */
+  className?: string
+}
+
+/**
+ * Non-blocking, self-healing desync indicator (CLIENT-01 / 04-UI-SPEC).
+ *
+ * Presentational only — props in, JSX out. Surfaces recoverable realtime
+ * trouble (invalid Zod payloads + channel CHANNEL_ERROR/TIMED_OUT/CLOSED) as a
+ * polite "Reconnecting…" pill, auto-hiding on recovery.
+ *
+ * Visually distinct from the terminal error banner (D-01): it uses the caution
+ * accent `var(--amber)` for the pulsing dot + border, never the reserved
+ * destructive error-banner token.
+ */
+export function DesyncIndicator({
+  active,
+  message = 'Reconnecting…',
+  className,
+}: DesyncIndicatorProps) {
+  if (!active) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="desync-indicator"
+      className={cn(styles.indicator, className)}
+      // Amber caution accent for the border (distinct from the destructive error banner, D-01).
+      style={{ borderColor: 'var(--amber)' }}
+    >
+      <span aria-hidden="true" className={styles.dot} style={{ background: 'var(--amber)' }} />
+      <span className={styles.label}>{message}</span>
+    </div>
+  )
+}

--- a/src/games/agario/AgarioGame.tsx
+++ b/src/games/agario/AgarioGame.tsx
@@ -6,6 +6,7 @@ import { getSavedPlayerName, savePlayerName } from '@/lib/player-name'
 import { isSupabaseConfigured } from '@/lib/supabase'
 import { useInviteCode, getInviteLink } from '@/hooks/useInviteCode'
 import { normalizeRoomCode } from '@/lib/room-code'
+import { DesyncIndicator } from '@/components/multiplayer/DesyncIndicator'
 import { useAgarioRoom } from './useAgarioRoom'
 import {
   MAP_WIDTH,
@@ -859,6 +860,7 @@ export function AgarioGame() {
     roomCode,
     status,
     error,
+    connectionStatus,
     savedSession,
     createRoom,
     joinRoom,
@@ -1359,6 +1361,7 @@ export function AgarioGame() {
   if (isPlaying && mySnakeState && playerId) {
     return (
       <div className="relative flex flex-col items-center">
+        <DesyncIndicator active={connectionStatus === 'desynced'} />
         <div
           data-testid="agario-game-area"
           className="relative overflow-hidden rounded-lg border border-white/10"

--- a/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
+++ b/src/games/cards-against-humanity/CardsAgainstHumanityGame.tsx
@@ -9,6 +9,7 @@ import {
   ResumeSessionButton,
   type SavedSessionSummary,
 } from '@/components/multiplayer/ResumeSessionButton'
+import { DesyncIndicator } from '@/components/multiplayer/DesyncIndicator'
 import { normalizeRoomCode } from '@/lib/room-code'
 import { useCAHRoom } from './useCAHRoom'
 import {
@@ -1046,6 +1047,7 @@ export function CardsAgainstHumanityGame() {
     roomCode,
     status,
     error,
+    connectionStatus,
     savedSession,
     createRoom,
     joinRoom,
@@ -1107,6 +1109,7 @@ export function CardsAgainstHumanityGame() {
   return (
     <>
       <CAHStyles />
+      <DesyncIndicator active={connectionStatus === 'desynced'} />
       <GameBoard
         gameState={gameState}
         playerId={playerId}

--- a/src/games/cards-against-humanity/useCAHRoom.ts
+++ b/src/games/cards-against-humanity/useCAHRoom.ts
@@ -33,7 +33,7 @@ export function useCAHRoom(): UseCAHRoomReturn {
       gameState,
       roomCode,
       playerId,
-      tableName,
+      roomToken,
       applyAction: apply,
       stateSchema,
     }) => {
@@ -41,44 +41,43 @@ export function useCAHRoom(): UseCAHRoomReturn {
 
       const MAX_RETRIES = 3
       let currentState: GameState | null = gameState
-      let currentVersion = 0
 
-      const { data: initial } = await supabase
-        .from(tableName)
-        .select('version')
-        .eq('code', roomCode)
-        .single()
-      if (!initial) return
-      currentVersion = initial.version as number
+      // Post-seal, direct .from() is RLS default-denied; read the live version through the
+      // code-gated get_cah RPC (D-01). No row means the room is already gone — nothing to leave.
+      const { data: initial } = await supabase.rpc('get_cah', { p_code: roomCode })
+      const initialRow = initial && initial.length > 0 ? initial[0] : null
+      if (!initialRow) return
+      let currentVersion = initialRow.version as number
 
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
         if (!currentState) break
         const newState = apply(currentState, { type: 'REMOVE_PLAYER', playerId } as GameAction)
         if (newState === currentState) break
 
-        const { data } = await supabase
-          .from(tableName)
-          .update({ state: newState, version: currentVersion + 1 })
-          .eq('code', roomCode)
-          .eq('version', currentVersion)
-          .select('version')
+        // Token-gated write through dispatch_cah (ACCESS-02/ACCESS-03): server CAS on
+        // p_expected_version, 42501 on bad/missing token (terminal), 40001/empty on conflict.
+        const { data, error: dispatchErr } = await supabase.rpc('dispatch_cah', {
+          p_code: roomCode,
+          p_room_token: roomToken,
+          p_new_state: newState,
+          p_expected_version: currentVersion,
+        })
 
         if (data && data.length > 0) break
+        // Bad/missing token is terminal — no retry can fix it.
+        if (dispatchErr?.code === '42501') break
 
         if (attempt < MAX_RETRIES) {
-          const { data: fresh } = await supabase
-            .from(tableName)
-            .select('state, version')
-            .eq('code', roomCode)
-            .single()
-          if (!fresh) break
-          const parsedFresh = stateSchema.safeParse(fresh.state)
+          const { data: fresh } = await supabase.rpc('get_cah', { p_code: roomCode })
+          const freshRow = fresh && fresh.length > 0 ? fresh[0] : null
+          if (!freshRow) break
+          const parsedFresh = stateSchema.safeParse(freshRow.state)
           if (!parsedFresh.success) {
             console.error('[cah] Invalid GameState in leaveRoom retry:', parsedFresh.error)
             break
           }
           currentState = parsedFresh.data
-          currentVersion = fresh.version as number
+          currentVersion = freshRow.version as number
         }
       }
     },

--- a/src/games/codenames/CodenamesGame.tsx
+++ b/src/games/codenames/CodenamesGame.tsx
@@ -9,6 +9,7 @@ import {
   ResumeSessionButton,
   type SavedSessionSummary,
 } from '@/components/multiplayer/ResumeSessionButton'
+import { DesyncIndicator } from '@/components/multiplayer/DesyncIndicator'
 import { normalizeRoomCode } from '@/lib/room-code'
 import { useCodenamesRoom } from './useCodenamesRoom'
 import {
@@ -709,6 +710,7 @@ export function CodenamesGame() {
     roomCode,
     status,
     error,
+    connectionStatus,
     savedSession,
     createRoom,
     joinRoom,
@@ -780,6 +782,7 @@ export function CodenamesGame() {
   return (
     <>
       <CodenamesStyles />
+      <DesyncIndicator active={connectionStatus === 'desynced'} />
       <GameBoard
         gameState={redactedState!}
         playerId={playerId}

--- a/src/games/codenames/schema.test.ts
+++ b/src/games/codenames/schema.test.ts
@@ -1,5 +1,7 @@
 import { GameStateSchema } from './schema'
 
+const validCard = { word: 'apple', type: 'neutral' as const, revealed: false }
+
 const validGameState = {
   phase: 'lobby' as const,
   players: [
@@ -62,5 +64,57 @@ describe('codenames GameStateSchema', () => {
       players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true, team: 'red' as const, role: null }],
     }
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  // board cell nested-structure cases (D-12 / TEST-03)
+  it('accepts a full 25-card board of valid cells', () => {
+    const state = { ...validGameState, board: Array.from({ length: 25 }, () => validCard) }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a board cell with an invalid type', () => {
+    const state = { ...validGameState, board: [{ ...validCard, type: 'gold' }] }
+    expect(GameStateSchema.safeParse(state).success).toBe(false)
+  })
+
+  it('rejects a board cell with a non-boolean revealed', () => {
+    const state = { ...validGameState, board: [{ ...validCard, revealed: 'yes' }] }
+    expect(GameStateSchema.safeParse(state).success).toBe(false)
+  })
+
+  it('rejects a board cell missing word', () => {
+    const state = { ...validGameState, board: [{ type: 'red' as const, revealed: false }] }
+    expect(GameStateSchema.safeParse(state).success).toBe(false)
+  })
+
+  it('accepts each valid cell type', () => {
+    const types = ['red', 'blue', 'neutral', 'assassin'] as const
+    const state = { ...validGameState, board: types.map((type) => ({ ...validCard, type })) }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  // currentClue / ClueSchema nested-structure cases (bonus within scope — D-12)
+  it('accepts a valid currentClue', () => {
+    const state = {
+      ...validGameState,
+      currentClue: { word: 'fruit', count: 2, team: 'red' as const, guessesUsed: 0 },
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(true)
+  })
+
+  it('rejects a currentClue with a negative count', () => {
+    const state = {
+      ...validGameState,
+      currentClue: { word: 'fruit', count: -1, team: 'red' as const, guessesUsed: 0 },
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(false)
+  })
+
+  it('rejects a currentClue with an invalid team', () => {
+    const state = {
+      ...validGameState,
+      currentClue: { word: 'fruit', count: 2, team: 'green', guessesUsed: 0 },
+    }
+    expect(GameStateSchema.safeParse(state).success).toBe(false)
   })
 })

--- a/src/games/mindmeld/MindmeldGame.tsx
+++ b/src/games/mindmeld/MindmeldGame.tsx
@@ -9,6 +9,7 @@ import {
   ResumeSessionButton,
   type SavedSessionSummary,
 } from '@/components/multiplayer/ResumeSessionButton'
+import { DesyncIndicator } from '@/components/multiplayer/DesyncIndicator'
 import { normalizeRoomCode } from '@/lib/room-code'
 import { useMindmeldRoom } from './useMindmeldRoom'
 import {
@@ -916,6 +917,7 @@ export function MindmeldGame() {
     roomCode,
     status,
     error,
+    connectionStatus,
     savedSession,
     createRoom,
     joinRoom,
@@ -982,6 +984,7 @@ export function MindmeldGame() {
   return (
     <>
       <MindmeldStyles />
+      <DesyncIndicator active={connectionStatus === 'desynced'} />
       <PlayingScreen
         gameState={redactedState}
         playerId={playerId}

--- a/src/games/mindmeld/schema.test.ts
+++ b/src/games/mindmeld/schema.test.ts
@@ -9,6 +9,21 @@ const validGameState = {
   log: [],
 }
 
+const validRound = {
+  number: 1,
+  psychicId: 'p1',
+  spectrum: { left: 'Cold', right: 'Hot' },
+  target: 50,
+  clue: null,
+  teamGuess: null,
+  guessLockedBy: null,
+  guesses: {},
+  roundScores: {},
+  phase: 'clue' as const,
+}
+
+const playing = { ...validGameState, phase: 'playing' as const, roundNumber: 1 }
+
 describe('mindmeld GameStateSchema', () => {
   it('accepts a valid lobby state', () => {
     expect(GameStateSchema.safeParse(validGameState).success).toBe(true)
@@ -69,5 +84,44 @@ describe('mindmeld GameStateSchema', () => {
       players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true, score: 0 }],
     }
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  // currentRound nested-structure cases (D-12 / TEST-03)
+  it('rejects a currentRound target above 100', () => {
+    const s = { ...playing, currentRound: { ...validRound, target: 101 } }
+    expect(GameStateSchema.safeParse(s).success).toBe(false)
+  })
+
+  it('rejects a currentRound target below -1', () => {
+    const s = { ...playing, currentRound: { ...validRound, target: -2 } }
+    expect(GameStateSchema.safeParse(s).success).toBe(false)
+  })
+
+  it('rejects a currentRound spectrum missing right', () => {
+    const s = { ...playing, currentRound: { ...validRound, spectrum: { left: 'Cold' } } }
+    expect(GameStateSchema.safeParse(s).success).toBe(false)
+  })
+
+  it('rejects an unknown currentRound phase', () => {
+    const s = { ...playing, currentRound: { ...validRound, phase: 'scoring' } }
+    expect(GameStateSchema.safeParse(s).success).toBe(false)
+  })
+
+  it('accepts a currentRound with populated guesses and roundScores maps', () => {
+    const s = {
+      ...playing,
+      currentRound: { ...validRound, guesses: { p1: 40 }, roundScores: { p1: 3 } },
+    }
+    expect(GameStateSchema.safeParse(s).success).toBe(true)
+  })
+
+  it('rejects a currentRound guess value above 100', () => {
+    const s = { ...playing, currentRound: { ...validRound, guesses: { p1: 200 } } }
+    expect(GameStateSchema.safeParse(s).success).toBe(false)
+  })
+
+  it('rejects a currentRound negative roundScore', () => {
+    const s = { ...playing, currentRound: { ...validRound, roundScores: { p1: -1 } } }
+    expect(GameStateSchema.safeParse(s).success).toBe(false)
   })
 })

--- a/src/games/mindmeld/useMindmeldRoom.ts
+++ b/src/games/mindmeld/useMindmeldRoom.ts
@@ -33,7 +33,7 @@ export function useMindmeldRoom(): UseMindmeldRoomReturn {
       gameState,
       roomCode,
       playerId,
-      tableName,
+      roomToken,
       applyAction: apply,
       stateSchema,
     }) => {
@@ -41,44 +41,43 @@ export function useMindmeldRoom(): UseMindmeldRoomReturn {
 
       const MAX_RETRIES = 3
       let currentState: GameState | null = gameState
-      let currentVersion = 0
 
-      const { data: initial } = await supabase
-        .from(tableName)
-        .select('version')
-        .eq('code', roomCode)
-        .single()
-      if (!initial) return
-      currentVersion = initial.version as number
+      // Post-seal, direct .from() is RLS default-denied; read the live version through the
+      // code-gated get_mindmeld RPC (D-01). No row means the room is gone — nothing to leave.
+      const { data: initial } = await supabase.rpc('get_mindmeld', { p_code: roomCode })
+      const initialRow = initial && initial.length > 0 ? initial[0] : null
+      if (!initialRow) return
+      let currentVersion = initialRow.version as number
 
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
         if (!currentState) break
         const newState = apply(currentState, { type: 'REMOVE_PLAYER', playerId } as GameAction)
         if (newState === currentState) break
 
-        const { data } = await supabase
-          .from(tableName)
-          .update({ state: newState, version: currentVersion + 1 })
-          .eq('code', roomCode)
-          .eq('version', currentVersion)
-          .select('version')
+        // Token-gated write through dispatch_mindmeld (ACCESS-02/ACCESS-03): server CAS on
+        // p_expected_version, 42501 on bad/missing token (terminal), 40001/empty on conflict.
+        const { data, error: dispatchErr } = await supabase.rpc('dispatch_mindmeld', {
+          p_code: roomCode,
+          p_room_token: roomToken,
+          p_new_state: newState,
+          p_expected_version: currentVersion,
+        })
 
         if (data && data.length > 0) break
+        // Bad/missing token is terminal — no retry can fix it.
+        if (dispatchErr?.code === '42501') break
 
         if (attempt < MAX_RETRIES) {
-          const { data: fresh } = await supabase
-            .from(tableName)
-            .select('state, version')
-            .eq('code', roomCode)
-            .single()
-          if (!fresh) break
-          const parsedFresh = stateSchema.safeParse(fresh.state)
+          const { data: fresh } = await supabase.rpc('get_mindmeld', { p_code: roomCode })
+          const freshRow = fresh && fresh.length > 0 ? fresh[0] : null
+          if (!freshRow) break
+          const parsedFresh = stateSchema.safeParse(freshRow.state)
           if (!parsedFresh.success) {
             console.error('[mindmeld] Invalid GameState in leaveRoom retry:', parsedFresh.error)
             break
           }
           currentState = parsedFresh.data
-          currentVersion = fresh.version as number
+          currentVersion = freshRow.version as number
         }
       }
     },

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -14,6 +14,7 @@ import { PlayerRoster } from '@/components/multiplayer/PlayerRoster'
 import { ResultsTable } from '@/components/multiplayer/ResultsTable'
 import { ResumeSessionCard } from '@/components/multiplayer/ResumeSessionCard'
 import { RoomInviteCard } from '@/components/multiplayer/RoomInviteCard'
+import { DesyncIndicator } from '@/components/multiplayer/DesyncIndicator'
 import { normalizeRoomCode } from '@/lib/room-code'
 import { useSkribblRoom, type UseSkribblRoomReturn } from './useSkribblRoom'
 import {
@@ -1454,6 +1455,7 @@ export function SkribblGame() {
     process.env.NEXT_PUBLIC_E2E_FAKE_SUPABASE === '1' ? 'entry' : 'howto'
   )
   const {
+    connectionStatus,
     createRoom,
     dispatch,
     error,
@@ -1506,6 +1508,7 @@ export function SkribblGame() {
 
   return (
     <ArcadeShell title="Skribbl" crumb={crumb} centered={centered}>
+      {!isEntryState && <DesyncIndicator active={connectionStatus === 'desynced'} />}
       {!isSupabaseConfigured ? (
         <SetupRequired />
       ) : isResolvingInvite ? (

--- a/src/games/uno/UnoGame.tsx
+++ b/src/games/uno/UnoGame.tsx
@@ -9,6 +9,7 @@ import { ArcadeShell, arcadeShellStyles } from '@/components/multiplayer/ArcadeS
 import { LobbyActions } from '@/components/multiplayer/LobbyActions'
 import { ResumeSessionCard } from '@/components/multiplayer/ResumeSessionCard'
 import type { SavedSessionSummary } from '@/components/multiplayer/ResumeSessionButton'
+import { DesyncIndicator } from '@/components/multiplayer/DesyncIndicator'
 import { normalizeRoomCode } from '@/lib/room-code'
 import { useUnoRoom } from './useUnoRoom'
 import {
@@ -1329,6 +1330,7 @@ export function UnoGame() {
     roomCode,
     status,
     error,
+    connectionStatus,
     savedSession,
     onlinePlayerIds,
     createRoom,
@@ -1363,6 +1365,7 @@ export function UnoGame() {
   return (
     <ArcadeShell title="Uno" crumb={crumb} centered={!inGame}>
       <UnoStyles />
+      {!isEntryState && <DesyncIndicator active={connectionStatus === 'desynced'} />}
       {!isSupabaseConfigured ? (
         <SetupRequired />
       ) : isResolvingInvite ? (

--- a/src/hooks/useGameRoom.test.ts
+++ b/src/hooks/useGameRoom.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Wave 0 scaffold: the first unit test for the shared useGameRoom engine.
+ *
+ * Focus is CLIENT-01 / D-02 / D-03: the connectionStatus set-then-clear wiring at the
+ * realtime trigger sites. The in-memory fake-supabase double only ever emits 'SUBSCRIBED'
+ * (Pitfall 6), so the CHANNEL_ERROR/TIMED_OUT/CLOSED branch is unreachable via E2E and MUST
+ * be driven here by a hand-rolled channel mock whose `.subscribe` status callback and
+ * `broadcast` handlers the test can invoke with arbitrary inputs.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { z } from 'zod'
+import { useGameRoom, type GameRoomConfig } from './useGameRoom'
+
+// --- Controllable supabase channel double ----------------------------------------------------
+
+type StatusCb = (status: string) => void | Promise<void>
+type BroadcastCb = (payload: { payload: unknown }) => void
+
+interface ChannelDouble {
+  name: string
+  statusCb: StatusCb | null
+  broadcastHandlers: Record<string, BroadcastCb>
+  on: jest.Mock
+  subscribe: jest.Mock
+  send: jest.Mock
+  track: jest.Mock
+  presenceState: jest.Mock
+  unsubscribe: jest.Mock
+}
+
+const channels: ChannelDouble[] = []
+
+function makeChannel(name: string): ChannelDouble {
+  const ch: ChannelDouble = {
+    name,
+    statusCb: null,
+    broadcastHandlers: {},
+    on: jest.fn(),
+    subscribe: jest.fn(),
+    send: jest.fn().mockResolvedValue(undefined),
+    track: jest.fn().mockResolvedValue(undefined),
+    presenceState: jest.fn().mockReturnValue({}),
+    unsubscribe: jest.fn().mockResolvedValue(undefined),
+  }
+  ch.on.mockImplementation((type: string, config: { event?: string }, cb: BroadcastCb) => {
+    if (type === 'broadcast' && config?.event) ch.broadcastHandlers[config.event] = cb
+    return ch
+  })
+  ch.subscribe.mockImplementation((cb?: StatusCb) => {
+    if (cb) ch.statusCb = cb
+    return ch
+  })
+  return ch
+}
+
+// Authoritative {state, version} the get_<game> RPC returns to refetchAuthoritativeState.
+let authoritativeRow: { state: unknown; version: number } | null = null
+
+const rpc = jest.fn(async (fn: string) => {
+  if (fn.startsWith('create_')) {
+    return {
+      data: [{ state: { phase: 'lobby', players: [] }, version: 1, room_token: 'tok' }],
+      error: null,
+    }
+  }
+  if (fn.startsWith('get_')) {
+    return { data: authoritativeRow ? [authoritativeRow] : [], error: null }
+  }
+  return { data: null, error: null }
+})
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    channel: (name: string) => {
+      const ch = makeChannel(name)
+      channels.push(ch)
+      return ch
+    },
+    rpc: (...args: unknown[]) => rpc(...(args as [string])),
+    from: jest.fn(),
+  },
+  isSupabaseConfigured: true,
+}))
+
+// --- Minimal game config ---------------------------------------------------------------------
+
+const StateSchema = z.object({
+  phase: z.string(),
+  players: z.array(z.object({ id: z.string() })),
+})
+type State = z.infer<typeof StateSchema>
+type Action = { type: 'noop' }
+
+const config: GameRoomConfig<State, Action> = {
+  tableName: 'test_rooms',
+  channelPrefix: 'test',
+  sessionKey: 'test_session',
+  stateSchema: StateSchema,
+  applyAction: (s) => s,
+  createLobbyState: (host) => ({ phase: 'lobby', players: [host] }),
+  createPlayer: ({ id }) => ({ id }),
+  addPlayer: (s, p) => ({ ...s, players: [...s.players, p] }),
+}
+
+function stateChannel() {
+  return channels.find((c) => c.name.startsWith('room:'))
+}
+function presenceChannel() {
+  return channels.find((c) => c.name.includes('-presence:'))
+}
+
+beforeEach(() => {
+  channels.length = 0
+  authoritativeRow = null
+  rpc.mockClear()
+  localStorage.clear()
+})
+
+describe('useGameRoom connectionStatus (CLIENT-01)', () => {
+  async function connect() {
+    const hook = renderHook(() => useGameRoom<State, Action>(config))
+    await act(async () => {
+      await hook.result.current.createRoom('Alice')
+    })
+    return hook
+  }
+
+  it('starts live and stays live on a clean subscribe', async () => {
+    const hook = await connect()
+    expect(hook.result.current.connectionStatus).toBe('live')
+
+    const ch = stateChannel()!
+    await act(async () => {
+      await ch.statusCb!('SUBSCRIBED')
+    })
+    expect(hook.result.current.connectionStatus).toBe('live')
+  })
+
+  it('flips to desynced on an invalid {state} payload, then auto-clears on a valid apply (D-02/D-03, Pitfall 5)', async () => {
+    const hook = await connect()
+    const ch = stateChannel()!
+
+    // A 'state' broadcast wakes a refetch; the authoritative row is garbage → safeParse fails.
+    authoritativeRow = { state: { phase: 123, players: 'nope' }, version: 99 }
+    await act(async () => {
+      ch.broadcastHandlers['state']({ payload: {} })
+    })
+    await waitFor(() => expect(hook.result.current.connectionStatus).toBe('desynced'))
+
+    // Next refetch returns a valid, strictly-newer row → applies and auto-clears to live.
+    authoritativeRow = { state: { phase: 'play', players: [{ id: 'a' }] }, version: 100 }
+    await act(async () => {
+      ch.broadcastHandlers['state']({ payload: {} })
+    })
+    await waitFor(() => expect(hook.result.current.connectionStatus).toBe('live'))
+  })
+
+  it('flips to desynced on a CHANNEL_ERROR status (the fake-only-SUBSCRIBED branch, Pitfall 6)', async () => {
+    const hook = await connect()
+    const ch = stateChannel()!
+
+    await act(async () => {
+      await ch.statusCb!('CHANNEL_ERROR')
+    })
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+  })
+
+  it('flips to desynced on TIMED_OUT and CLOSED statuses', async () => {
+    const hook = await connect()
+    const ch = stateChannel()!
+
+    await act(async () => {
+      await ch.statusCb!('TIMED_OUT')
+    })
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+
+    await act(async () => {
+      await ch.statusCb!('CLOSED')
+    })
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+  })
+
+  it('clears back to live on a re-SUBSCRIBED after channel trouble (D-03 auto-recovery)', async () => {
+    const hook = await connect()
+    const ch = stateChannel()!
+
+    await act(async () => {
+      await ch.statusCb!('CHANNEL_ERROR')
+    })
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+
+    await act(async () => {
+      await ch.statusCb!('SUBSCRIBED')
+    })
+    expect(hook.result.current.connectionStatus).toBe('live')
+  })
+
+  it('flips to desynced when the presence channel reports an error status', async () => {
+    const hook = await connect()
+    const presence = presenceChannel()!
+
+    await act(async () => {
+      await presence.statusCb!('CHANNEL_ERROR')
+    })
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+  })
+
+  it('does NOT clear a state-channel desync when only the presence channel re-subscribes (CR-02)', async () => {
+    const hook = await connect()
+    const stateCh = stateChannel()!
+    const presence = presenceChannel()!
+
+    // State channel goes dead → desynced.
+    await act(async () => {
+      await stateCh.statusCb!('CHANNEL_ERROR')
+    })
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+
+    // Presence independently recovers. This must NOT mask the dead state channel: the desync
+    // flag may only be cleared by the state channel's own SUBSCRIBED / valid-apply paths.
+    await act(async () => {
+      await presence.statusCb!('SUBSCRIBED')
+    })
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+    // Presence still tracks the player so peers see them online (unchanged behavior).
+    expect(presence.track).toHaveBeenCalledWith({ player_id: expect.any(String) })
+  })
+
+  it('keeps connectionStatus on the public return contract', async () => {
+    const hook = await connect()
+    expect(hook.result.current).toHaveProperty('connectionStatus')
+    // Existing public fields remain intact (additive-only contract change).
+    for (const field of [
+      'gameState',
+      'playerId',
+      'roomCode',
+      'status',
+      'error',
+      'onlinePlayerIds',
+    ]) {
+      expect(hook.result.current).toHaveProperty(field)
+    }
+  })
+})
+
+describe('useGameRoom dispatch CAS exhaustion (BL-02)', () => {
+  // A config whose applyAction always returns a NEW state object, so dispatch does not early-return
+  // on the `newState === currentState` reference check and actually enters the CAS retry loop.
+  const casConfig: GameRoomConfig<State, Action> = {
+    ...config,
+    applyAction: (s) => ({ ...s, players: [...s.players] }),
+  }
+
+  async function connect() {
+    const hook = renderHook(() => useGameRoom<State, Action>(casConfig))
+    await act(async () => {
+      await hook.result.current.createRoom('Alice')
+    })
+    return hook
+  }
+
+  it('sets connectionStatus to desynced after MAX_RETRIES CAS conflicts are exhausted', async () => {
+    const hook = await connect()
+    expect(hook.result.current.connectionStatus).toBe('live')
+
+    // dispatch_<game> RPC returns { data: null } for every attempt (default mock) → CAS conflict.
+    // get_<game> returns a valid, strictly-newer row so each retry refetches and loops again
+    // (rather than bailing on a missing/invalid fresh row) until MAX_RETRIES is exhausted.
+    authoritativeRow = { state: { phase: 'play', players: [{ id: 'a' }] }, version: 999 }
+
+    await act(async () => {
+      await hook.result.current.dispatch({ type: 'noop' })
+    })
+
+    // Exhausted: both the existing error AND the new desync flag are surfaced.
+    expect(hook.result.current.error).toBe('Action failed due to a conflict. Please try again.')
+    expect(hook.result.current.connectionStatus).toBe('desynced')
+  })
+})
+
+describe('useGameRoom tab-close teardown lifecycle (CLIENT-02)', () => {
+  // Override document.visibilityState (read-only in jsdom) for the hidden/visible paths.
+  function setVisibility(state: 'hidden' | 'visible') {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    })
+  }
+
+  async function connect() {
+    const hook = renderHook(() => useGameRoom<State, Action>(config))
+    await act(async () => {
+      await hook.result.current.createRoom('Alice')
+    })
+    return hook
+  }
+
+  afterEach(() => {
+    // Reset to the jsdom default so cases don't leak visibility state into one another.
+    setVisibility('visible')
+  })
+
+  it('unsubscribes the channels on pagehide WITHOUT clearing the session/status/playerId (D-05)', async () => {
+    const hook = await connect()
+    const stateCh = stateChannel()!
+    const presenceCh = presenceChannel()!
+    const playerIdBefore = hook.result.current.playerId
+    const sessionRaw = localStorage.getItem('test_session')
+    expect(sessionRaw).not.toBeNull()
+
+    await act(async () => {
+      document.dispatchEvent(new Event('pagehide'))
+    })
+
+    // Channels torn down...
+    expect(stateCh.unsubscribe).toHaveBeenCalled()
+    expect(presenceCh.unsubscribe).toHaveBeenCalled()
+    // ...but the session-bearing state is deliberately preserved (NOT a leaveRoom — D-05).
+    expect(hook.result.current.status).toBe('connected')
+    expect(hook.result.current.roomCode).not.toBeNull()
+    expect(hook.result.current.playerId).toBe(playerIdBefore)
+    expect(localStorage.getItem('test_session')).toBe(sessionRaw)
+  })
+
+  it('tears down on visibilitychange→hidden the same way (channel-only, session kept)', async () => {
+    const hook = await connect()
+    const stateCh = stateChannel()!
+    const presenceCh = presenceChannel()!
+
+    setVisibility('hidden')
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(stateCh.unsubscribe).toHaveBeenCalled()
+    expect(presenceCh.unsubscribe).toHaveBeenCalled()
+    expect(hook.result.current.status).toBe('connected')
+    expect(localStorage.getItem('test_session')).not.toBeNull()
+  })
+
+  it('is idempotent when both pagehide and visibilitychange→hidden fire — no throw, no double-unsubscribe on a nulled ref (D-08)', async () => {
+    await connect()
+    const stateCh = stateChannel()!
+
+    await act(async () => {
+      document.dispatchEvent(new Event('pagehide'))
+    })
+    expect(stateCh.unsubscribe).toHaveBeenCalledTimes(1)
+
+    // Second teardown (visibilitychange→hidden after pagehide already nulled the refs) must be a
+    // no-op: the ref is null so unsubscribe is NOT called again, and nothing throws.
+    setVisibility('hidden')
+    await act(async () => {
+      expect(() => document.dispatchEvent(new Event('visibilitychange'))).not.toThrow()
+    })
+    expect(stateCh.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-subscribes state + presence on visibilitychange→visible while still connected (D-07, Pitfall 4)', async () => {
+    await connect()
+
+    // Background: tear the channels down.
+    await act(async () => {
+      document.dispatchEvent(new Event('pagehide'))
+    })
+    const channelsAfterTeardown = channels.length
+
+    // Return: a valid authoritative row so refetch-on-reconnect applies cleanly.
+    authoritativeRow = { state: { phase: 'play', players: [{ id: 'a' }] }, version: 50 }
+    setVisibility('visible')
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    // New state + presence channels were created (subscribeToRoom + subscribeToPresence).
+    expect(channels.length).toBeGreaterThan(channelsAfterTeardown)
+    const newStateChannels = channels.filter((c) => c.name.startsWith('room:'))
+    const newPresenceChannels = channels.filter((c) => c.name.includes('-presence:'))
+    expect(newStateChannels.length).toBeGreaterThanOrEqual(2)
+    expect(newPresenceChannels.length).toBeGreaterThanOrEqual(2)
+
+    // Presence re-establishes: the freshest presence channel drives a track() on SUBSCRIBED,
+    // so the returning player becomes visible to peers again (Pitfall 4).
+    const freshPresence = newPresenceChannels[newPresenceChannels.length - 1]
+    await act(async () => {
+      await freshPresence.statusCb!('SUBSCRIBED')
+    })
+    expect(freshPresence.track).toHaveBeenCalledWith({ player_id: expect.any(String) })
+  })
+
+  it('removes the document listeners on unmount (no leak across rooms)', async () => {
+    const removeSpy = jest.spyOn(document, 'removeEventListener')
+    const hook = await connect()
+
+    hook.unmount()
+
+    expect(removeSpy).toHaveBeenCalledWith('pagehide', expect.any(Function))
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    removeSpy.mockRestore()
+  })
+})

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -2,10 +2,22 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { supabase } from '@/lib/supabase'
+import type { RoomRpcRow } from '@/lib/supabase'
 import { generateRoomCode } from '@/lib/room-code'
 import type { ZodType } from 'zod'
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000
+
+// Runtime guard for presence rows crossing the (untrusted) presence channel into React.
+// Strictly stronger than the previous unchecked player_id cast: a malformed presence row is
+// now filtered out instead of blindly trusted (T-04-02).
+function hasPlayerId(p: unknown): p is { player_id: string } {
+  return (
+    typeof p === 'object' &&
+    p !== null &&
+    typeof (p as { player_id?: unknown }).player_id === 'string'
+  )
+}
 
 interface Session {
   roomCode: string
@@ -40,7 +52,10 @@ function loadSession(key: string): Session | null {
 
 // Derive a Phase-2 RPC name from a room table: `<game>_rooms` + op -> `<op>_<game>`
 // e.g. rpcName('uno_rooms', 'dispatch') === 'dispatch_uno'. (ACCESS-02)
-function rpcName(tableName: string, op: 'create' | 'join' | 'restore' | 'dispatch'): string {
+function rpcName(
+  tableName: string,
+  op: 'create' | 'join' | 'restore' | 'dispatch' | 'get'
+): string {
   return `${op}_${tableName.replace('_rooms', '')}`
 }
 
@@ -100,6 +115,7 @@ export interface GameRoomConfig<TState extends BaseGameState, TAction, TBroadcas
     gameState: TState | null
     roomCode: string | null
     playerId: string | null
+    roomToken: string
     tableName: string
     applyAction: (state: TState, action: TAction) => TState
     stateSchema: ZodType<TState>
@@ -114,6 +130,9 @@ export interface UseGameRoomReturn<TState, TAction, TBroadcast = never> {
   error: string | null
   savedSession: Session | null
   onlinePlayerIds: string[]
+  // CLIENT-01: 'desynced' when a realtime payload fails Zod safeParse or the channel reports
+  // CHANNEL_ERROR/TIMED_OUT/CLOSED; auto-clears to 'live' on the next valid apply or SUBSCRIBED.
+  connectionStatus: 'live' | 'desynced'
   createRoom: (playerName: string, extras?: Record<string, unknown>) => Promise<void>
   joinRoom: (code: string, playerName: string, extras?: Record<string, unknown>) => Promise<void>
   restoreSession: () => Promise<void>
@@ -135,6 +154,10 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
   const [error, setError] = useState<string | null>(null)
   const [savedSession, setSavedSession] = useState<Session | null>(null)
   const [onlinePlayerIds, setOnlinePlayerIds] = useState<string[]>([])
+  // CLIENT-01 (D-02/D-03): visible, self-healing realtime-trouble flag. Set 'desynced' at the
+  // four trigger sites (invalid apply, invalid broadcast, state-channel error, presence error);
+  // cleared back to 'live' only at the two recovery points (valid apply, SUBSCRIBED) — Pitfall 5.
+  const [connectionStatus, setConnectionStatus] = useState<'live' | 'desynced'>('live')
   const stateChannelRef = useRef<ReturnType<NonNullable<typeof supabase>['channel']> | null>(null)
   const broadcastChannelRef = useRef<ReturnType<NonNullable<typeof supabase>['channel']> | null>(
     null
@@ -156,32 +179,53 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     setSavedSession(loadSession(configRef.current.sessionKey))
   }, [])
 
-  // Track presence to show which players are online
-  useEffect(() => {
-    if (!playerId || !roomCode || !supabase) return
+  // Create (or recreate) the presence channel and start tracking this player. Extracted from the
+  // presence effect so the CLIENT-02 tab-close `visible` path can re-establish presence too:
+  // teardown() nulls presenceChannelRef, and subscribeToRoom only recreates state+broadcast, so
+  // without this the returning player would stay invisible to peers (Pitfall 4). Idempotent:
+  // unsubscribes any existing presence channel first (null-checked) before opening a new one.
+  const subscribeToPresence = useCallback((pid: string, code: string) => {
+    if (!supabase) return
     const { channelPrefix } = configRef.current
+    presenceChannelRef.current?.unsubscribe()
     const channel = supabase
-      .channel(`${channelPrefix}-presence:${roomCode}`)
+      .channel(`${channelPrefix}-presence:${code}`)
       .on('presence', { event: 'sync' }, () => {
         const state = channel.presenceState()
         const ids = Object.values(state)
           .flat()
-          .map((p) => (p as unknown as { player_id: string }).player_id)
+          .filter(hasPlayerId)
+          .map((p) => p.player_id)
           .filter(Boolean)
         setOnlinePlayerIds(ids)
       })
       .subscribe(async (s: string) => {
+        if (s === 'CHANNEL_ERROR' || s === 'TIMED_OUT' || s === 'CLOSED') {
+          console.error(`[presence] channel ${s}`)
+          setConnectionStatus('desynced')
+          return
+        }
         if (s === 'SUBSCRIBED') {
-          await channel.track({ player_id: playerId })
+          // CR-02: do NOT clear connectionStatus here. Presence re-subscribing says nothing
+          // about the STATE channel's health; clearing on presence SUBSCRIBED produces a
+          // false-healthy signal (amber pill hidden) while the state channel is still dead.
+          // Only the state channel's SUBSCRIBED / valid-apply paths may clear the desync flag.
+          await channel.track({ player_id: pid })
         }
       })
     presenceChannelRef.current = channel
+  }, [])
+
+  // Track presence to show which players are online
+  useEffect(() => {
+    if (!playerId || !roomCode || !supabase) return
+    subscribeToPresence(playerId, roomCode)
     return () => {
-      channel.unsubscribe()
+      presenceChannelRef.current?.unsubscribe()
       presenceChannelRef.current = null
       setOnlinePlayerIds([])
     }
-  }, [playerId, roomCode])
+  }, [playerId, roomCode, subscribeToPresence])
 
   const setStateAndRef = useCallback((state: TState | null, version?: number) => {
     gameStateRef.current = state
@@ -202,9 +246,13 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         const parsed = stateSchema.safeParse(rawState)
         if (!parsed.success) {
           console.error(`[${channelPrefix}] Invalid GameState payload:`, parsed.error)
+          // D-02: an invalid payload is a recoverable desync — surface it (not just console).
+          setConnectionStatus('desynced')
           return
         }
         setStateAndRef(parsed.data, version)
+        // D-03: a valid apply means we are back in sync — auto-clear (no manual reload).
+        setConnectionStatus('live')
       }
 
       const supabaseClient = supabase
@@ -217,12 +265,9 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       // huge version can't freeze the room because the forged version is never written
       // to versionRef (only the value returned by the authoritative SELECT is).
       const refetchAuthoritativeState = async () => {
-        const { data } = await supabaseClient
-          .from(tableName)
-          .select('state, version')
-          .eq('code', code)
-          .single()
-        if (data) applyIfNewer(data.state, data.version)
+        const { data } = await supabaseClient.rpc(rpcName(tableName, 'get'), { p_code: code })
+        const row = data && data.length > 0 ? data[0] : null
+        if (row) applyIfNewer(row.state, row.version)
       }
 
       // State sync is broadcast-signalled now (ACCESS-05, D-08): the postgres_changes UPDATE
@@ -238,7 +283,16 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         // through the still-permissive SELECT (additive window), recovering any signal
         // missed while disconnected. No postgres_changes backstop.
         .subscribe(async (s: string) => {
+          // D-02: channel trouble is the other failure class. Compare against the literal status
+          // strings (RESEARCH anti-pattern: do NOT import REALTIME_SUBSCRIBE_STATES across the seam).
+          if (s === 'CHANNEL_ERROR' || s === 'TIMED_OUT' || s === 'CLOSED') {
+            console.error(`[${channelPrefix}] State channel ${s}`)
+            setConnectionStatus('desynced')
+            return
+          }
           if (s !== 'SUBSCRIBED') return
+          // D-03: (re)subscribe means we are reconnected — clear, then recover missed state.
+          setConnectionStatus('live')
           await refetchAuthoritativeState()
         })
 
@@ -251,6 +305,8 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
               const parsed = broadcastCfg.schema.safeParse(payload.payload)
               if (!parsed.success) {
                 console.error(`[${channelPrefix}] Invalid broadcast payload:`, parsed.error)
+                // D-02: malformed broadcast is the same recoverable desync class as a bad state.
+                setConnectionStatus('desynced')
                 return
               }
               onBroadcastRef.current(parsed.data)
@@ -292,7 +348,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       // bounded to 3 attempts, mirroring the dispatch() CAS retry idiom (MAX_RETRIES = 3). Any
       // other error (network/22023 invalid name) fails fast. (CODE-02, ACCESS-02)
       const MAX_CREATE_ATTEMPTS = 3
-      let inserted: Record<string, unknown> | null = null
+      let inserted: RoomRpcRow | null = null
       let landedCode = ''
       let lastErrCode: string | undefined
 
@@ -319,11 +375,11 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         return
       }
 
-      const roomToken = (inserted.room_token as string) ?? ''
+      const roomToken = inserted.room_token ?? ''
       roomTokenRef.current = roomToken
       setPlayerId(id)
       setRoomCode(landedCode)
-      setStateAndRef(initialState, inserted.version as number)
+      setStateAndRef(initialState, inserted.version)
       setStatus('connected')
       saveSession(cfg.sessionKey, { roomCode: landedCode, playerId: id, playerName, roomToken })
       subscribeToRoom(landedCode)
@@ -339,19 +395,18 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       setError(null)
 
       const normalizedCode = code.trim().toUpperCase()
-      const { data, error: err } = await supabase
-        .from(cfg.tableName)
-        .select('state, version')
-        .eq('code', normalizedCode)
-        .single()
+      const { data, error: err } = await supabase.rpc(rpcName(cfg.tableName, 'get'), {
+        p_code: normalizedCode,
+      })
+      const row = data && data.length > 0 ? data[0] : null
 
-      if (err || !data) {
+      if (err || !row) {
         setError('Room not found. Check the code and try again.')
         setStatus('error')
         return
       }
 
-      const parsedCurrent = cfg.stateSchema.safeParse(data.state)
+      const parsedCurrent = cfg.stateSchema.safeParse(row.state)
       if (!parsedCurrent.success) {
         console.error(`[${cfg.channelPrefix}] Invalid GameState in joinRoom:`, parsedCurrent.error)
         setError('Room data is invalid. Try again.')
@@ -382,10 +437,10 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         return
       }
 
-      // Additive window: the SELECT above (still-permissive policy) computes newState/version,
-      // but the WRITE goes through the join_<game> RPC, which CAS-updates and returns the
-      // room_token (D-02). (ACCESS-02)
-      const currentVersion = data.version as number
+      // The code-gated get_<game> read above computes newState/version, but the WRITE goes
+      // through the join_<game> RPC, which CAS-updates and returns the room_token (D-02).
+      // (ACCESS-02)
+      const currentVersion = row.version
       const { data: updated, error: updateErr } = await supabase.rpc(
         rpcName(cfg.tableName, 'join'),
         {
@@ -411,11 +466,11 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         return
       }
 
-      const roomToken = (updated[0].room_token as string) ?? ''
+      const roomToken = updated[0].room_token ?? ''
       roomTokenRef.current = roomToken
       setPlayerId(id)
       setRoomCode(normalizedCode)
-      setStateAndRef(newState, (updated[0].version as number) ?? currentVersion + 1)
+      setStateAndRef(newState, updated[0].version ?? currentVersion + 1)
       setStatus('connected')
       saveSession(cfg.sessionKey, { roomCode: normalizedCode, playerId: id, playerName, roomToken })
       subscribeToRoom(normalizedCode)
@@ -457,7 +512,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     }
     const state = parsedState.data
 
-    const roomToken = (row.room_token as string) ?? ''
+    const roomToken = row.room_token ?? ''
     roomTokenRef.current = roomToken
     saveSession(cfg.sessionKey, {
       roomCode: session.roomCode,
@@ -467,7 +522,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     })
     setPlayerId(session.playerId)
     setRoomCode(session.roomCode)
-    setStateAndRef(state, row.version as number)
+    setStateAndRef(state, row.version)
     setStatus('connected')
     subscribeToRoom(session.roomCode)
   }, [subscribeToRoom, setStateAndRef])
@@ -501,7 +556,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         if (data && data.length > 0) {
           // Apply the accepted state locally right away so controls feel instant
           // instead of waiting for the realtime broadcast echo from Supabase.
-          setStateAndRef(newState, (data[0].version as number) ?? currentVersion + 1)
+          setStateAndRef(newState, data[0].version ?? currentVersion + 1)
           return
         }
 
@@ -512,13 +567,12 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         }
 
         if (attempt < MAX_RETRIES) {
-          const { data: fresh } = await supabase
-            .from(cfg.tableName)
-            .select('state, version')
-            .eq('code', roomCode)
-            .single()
-          if (!fresh) return
-          const parsedFresh = cfg.stateSchema.safeParse(fresh.state)
+          const { data: fresh } = await supabase.rpc(rpcName(cfg.tableName, 'get'), {
+            p_code: roomCode,
+          })
+          const freshRow = fresh && fresh.length > 0 ? fresh[0] : null
+          if (!freshRow) return
+          const parsedFresh = cfg.stateSchema.safeParse(freshRow.state)
           if (!parsedFresh.success) {
             console.error(
               `[${cfg.channelPrefix}] Invalid GameState in dispatch retry:`,
@@ -527,10 +581,13 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
             return
           }
           currentState = parsedFresh.data
-          currentVersion = fresh.version as number
+          currentVersion = freshRow.version
           setStateAndRef(currentState, currentVersion)
         } else {
           setError('Action failed due to a conflict. Please try again.')
+          // BL-02: MAX_RETRIES CAS conflicts exhausted means local {state, version} is
+          // known-stale. Surface the desync indicator so the player knows they are out of sync.
+          setConnectionStatus('desynced')
         }
       }
     },
@@ -545,6 +602,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
           gameState: gameStateRef.current,
           roomCode,
           playerId,
+          roomToken: roomTokenRef.current,
           tableName: cfg.tableName,
           applyAction: cfg.applyAction,
           stateSchema: cfg.stateSchema,
@@ -569,6 +627,46 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     }
   }, [roomCode, playerId, setStateAndRef])
 
+  // CLIENT-02 (D-05..D-08): tear down realtime/broadcast/presence channels on tab close/hide
+  // (`pagehide` / `visibilitychange→hidden`), NOT only on React unmount, and re-subscribe on
+  // return (`→visible`). This is a GENTLE, channel-only teardown: it deliberately PRESERVES the
+  // 24h localStorage session, status, playerId, gameState and onlinePlayerIds — a full leaveRoom
+  // would be hostile because `hidden` fires on every routine mobile backgrounding (Pitfall 1).
+  useEffect(() => {
+    if (!roomCode || !playerId) return
+
+    // Channel-only teardown (D-05). Null the refs after `?.unsubscribe()` so a second call —
+    // both events firing, or an event followed by the unmount cleanup below — is a no-op (D-08).
+    // MUST NOT clearSession / setStatus / setPlayerId / setGameState / setOnlinePlayerIds.
+    const teardown = () => {
+      stateChannelRef.current?.unsubscribe()
+      stateChannelRef.current = null
+      broadcastChannelRef.current?.unsubscribe()
+      broadcastChannelRef.current = null
+      presenceChannelRef.current?.unsubscribe()
+      presenceChannelRef.current = null
+    }
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        teardown()
+      } else if (document.visibilityState === 'visible') {
+        // D-07: re-establish state+broadcast (subscribeToRoom re-reads authoritative {state,version}
+        // on SUBSCRIBED — Phase 2 D-10) AND presence (Pitfall 4 — presence is a separate channel
+        // that subscribeToRoom does not recreate).
+        subscribeToRoom(roomCode)
+        subscribeToPresence(playerId, roomCode)
+      }
+    }
+
+    document.addEventListener('pagehide', teardown)
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => {
+      document.removeEventListener('pagehide', teardown)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [roomCode, playerId, subscribeToRoom, subscribeToPresence])
+
   useEffect(() => {
     return () => {
       stateChannelRef.current?.unsubscribe()
@@ -585,6 +683,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     error,
     savedSession,
     onlinePlayerIds,
+    connectionStatus,
     createRoom,
     joinRoom,
     restoreSession,

--- a/src/lib/room-code.test.ts
+++ b/src/lib/room-code.test.ts
@@ -60,13 +60,23 @@ describe('3-layer agreement', () => {
   })
 })
 
+// Post-Phase-3 seal: the permissive insert-CHECK policies (which carried the
+// room-code regex as `code ~ '<regex>'`) were dropped; INSERT is now RPC-only.
+// SQL-side room-code validation therefore lives entirely in the SECURITY DEFINER
+// RPC bodies as `p_code !~ '<regex>'` — one per RPC across 6 games × 5 RPC
+// families (create/join/restore/dispatch/get) = 30. This guard keeps those 30
+// literals from drifting off ROOM_CODE_REGEX_SQL (CODE-03).
 describe('SQL drift guard', () => {
   const schemaPath = path.resolve(__dirname, '../../supabase-schema.sql')
   const sql = fs.readFileSync(schemaPath, 'utf8')
-  const literals = [...sql.matchAll(/code ~ '([^']+)'/g)].map((m) => m[1])
+  const literals = [...sql.matchAll(/p_code !~ '([^']+)'/g)].map((m) => m[1])
 
-  it('finds exactly 6 insert-CHECK code regex literals', () => {
-    expect(literals).toHaveLength(6)
+  it('finds exactly 30 RPC code-validation regex literals (6 games × 5 RPC families)', () => {
+    expect(literals).toHaveLength(30)
+  })
+
+  it('has no permissive insert-CHECK code literals left after the seal', () => {
+    expect([...sql.matchAll(/code ~ '([^']+)'/g)]).toHaveLength(0)
   })
 
   it('every SQL code regex literal is byte-identical to ROOM_CODE_REGEX_SQL', () => {
@@ -94,9 +104,12 @@ describe('schema templating drift guard (MIGR-03 / ACCESS-04)', () => {
     expect(countMatches(/_broadcast_state after update on public\./g)).toBe(6)
   })
 
-  it.each(['create', 'join', 'restore', 'dispatch'])('defines the %s_<game> RPC 6×', (op) => {
-    expect(countMatches(new RegExp(`create or replace function public\\.${op}_`, 'g'))).toBe(6)
-  })
+  it.each(['create', 'join', 'restore', 'dispatch', 'get'])(
+    'defines the %s_<game> RPC 6×',
+    (op) => {
+      expect(countMatches(new RegExp(`create or replace function public\\.${op}_`, 'g'))).toBe(6)
+    }
+  )
 
   it('pins search_path on every `security definer` function (definer hygiene, lint 0011)', () => {
     // Every SECURITY DEFINER function MUST pin search_path to '' (Advisor 0011). Some

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -27,10 +27,21 @@ type ChannelBoundary = {
   unsubscribe(): Promise<unknown>
 }
 
+// The single typed view of a room row returned by the SECURITY DEFINER RPCs
+// (create/join/restore/get/dispatch_<game>). `state` STAYS `unknown` (D-09): it is untrusted
+// network data and MUST continue through the game's Zod `stateSchema.safeParse` downstream —
+// narrowing it here would silently bypass that runtime validation. Typing this seam once removes
+// the ad-hoc per-field `as number` / `as string` / `as Record` casts at every call site.
+export interface RoomRpcRow {
+  state: unknown
+  version: number
+  room_token?: string
+}
+
 // SECURITY DEFINER RPCs (plan 02-01) use `returns table(...)`, so `data` is an array the
 // caller reads `[0]` from, and `error` carries a stable Postgres `code` (22023/42501/40001/23505).
 type RpcResult = {
-  data: Record<string, unknown>[] | null
+  data: RoomRpcRow[] | null
   error: { message: string; code?: string } | null
 }
 
@@ -45,8 +56,14 @@ const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
 const useFakeSupabase = process.env.NEXT_PUBLIC_E2E_FAKE_SUPABASE === '1'
 
 export const supabase: SupabaseBoundary | null = useFakeSupabase
-  ? (createFakeSupabaseClient() as unknown as SupabaseBoundary)
+  ? // Deliberate untyped fake↔real boundary cast (D-10): the in-memory fake client and the
+    // real @supabase/supabase-js client are two different concrete types unified onto the
+    // minimal SupabaseBoundary contract; structurally typing that seam would require widening
+    // SupabaseBoundary. No `any` and no suppression directive (D-11) — the narrow boundary type is kept.
+    (createFakeSupabaseClient() as unknown as SupabaseBoundary)
   : url && key
-    ? (createClient(url, key) as unknown as SupabaseBoundary)
+    ? // Deliberate untyped fake↔real boundary cast (D-10): the real SupabaseClient is far wider
+      // than the SupabaseBoundary contract we consume; this cast pins it to that minimal surface.
+      (createClient(url, key) as unknown as SupabaseBoundary)
     : null
 export const isSupabaseConfigured = useFakeSupabase || Boolean(url && key)

--- a/supabase-migration-seal-rls-rollback.sql
+++ b/supabase-migration-seal-rls-rollback.sql
@@ -1,0 +1,65 @@
+-- Migration: SEAL rollback (Phase 3, ACCESS-01) — UNSEAL the room tables
+-- Run this in your Supabase project: SQL Editor → New query → Paste → Run
+--
+-- This is the byte-faithful inverse of supabase-migration-seal-rls.sql: it
+-- re-creates the 3 permissive SELECT/UPDATE/INSERT policies on each of the 6
+-- room tables, restoring the pre-seal world-readable/writable state. Apply only
+-- if a seal verification step fails and you need to roll back.
+--
+-- RLS is already enabled on every table (the seal never disabled it), so this
+-- only re-creates the dropped policies. Each policy uses the table's ORIGINAL
+-- name and the original INSERT predicate.
+
+-- ── uno_rooms ────────────────────────────────────────────────────────────────
+create policy "select rooms" on public.uno_rooms for select using (true);
+create policy "insert with valid code" on public.uno_rooms
+  for insert with check (
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
+    and state is not null
+  );
+create policy "update rooms" on public.uno_rooms for update using (true);
+
+-- ── skribbl_rooms ────────────────────────────────────────────────────────────
+create policy "select skribbl rooms" on public.skribbl_rooms for select using (true);
+create policy "insert skribbl rooms" on public.skribbl_rooms
+  for insert with check (
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
+    and state is not null
+  );
+create policy "update skribbl rooms" on public.skribbl_rooms for update using (true);
+
+-- ── agario_rooms ─────────────────────────────────────────────────────────────
+create policy "select agario rooms" on public.agario_rooms for select using (true);
+create policy "insert agario rooms" on public.agario_rooms
+  for insert with check (
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
+    and state is not null
+  );
+create policy "update agario rooms" on public.agario_rooms for update using (true);
+
+-- ── cah_rooms ────────────────────────────────────────────────────────────────
+create policy "select cah rooms" on public.cah_rooms for select using (true);
+create policy "insert cah rooms" on public.cah_rooms
+  for insert with check (
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
+    and state is not null
+  );
+create policy "update cah rooms" on public.cah_rooms for update using (true);
+
+-- ── codenames_rooms ──────────────────────────────────────────────────────────
+create policy "select codenames rooms" on public.codenames_rooms for select using (true);
+create policy "insert codenames rooms" on public.codenames_rooms
+  for insert with check (
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
+    and state is not null
+  );
+create policy "update codenames rooms" on public.codenames_rooms for update using (true);
+
+-- ── mindmeld_rooms ───────────────────────────────────────────────────────────
+create policy "select mindmeld rooms" on public.mindmeld_rooms for select using (true);
+create policy "insert mindmeld rooms" on public.mindmeld_rooms
+  for insert with check (
+    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
+    and state is not null
+  );
+create policy "update mindmeld rooms" on public.mindmeld_rooms for update using (true);

--- a/supabase-migration-seal-rls.sql
+++ b/supabase-migration-seal-rls.sql
@@ -1,0 +1,53 @@
+-- Migration: SEAL the room tables (Phase 3, ACCESS-01)
+-- Run this in your Supabase project: SQL Editor → New query → Paste → Run
+--
+-- What this does:
+--   Drops the permissive SELECT/UPDATE/INSERT `using(true)` policies on all 6
+--   room tables, closing the world-readable enumeration vector and the
+--   world-write surface. RLS is left ENABLED (default-deny for anon).
+--
+-- Why this is needed on EXISTING deployments:
+--   PostgreSQL keeps policies until an explicit DROP. Re-running supabase-schema.sql
+--   (which no longer CREATEs these policies) does NOT remove already-installed
+--   policies. Apply this migration once to seal a project that ran an earlier schema.
+--   (supabase-schema.sql now also embeds this same drop block for fresh paste-and-run.)
+--
+-- Safe to run repeatedly: `drop policy if exists` is idempotent, and on a fresh
+-- project (no permissive policies) this is a no-op.
+--
+-- After Phase 2, every create/join/restore/dispatch and every read runs through
+-- SECURITY DEFINER RPCs that bypass RLS as the table owner, so dropping these
+-- policies does NOT break legitimate play.
+--
+-- CRITICAL: this migration ONLY drops policies. It must NEVER turn RLS off —
+-- doing so would re-open world-read. RLS stays enabled throughout. DELETE has no
+-- policy (pg_cron-only cleanup) and is left untouched.
+--
+-- Rollback: supabase-migration-seal-rls-rollback.sql re-creates all 18 policies.
+--
+-- This migration is name-agnostic: per-table policy names diverge (uno uses
+-- "select rooms" / "insert with valid code" / "update rooms"; the other five use
+-- "select <game> rooms" / "insert <game> rooms" / "update <game> rooms"), so we
+-- iterate pg_policies and drop by discovered name rather than hard-coding names.
+
+do $$
+declare
+  t text;
+  pol record;
+begin
+  foreach t in array array[
+    'uno_rooms', 'skribbl_rooms', 'agario_rooms',
+    'cah_rooms', 'codenames_rooms', 'mindmeld_rooms'
+  ] loop
+    for pol in
+      select policyname from pg_policies
+       where schemaname = 'public'
+         and tablename = t
+         and cmd in ('SELECT', 'UPDATE', 'INSERT')
+    loop
+      execute format('drop policy if exists %I on public.%I', pol.policyname, t);
+    end loop;
+  end loop;
+end $$;
+
+-- RLS stays ENABLED (default-deny for anon). DELETE has no policy (pg_cron-only) → untouched.

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -57,9 +57,11 @@ create or replace trigger uno_rooms_protect_immutable
 -- through the SECURITY DEFINER RPCs (create/join/restore/dispatch/get_<game>),
 -- which bypass RLS as the table owner. The code-gated get_<game>(p_code) read
 -- RPC prevents enumeration without Supabase Auth (requires the exact code,
--- returns at most one row). The previous permissive select/update/insert
--- using(true) policies were dropped by seal-up.sql; seal-down.sql re-creates
--- them for rollback. DELETE has no policy (pg_cron-only cleanup).
+-- returns at most one row). Any pre-existing permissive select/update/insert
+-- using(true) policies are dropped by the SEAL block further below (so
+-- re-pasting this file onto an existing deployment actually seals it); rollback
+-- lives in supabase-migration-seal-rls-rollback.sql. DELETE has no policy
+-- (pg_cron-only cleanup).
 alter table uno_rooms enable row level security;
 
 -- Optional: auto-delete rooms older than 24 hours
@@ -195,6 +197,37 @@ alter publication supabase_realtime add table mindmeld_rooms;
 alter table mindmeld_rooms enable row level security;
 
 -- delete from mindmeld_rooms where updated_at < now() - interval '24 hours';
+
+-- ─── SEAL: drop any pre-existing permissive policies (Phase 3, ACCESS-01) ─────
+-- On a FRESH project this is a no-op (no policies were ever created). On an
+-- EXISTING project that ran an earlier version of this schema, the old
+-- permissive SELECT/UPDATE/INSERT `using(true)` policies SURVIVE a re-paste —
+-- PostgreSQL keeps policies until an explicit DROP — which would leave anon
+-- direct table access open and defeat the seal. This block drops them
+-- name-agnostically (policy names diverge across tables), so pasting this file
+-- actually seals an existing deployment. RLS stays ENABLED throughout (never
+-- disabled — that would re-open world-read). DELETE has no policy (pg_cron-only
+-- cleanup) and is left untouched. Standalone + rollback equivalents:
+-- supabase-migration-seal-rls.sql / supabase-migration-seal-rls-rollback.sql
+do $$
+declare
+  t text;
+  pol record;
+begin
+  foreach t in array array[
+    'uno_rooms', 'skribbl_rooms', 'agario_rooms',
+    'cah_rooms', 'codenames_rooms', 'mindmeld_rooms'
+  ] loop
+    for pol in
+      select policyname from pg_policies
+       where schemaname = 'public'
+         and tablename = t
+         and cmd in ('SELECT', 'UPDATE', 'INSERT')
+    loop
+      execute format('drop policy if exists %I on public.%I', pol.policyname, t);
+    end loop;
+  end loop;
+end $$;
 
 -- ─── Migration: add version column to existing tables ───────────────────────
 -- Run this once if your tables already exist (the CREATE TABLE statements above

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -50,24 +50,17 @@ create or replace trigger uno_rooms_protect_immutable
 -- The anon key is public by design (like Firebase API keys).
 -- RLS is the real security layer. Room codes act as access tokens —
 -- you must know the code to read or mutate a room.
+--
+-- SEALED (Phase 3, ACCESS-01): RLS is ENABLED with NO permissive policies, so
+-- this table is default-deny for anon — a direct .from('uno_rooms').select()
+-- returns zero rows and direct writes are denied. All legitimate access flows
+-- through the SECURITY DEFINER RPCs (create/join/restore/dispatch/get_<game>),
+-- which bypass RLS as the table owner. The code-gated get_<game>(p_code) read
+-- RPC prevents enumeration without Supabase Auth (requires the exact code,
+-- returns at most one row). The previous permissive select/update/insert
+-- using(true) policies were dropped by seal-up.sql; seal-down.sql re-creates
+-- them for rollback. DELETE has no policy (pg_cron-only cleanup).
 alter table uno_rooms enable row level security;
-
--- SELECT: allow reads (room codes are the access tokens; you must know the code
--- to query). RLS cannot inspect PostgREST query parameters, so to fully prevent
--- enumeration, use Supabase Auth with user-scoped rooms.
-create policy "select rooms" on uno_rooms for select using (true);
-
--- INSERT: enforce 6-char Crockford base-32 room code format
-create policy "insert with valid code" on uno_rooms
-  for insert with check (
-    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
-    and state is not null
-  );
-
--- UPDATE: allow state changes (immutable column protection is enforced by trigger)
-create policy "update rooms" on uno_rooms for update using (true);
-
--- DELETE: no policy = denied with RLS enabled. Rooms are cleaned up by pg_cron only.
 
 -- Optional: auto-delete rooms older than 24 hours
 -- (run manually or schedule via pg_cron if you have it)
@@ -93,17 +86,9 @@ create or replace trigger skribbl_rooms_protect_immutable
 
 alter publication supabase_realtime add table skribbl_rooms;
 
+-- SEALED (Phase 3, ACCESS-01): RLS enabled, no permissive policies (default-deny
+-- for anon). Access flows through the SECURITY DEFINER RPCs only.
 alter table skribbl_rooms enable row level security;
-
-create policy "select skribbl rooms" on skribbl_rooms for select using (true);
-
-create policy "insert skribbl rooms" on skribbl_rooms
-  for insert with check (
-    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
-    and state is not null
-  );
-
-create policy "update skribbl rooms" on skribbl_rooms for update using (true);
 
 -- delete from skribbl_rooms where updated_at < now() - interval '24 hours';
 
@@ -127,17 +112,9 @@ create or replace trigger agario_rooms_protect_immutable
 
 alter publication supabase_realtime add table agario_rooms;
 
+-- SEALED (Phase 3, ACCESS-01): RLS enabled, no permissive policies (default-deny
+-- for anon). Access flows through the SECURITY DEFINER RPCs only.
 alter table agario_rooms enable row level security;
-
-create policy "select agario rooms" on agario_rooms for select using (true);
-
-create policy "insert agario rooms" on agario_rooms
-  for insert with check (
-    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
-    and state is not null
-  );
-
-create policy "update agario rooms" on agario_rooms for update using (true);
 
 -- delete from agario_rooms where updated_at < now() - interval '24 hours';
 
@@ -161,17 +138,9 @@ create or replace trigger cah_rooms_protect_immutable
 
 alter publication supabase_realtime add table cah_rooms;
 
+-- SEALED (Phase 3, ACCESS-01): RLS enabled, no permissive policies (default-deny
+-- for anon). Access flows through the SECURITY DEFINER RPCs only.
 alter table cah_rooms enable row level security;
-
-create policy "select cah rooms" on cah_rooms for select using (true);
-
-create policy "insert cah rooms" on cah_rooms
-  for insert with check (
-    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
-    and state is not null
-  );
-
-create policy "update cah rooms" on cah_rooms for update using (true);
 
 -- delete from cah_rooms where updated_at < now() - interval '24 hours';
 
@@ -195,17 +164,9 @@ create or replace trigger codenames_rooms_protect_immutable
 
 alter publication supabase_realtime add table codenames_rooms;
 
+-- SEALED (Phase 3, ACCESS-01): RLS enabled, no permissive policies (default-deny
+-- for anon). Access flows through the SECURITY DEFINER RPCs only.
 alter table codenames_rooms enable row level security;
-
-create policy "select codenames rooms" on codenames_rooms for select using (true);
-
-create policy "insert codenames rooms" on codenames_rooms
-  for insert with check (
-    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
-    and state is not null
-  );
-
-create policy "update codenames rooms" on codenames_rooms for update using (true);
 
 -- delete from codenames_rooms where updated_at < now() - interval '24 hours';
 
@@ -229,17 +190,9 @@ create or replace trigger mindmeld_rooms_protect_immutable
 
 alter publication supabase_realtime add table mindmeld_rooms;
 
+-- SEALED (Phase 3, ACCESS-01): RLS enabled, no permissive policies (default-deny
+-- for anon). Access flows through the SECURITY DEFINER RPCs only.
 alter table mindmeld_rooms enable row level security;
-
-create policy "select mindmeld rooms" on mindmeld_rooms for select using (true);
-
-create policy "insert mindmeld rooms" on mindmeld_rooms
-  for insert with check (
-    code ~ '^[0-9A-HJKMNP-TV-Z]{6}$'
-    and state is not null
-  );
-
-create policy "update mindmeld rooms" on mindmeld_rooms for update using (true);
 
 -- delete from mindmeld_rooms where updated_at < now() - interval '24 hours';
 
@@ -254,12 +207,13 @@ create policy "update mindmeld rooms" on mindmeld_rooms for update using (true);
 
 -- ════════════════════════════════════════════════════════════════════════════
 -- Phase 2 (ADDITIVE): member-scoped RPCs, broadcast delivery, server-side
--- validation. Everything below is additive — the permissive `using(true)`
--- SELECT/UPDATE policies above stay in place (sealing is Phase 3, never this
--- phase). Each block is independently reversible (drop column / drop trigger /
--- drop function) and does not break in-flight rooms or stale cached clients.
--- Applied identically across all 6 room tables from one templated source
--- (MIGR-03 / D-15).
+-- validation. These RPCs are the sanctioned access path. (Phase 3 then SEALED
+-- the tables — the previously-permissive `using(true)` SELECT/UPDATE/INSERT
+-- policies have been dropped above; RLS stays enabled, default-deny for anon, so
+-- these SECURITY DEFINER RPCs are now the ONLY way to touch a room.) Each block
+-- is independently reversible (drop column / drop trigger / drop function) and
+-- does not break in-flight rooms or stale cached clients. Applied identically
+-- across all 6 room tables from one templated source (MIGR-03 / D-15).
 -- ════════════════════════════════════════════════════════════════════════════
 
 -- ─── room_token column (×6) ─────────────────────────────────────────────────
@@ -1394,3 +1348,137 @@ $$;
 
 revoke all on function public.dispatch_mindmeld(text, uuid, jsonb, integer) from public;
 grant execute on function public.dispatch_mindmeld(text, uuid, jsonb, integer) to anon;
+
+-- ─── Code-gated read RPCs (ACCESS-01) ─────────────────────────────────────────
+-- get_<game>(p_code) is the sealed-world read primitive. It requires the EXACT
+-- room code and returns at most one room's { state, version } — there is no list
+-- capability and no wildcard, so it is NOT a re-opening of the world-readable
+-- `select using(true)` path. SECURITY DEFINER lets a code-holder read a room once
+-- the permissive SELECT policy is dropped (Plan 03 seal). An unknown code returns
+-- ZERO rows (NOT a raised error), preserving the "Room not found" UX (D-01).
+
+create or replace function public.get_uno(p_code text)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  return query
+  select public.uno_rooms.state, public.uno_rooms.version
+    from public.uno_rooms
+   where public.uno_rooms.code = p_code;
+  -- NO `if not found` raise: unknown code → zero rows (preserves "Room not found" UX).
+end;
+$$;
+
+revoke all on function public.get_uno(text) from public;
+grant execute on function public.get_uno(text) to anon;
+
+create or replace function public.get_skribbl(p_code text)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  return query
+  select public.skribbl_rooms.state, public.skribbl_rooms.version
+    from public.skribbl_rooms
+   where public.skribbl_rooms.code = p_code;
+  -- NO `if not found` raise: unknown code → zero rows (preserves "Room not found" UX).
+end;
+$$;
+
+revoke all on function public.get_skribbl(text) from public;
+grant execute on function public.get_skribbl(text) to anon;
+
+create or replace function public.get_agario(p_code text)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  return query
+  select public.agario_rooms.state, public.agario_rooms.version
+    from public.agario_rooms
+   where public.agario_rooms.code = p_code;
+  -- NO `if not found` raise: unknown code → zero rows (preserves "Room not found" UX).
+end;
+$$;
+
+revoke all on function public.get_agario(text) from public;
+grant execute on function public.get_agario(text) to anon;
+
+create or replace function public.get_cah(p_code text)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  return query
+  select public.cah_rooms.state, public.cah_rooms.version
+    from public.cah_rooms
+   where public.cah_rooms.code = p_code;
+  -- NO `if not found` raise: unknown code → zero rows (preserves "Room not found" UX).
+end;
+$$;
+
+revoke all on function public.get_cah(text) from public;
+grant execute on function public.get_cah(text) to anon;
+
+create or replace function public.get_codenames(p_code text)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  return query
+  select public.codenames_rooms.state, public.codenames_rooms.version
+    from public.codenames_rooms
+   where public.codenames_rooms.code = p_code;
+  -- NO `if not found` raise: unknown code → zero rows (preserves "Room not found" UX).
+end;
+$$;
+
+revoke all on function public.get_codenames(text) from public;
+grant execute on function public.get_codenames(text) to anon;
+
+create or replace function public.get_mindmeld(p_code text)
+returns table(state jsonb, version integer)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if p_code !~ '^[0-9A-HJKMNP-TV-Z]{6}$' then
+    raise exception 'invalid code' using errcode = '22023';
+  end if;
+  return query
+  select public.mindmeld_rooms.state, public.mindmeld_rooms.version
+    from public.mindmeld_rooms
+   where public.mindmeld_rooms.code = p_code;
+  -- NO `if not found` raise: unknown code → zero rows (preserves "Room not found" UX).
+end;
+$$;
+
+revoke all on function public.get_mindmeld(text) from public;
+grant execute on function public.get_mindmeld(text) to anon;


### PR DESCRIPTION
## Summary

Phases 3–4 of the Security Hardening milestone, on top of Phases 1–2 already merged via #151. Source changes only — GSD `.planning/` artifacts and `CLAUDE.md` are intentionally excluded.

## What changed

**Phase 3 — Seal the tables**
- Code-gated `get_<game>` read RPCs; anon table reads sealed behind RPCs
- Enumeration-prevention canary; fake-supabase `/rpc` + DB-broadcast model

**Phase 4 — Client hardening & test coverage**
- User-visible `DesyncIndicator` (`connectionStatus`) across all 6 online games — kept visible when only presence recovers (CR-02), surfaced on dispatch CAS exhaustion (BL-02)
- Channel teardown on `pagehide` / `visibilitychange→hidden` (idempotent), 24h session preserved, re-subscribe on return
- Narrowed unsafe `as unknown as` casts at the Supabase boundary (`RoomRpcRow`)
- Deepened schema tests for codenames & mindmeld

## Testing
- Unit suite: **701 tests** green
- Static export build green (rebased onto current `main`, incl. #154 a11y deps)
- No gameplay regressions across all 17 games

🤖 Generated with [Claude Code](https://claude.com/claude-code)