### PR TITLE
Fix Globetrotter panorama and board layout on phones

### DIFF
--- a/e2e/games/globetrotter.spec.ts
+++ b/e2e/games/globetrotter.spec.ts
@@ -212,6 +212,78 @@ const TINY_JPEG = Buffer.from(
   'base64'
 )
 
+type GlCounts = {
+  createProgram: number
+  deleteProgram: number
+  createTexture: number
+  deleteTexture: number
+  createBuffer: number
+  deleteBuffer: number
+}
+
+/**
+ * Count WebGL object churn, and optionally make the first few texture uploads
+ * fail the way a mobile driver does.
+ *
+ * The panorama viewer keeps one canvas — and therefore one context — for its
+ * whole life, rebuilding a program and a texture per round on top of it, so
+ * anything it allocates and never releases simply piles up on the GPU.
+ */
+async function instrumentWebGL(page: Page, failedUploads = 0): Promise<void> {
+  await page.addInitScript((failures: number) => {
+    const counts = {
+      createProgram: 0,
+      deleteProgram: 0,
+      createTexture: 0,
+      deleteTexture: 0,
+      createBuffer: 0,
+      deleteBuffer: 0,
+    }
+    const scope = window as unknown as {
+      __glCounts: typeof counts
+      __glContext?: WebGLRenderingContext
+    }
+    scope.__glCounts = counts
+
+    const original = HTMLCanvasElement.prototype.getContext
+    type Wrapped = WebGLRenderingContext & { __counted?: boolean }
+    HTMLCanvasElement.prototype.getContext = function (
+      this: HTMLCanvasElement,
+      ...args: unknown[]
+    ) {
+      const context = (original as (...a: unknown[]) => unknown).apply(this, args) as Wrapped | null
+      if (!context || !String(args[0]).includes('webgl') || context.__counted) return context
+      context.__counted = true
+      scope.__glContext = context
+
+      const spied = context as unknown as Record<string, (...a: unknown[]) => unknown>
+      for (const name of Object.keys(counts) as (keyof typeof counts)[]) {
+        const inner = spied[name].bind(context)
+        spied[name] = (...callArgs: unknown[]) => {
+          counts[name] += 1
+          return inner(...callArgs)
+        }
+      }
+
+      let remaining = failures
+      const upload = spied.texImage2D.bind(context)
+      spied.texImage2D = (...callArgs: unknown[]) => {
+        if (remaining > 0) {
+          remaining -= 1
+          // How Safari refuses an ImageBitmap its driver will not take.
+          throw new TypeError('simulated driver rejection')
+        }
+        return upload(...callArgs)
+      }
+      return context
+    } as typeof HTMLCanvasElement.prototype.getContext
+  }, failedUploads)
+}
+
+function readGlCounts(page: Page): Promise<GlCounts> {
+  return page.evaluate(() => (window as unknown as { __glCounts: GlCounts }).__glCounts)
+}
+
 test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
   /**
    * Commons double for the two-request pipeline: one `generator=categorymembers`
@@ -521,6 +593,76 @@ test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
     // A phone takes the small rendition, not the 1.2 MB one.
     expect(widths[0]).toBe(1920)
     await expect(page.getByTestId('globetrotter-pano-error')).toBeHidden()
+  })
+
+  test('hands back the GPU resources of the round it just left', async ({ page }) => {
+    await instrumentWebGL(page)
+    await mockCommons(page)
+
+    const solo = new GlobetrotterPage(page)
+    await solo.goto()
+    await solo.dismissPlayGate()
+    await solo.soloButton.click()
+    await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
+
+    await solo.placeAndLockGuess(0.4, 0.4)
+    await expect(solo.reveal).toBeVisible()
+    await solo.advanceRound()
+    await solo.expectStatus('Round 2 of 5')
+    await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
+
+    const counts = await readGlCounts(page)
+    // Two rounds, two builds — otherwise the assertions below prove nothing.
+    expect(counts.createProgram).toBeGreaterThan(1)
+    // Only the round on screen is allowed to still hold anything. Every
+    // earlier round's texture is several megabytes of video memory, and a
+    // phone answers that pressure by taking the context away entirely.
+    expect(counts.createProgram - counts.deleteProgram).toBeLessThanOrEqual(1)
+    expect(counts.createTexture - counts.deleteTexture).toBeLessThanOrEqual(1)
+    expect(counts.createBuffer - counts.deleteBuffer).toBeLessThanOrEqual(1)
+  })
+
+  test('rebuilds itself when the browser takes the WebGL context away', async ({ page }) => {
+    await instrumentWebGL(page)
+    await mockCommons(page)
+
+    const solo = new GlobetrotterPage(page)
+    await solo.goto()
+    await solo.dismissPlayGate()
+    await solo.soloButton.click()
+    await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
+    const before = (await readGlCounts(page)).createProgram
+
+    await page.evaluate(() => {
+      const context = (window as unknown as { __glContext: WebGLRenderingContext }).__glContext
+      const ext = context.getExtension('WEBGL_lose_context')!
+      ext.loseContext()
+      setTimeout(() => ext.restoreContext(), 50)
+    })
+
+    // The viewer comes back on its own — no Try again, no dead black box.
+    await expect
+      .poll(async () => (await readGlCounts(page)).createProgram, { timeout: 15000 })
+      .toBeGreaterThan(before)
+    await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
+    await expect(page.getByTestId('globetrotter-pano-error')).toBeHidden()
+  })
+
+  test('recovers when the driver refuses the first texture upload', async ({ page }) => {
+    // One rejection: enough to force the ladder's first rung, a 2D-canvas copy
+    // of the source, which is what gets a stubborn mobile driver to accept it.
+    await instrumentWebGL(page, 1)
+    await mockCommons(page)
+
+    const solo = new GlobetrotterPage(page)
+    await solo.goto()
+    await solo.dismissPlayGate()
+    await solo.soloButton.click()
+
+    await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
+    await expect(page.getByTestId('globetrotter-pano-error')).toBeHidden()
+    // The compass only renders once a texture is live on the context.
+    await expect(page.locator('.gt-compass')).toBeVisible()
   })
 
   test('names the reason a photosphere would not load', async ({ page }) => {

--- a/e2e/games/globetrotter.spec.ts
+++ b/e2e/games/globetrotter.spec.ts
@@ -252,7 +252,9 @@ test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
             title,
             imageinfo: [
               {
-                thumburl: `https://upload.wikimedia.org/mock-${index}.jpg`,
+                // Shaped like a real Commons rendition: the client rewrites the
+                // `NNNpx-` segment to pick a size its screen can use.
+                thumburl: `https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Mock_pano_${index}.jpg/3840px-Mock_pano_${index}.jpg`,
                 extmetadata: {
                   Artist: { value: 'Mock Mapper' },
                   LicenseShortName: { value: 'CC BY-SA 4.0' },
@@ -480,6 +482,66 @@ test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
 
     await solo.placeAndLockGuess(0.5, 0.5)
     await expect(solo.reveal).toBeVisible()
+  })
+
+  test('only ever asks Wikimedia for a rendition it will serve', async ({ page }) => {
+    // upload.wikimedia.org rejects any width off its standard ladder with a
+    // 400 ("Use thumbnail sizes listed on https://w.wiki/GHai"), so a phone
+    // asking for a convenient 2048px gets nothing at all.
+    const STANDARD = [20, 40, 60, 120, 250, 330, 500, 960, 1280, 1920, 3840]
+    const widths: number[] = []
+    await mockCommons(page)
+    // Registered after mockCommons so it wins over its blanket image route.
+    await page.route('https://upload.wikimedia.org/**', (route) => {
+      const width = Number(
+        route
+          .request()
+          .url()
+          .match(/\/(\d+)px-/)?.[1]
+      )
+      if (Number.isFinite(width)) widths.push(width)
+      return route.fulfill({
+        status: STANDARD.includes(width) ? 200 : 400,
+        headers: { 'access-control-allow-origin': '*' },
+        contentType: 'image/jpeg',
+        body: TINY_JPEG,
+      })
+    })
+    await page.setViewportSize({ width: 390, height: 664 })
+
+    const solo = new GlobetrotterPage(page)
+    await solo.goto()
+    await solo.dismissPlayGate()
+    await solo.soloButton.click()
+    await expect(solo.pano).toBeVisible()
+    await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
+
+    expect(widths.length).toBeGreaterThan(0)
+    expect(widths.filter((width) => !STANDARD.includes(width))).toEqual([])
+    // A phone takes the small rendition, not the 1.2 MB one.
+    expect(widths[0]).toBe(1920)
+    await expect(page.getByTestId('globetrotter-pano-error')).toBeHidden()
+  })
+
+  test('names the reason a photosphere would not load', async ({ page }) => {
+    await mockCommons(page)
+    await page.route('https://upload.wikimedia.org/**', (route) =>
+      route.fulfill({
+        status: 400,
+        headers: { 'access-control-allow-origin': '*' },
+        contentType: 'text/html',
+        body: 'Use thumbnail sizes listed on https://w.wiki/GHai',
+      })
+    )
+
+    const solo = new GlobetrotterPage(page)
+    await solo.goto()
+    await solo.dismissPlayGate()
+    await solo.soloButton.click()
+
+    // An opaque "would not load" sends players to Try again forever; the
+    // status code says whether it is the archive, the network or the device.
+    await expect(page.getByTestId('globetrotter-pano-error-hint')).toContainText('400')
   })
 })
 

--- a/e2e/games/globetrotter.spec.ts
+++ b/e2e/games/globetrotter.spec.ts
@@ -328,6 +328,88 @@ test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
     await expect(solo.soloButton).toBeVisible()
   })
 
+  test.describe('touch map navigation', () => {
+    test.use({ viewport: { width: 390, height: 664 }, hasTouch: true })
+
+    test('pinches to zoom, drags to pan, and only taps drop a pin', async ({ page }) => {
+      await mockCommons(page)
+
+      const solo = new GlobetrotterPage(page)
+      await solo.goto()
+      await solo.dismissPlayGate()
+      await solo.soloButton.click()
+      await expect(solo.pano).toBeVisible()
+      await solo.expandMap()
+      // The dock animates open; gestures need the settled element box.
+      await expect(solo.lockGuessButton).toBeDisabled()
+      await page.waitForTimeout(600)
+
+      const cdp = await page.context().newCDPSession(page)
+      const dispatch = (
+        type: 'touchStart' | 'touchMove' | 'touchEnd',
+        points: [number, number][]
+      ) =>
+        cdp.send('Input.dispatchTouchEvent', {
+          type,
+          touchPoints: points.map(([x, y], index) => ({ x, y, id: index + 1 })),
+        })
+
+      const box = (await solo.map.boundingBox())!
+      const cx = Math.round(box.x + box.width / 2)
+      const cy = Math.round(box.y + box.height / 2)
+      const viewWidth = async () => Number((await solo.map.getAttribute('viewBox'))!.split(' ')[2])
+      const viewX = async () => Number((await solo.map.getAttribute('viewBox'))!.split(' ')[0])
+      const pins = () => page.locator('.gt-map-pin').count()
+
+      // Spread two fingers: the map zooms in and drops nothing.
+      const worldWidth = await viewWidth()
+      await dispatch('touchStart', [
+        [cx - 30, cy],
+        [cx + 30, cy],
+      ])
+      for (let step = 1; step <= 8; step++) {
+        const spread = 30 + step * 15
+        await dispatch('touchMove', [
+          [cx - spread, cy],
+          [cx + spread, cy],
+        ])
+      }
+      await dispatch('touchEnd', [])
+      expect(await viewWidth()).toBeLessThan(worldWidth / 2)
+      expect(await pins()).toBe(0)
+
+      // One finger drags the map rather than dropping a pin.
+      const beforePan = await viewX()
+      await dispatch('touchStart', [[cx, cy]])
+      for (let step = 1; step <= 6; step++) await dispatch('touchMove', [[cx - step * 12, cy]])
+      await dispatch('touchEnd', [])
+      expect(await viewX()).toBeGreaterThan(beforePan)
+      expect(await pins()).toBe(0)
+
+      // Closing the fingers zooms back out.
+      const zoomedWidth = await viewWidth()
+      await dispatch('touchStart', [
+        [cx - 120, cy],
+        [cx + 120, cy],
+      ])
+      for (let step = 1; step <= 8; step++) {
+        const spread = 120 - step * 12
+        await dispatch('touchMove', [
+          [cx - spread, cy],
+          [cx + spread, cy],
+        ])
+      }
+      await dispatch('touchEnd', [])
+      expect(await viewWidth()).toBeGreaterThan(zoomedWidth)
+
+      // A plain tap is still how a pin gets placed.
+      await dispatch('touchStart', [[cx, cy]])
+      await dispatch('touchEnd', [])
+      await expect(solo.lockGuessButton).toBeEnabled()
+      expect(await pins()).toBe(1)
+    })
+  })
+
   test('fits the whole board on a phone screen', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 664 })
     await mockCommons(page)

--- a/e2e/games/globetrotter.spec.ts
+++ b/e2e/games/globetrotter.spec.ts
@@ -328,6 +328,36 @@ test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
     await expect(solo.soloButton).toBeVisible()
   })
 
+  test('fits the whole board on a phone screen', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 664 })
+    await mockCommons(page)
+
+    const solo = new GlobetrotterPage(page)
+    await solo.goto()
+    await solo.dismissPlayGate()
+    await solo.soloButton.click()
+    await expect(solo.pano).toBeVisible()
+
+    const layout = await page.evaluate(() => {
+      const rect = (selector: string) => document.querySelector(selector)!.getBoundingClientRect()
+      return {
+        innerHeight: window.innerHeight,
+        scrollHeight: document.documentElement.scrollHeight,
+        viewportHeight: rect('.gt-viewport').height,
+        panoHeight: rect('.gt-pano').height,
+        mapDockBottom: rect('.gt-mapdock').bottom,
+      }
+    })
+
+    // The photo fills the slot reserved for it. It used to collapse to the
+    // canvas' intrinsic size, leaving a band of dead space underneath.
+    expect(layout.panoHeight).toBeCloseTo(layout.viewportHeight, 0)
+    expect(layout.panoHeight).toBeGreaterThan(200)
+    // Everything — photo, minimap, field notes — sits inside one screenful.
+    expect(layout.scrollHeight).toBeLessThanOrEqual(layout.innerHeight + 1)
+    expect(layout.mapDockBottom).toBeLessThanOrEqual(layout.innerHeight)
+  })
+
   test('shows scouting progress while the deck is assembled', async ({ page }) => {
     await mockCommons(page)
     let release: () => void = () => {}

--- a/src/app/games/globetrotter/globetrotter-design.css
+++ b/src/app/games/globetrotter/globetrotter-design.css
@@ -1066,6 +1066,15 @@ a.gt-pano-watermark:hover {
     transform: rotate(360deg);
   }
 }
+.gt-scope .gt-pano-error-hint {
+  max-width: 34ch;
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.06em;
+  text-align: center;
+  text-transform: none;
+  color: rgba(255, 255, 255, 0.55);
+}
 .gt-scope .gt-pano-bar {
   position: relative;
   display: block;

--- a/src/app/games/globetrotter/globetrotter-design.css
+++ b/src/app/games/globetrotter/globetrotter-design.css
@@ -1817,6 +1817,19 @@ a.gt-pano-watermark:hover {
     width: 34px;
     height: 34px;
   }
+  /* Fingertip-sized zoom controls — 26px is a mouse target, not a thumb one. */
+  .gt-scope .gt-zoom {
+    gap: 6px;
+  }
+  .gt-scope .gt-zoom button {
+    width: 38px;
+    height: 38px;
+    font-size: 17px;
+  }
+  /* The minimap is too small to host controls; it opens on tap instead. */
+  .gt-scope .gt-mapdock.is-collapsed .gt-zoom {
+    display: none;
+  }
   .gt-scope .gt-locked-badge {
     bottom: calc(min(120px, 28vw) + 16px);
     right: 8px;

--- a/src/app/games/globetrotter/globetrotter-design.css
+++ b/src/app/games/globetrotter/globetrotter-design.css
@@ -58,6 +58,10 @@
 .gt-scope.sk-shell,
 .gt-scope .sk-shell {
   min-height: 100vh;
+  /* dvh tracks the space mobile browsers actually leave between their address
+     bar and toolbar; vh does not, which is why the board used to run off the
+     bottom of a phone screen. */
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   background: var(--bg);
@@ -903,10 +907,13 @@
   flex: 1;
   min-height: 340px;
 }
+/* The pano fills the viewport by inset rather than `height: 100%`: the
+   viewport's height comes from flexing, which browsers do not treat as a
+   definite height, so a percentage would collapse the photo to the canvas'
+   intrinsic size (that is the mobile "tiny photo, dead space below" bug). */
 .gt-scope .gt-pano {
-  position: relative;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  inset: 0;
   overflow: hidden;
   background: #111;
   border: 1px solid var(--ink);
@@ -927,6 +934,8 @@
   cursor: default;
 }
 .gt-scope .gt-pano canvas {
+  position: absolute;
+  inset: 0;
   display: block;
   width: 100%;
   height: 100%;
@@ -968,6 +977,18 @@
 @keyframes gt-hint-pulse {
   50% {
     opacity: 0.5;
+  }
+}
+/* Same hint, phrased for whichever input the device actually has. */
+.gt-scope .gt-pano-hint-touch {
+  display: none;
+}
+@media (hover: none) and (pointer: coarse) {
+  .gt-scope .gt-pano-hint-desktop {
+    display: none;
+  }
+  .gt-scope .gt-pano-hint-touch {
+    display: inline;
   }
 }
 .gt-scope .gt-pano-watermark {
@@ -1652,18 +1673,24 @@ a.gt-pano-watermark:hover {
   .gt-scope .sk-lobby {
     grid-template-columns: 1fr;
   }
+  /* Round + score stay on one line and the flavour/status text drops to a
+     slim second row. Stacking all three cells burned ~180px of a phone
+     screen before the photo even started. */
   .gt-scope .sk-hud {
-    grid-template-columns: 1fr;
-    gap: 8px;
+    grid-template-columns: 1fr auto;
     min-height: 0;
   }
   .gt-scope .sk-hud-left,
-  .gt-scope .sk-hud-center,
   .gt-scope .sk-hud-right {
-    justify-content: center;
+    padding: 10px 14px;
   }
   .gt-scope .sk-hud-center {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-content: center;
+    padding: 6px 14px;
     border: 0;
+    border-top: 1px solid var(--line);
   }
   .gt-scope .gt-board-main {
     gap: 14px;
@@ -1683,20 +1710,94 @@ a.gt-pano-watermark:hover {
   }
 }
 @media (max-width: 680px) {
+  /* The board is a single screenful: photo, map and status all have to be
+     reachable without scrolling, so pin the shell to the visible viewport and
+     let the photo absorb whatever height is left over. */
+  .gt-scope.sk-shell:has(.gt-board) {
+    height: 100dvh;
+    overflow: hidden;
+  }
+  .gt-scope .sk-topbar {
+    padding: 10px 12px;
+    gap: 10px;
+  }
+  .gt-scope .sk-logo {
+    font-size: 15px;
+    gap: 8px;
+  }
+  .gt-scope .sk-logo-mark {
+    width: 24px;
+    height: 24px;
+    font-size: 12px;
+  }
+  .gt-scope .sk-crumb {
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    text-align: right;
+  }
+  .gt-scope .sk-stage {
+    padding: 24px 14px;
+  }
+  .gt-scope .sk-hud-left,
+  .gt-scope .sk-hud-right {
+    padding: 8px 12px;
+    gap: 10px;
+  }
+  .gt-scope .sk-round-val {
+    font-size: 16px;
+  }
+  .gt-scope .sk-hud-right .sk-round-val {
+    font-size: 14px;
+  }
+  .gt-scope .sk-hud-center {
+    padding: 5px 12px;
+  }
+  .gt-scope .gt-hud-mode {
+    font-size: 9px;
+  }
   .gt-scope .gt-board-main {
     padding: 10px;
-    gap: 12px;
+    gap: 10px;
+    /* Everything is meant to fit, but a long clue or a wrapped deck note must
+       stay reachable rather than get clipped by the shell above. */
+    overflow-y: auto;
   }
   .gt-scope .gt-pano {
     box-shadow: 4px 4px 0 var(--ink);
   }
   .gt-scope .gt-viewport {
-    min-height: 260px;
+    /* A floor in viewport units, not pixels: the photo keeps a usable share of
+       whatever the phone actually gives us instead of forcing the field notes
+       off the bottom of a short screen. */
+    min-height: 32dvh;
+  }
+  /* Field notes get a compact, self-scrolling block so three long clues can
+     never crowd the photo out of the layout. */
+  .gt-scope .gt-briefing {
+    padding: 12px 14px;
+    gap: 8px;
+    box-shadow: 3px 3px 0 var(--ink);
+  }
+  .gt-scope .gt-briefing ol {
+    gap: 6px 14px;
+    max-height: 22dvh;
+    overflow-y: auto;
+  }
+  .gt-scope .gt-briefing li {
+    flex: 1 1 100%;
+    gap: 8px;
+  }
+  .gt-scope .gt-briefing.aside li {
+    font-size: 12px;
+  }
+  .gt-scope .gt-deck-note {
+    font-size: 9px;
   }
   /* Phones get the map full-bleed when open — a corner panel is unusable. */
   .gt-scope .gt-mapdock {
     right: 8px;
     bottom: 8px;
+    box-shadow: 4px 4px 0 var(--ink);
   }
   .gt-scope .gt-mapdock.is-expanded {
     width: calc(100% - 16px);
@@ -1704,17 +1805,26 @@ a.gt-pano-watermark:hover {
   }
   .gt-scope .gt-mapdock.is-collapsed,
   .gt-scope .gt-mapdock.is-collapsed:hover {
-    width: 42vw;
-    height: 26vw;
+    width: min(200px, 46vw);
+    height: min(120px, 28vw);
+  }
+  .gt-scope .gt-map-open {
+    padding-bottom: 8px;
+    font-size: 9px;
+    letter-spacing: 0.1em;
+  }
+  .gt-scope .gt-map-close {
+    width: 34px;
+    height: 34px;
   }
   .gt-scope .gt-locked-badge {
-    bottom: calc(26vw + 16px);
+    bottom: calc(min(120px, 28vw) + 16px);
     right: 8px;
   }
   .gt-scope .gt-players-float {
     top: 8px;
     right: 8px;
-    width: 150px;
+    width: 144px;
     font-size: 11px;
   }
   .gt-scope .gt-compass {
@@ -1722,8 +1832,15 @@ a.gt-pano-watermark:hover {
   }
   .gt-scope .gt-pano-hint {
     font-size: 9px;
-    padding: 7px 12px;
+    padding: 7px 10px;
     left: 10px;
+    bottom: 10px;
+    /* Keep clear of the minimap, which owns the bottom-right corner. */
+    right: calc(min(200px, 46vw) + 18px);
+    white-space: normal;
+  }
+  .gt-scope .gt-pano-watermark {
+    max-width: 60%;
   }
   .gt-scope .gt-guess-actions {
     flex-direction: column;
@@ -1743,6 +1860,12 @@ a.gt-pano-watermark:hover {
   .gt-scope .gt-reveal-head h2 {
     font-size: 30px;
   }
+  .gt-scope .gt-reveal-map .gt-mapwrap {
+    min-height: 240px;
+  }
+  .gt-scope .gt-reveal-verdict strong {
+    font-size: 26px;
+  }
   .gt-scope .gt-reveal-row {
     grid-template-columns: 18px 24px 1fr auto;
     gap: 6px;
@@ -1752,6 +1875,9 @@ a.gt-pano-watermark:hover {
   .gt-scope .gt-reveal-dist {
     display: none;
   }
+  .gt-scope .sk-end h2 {
+    font-size: 36px;
+  }
   .gt-scope .sk-end-cta {
     flex-direction: column;
     align-items: stretch;
@@ -1760,6 +1886,9 @@ a.gt-pano-watermark:hover {
     width: 100%;
   }
   .gt-scope .sk-entry-choose {
+    grid-template-columns: 1fr;
+  }
+  .gt-scope .sk-steps {
     grid-template-columns: 1fr;
   }
   .gt-scope .sk-room-code {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Space_Grotesk, JetBrains_Mono, Geist } from 'next/font/google'
+import { contentSecurityPolicy } from '@/lib/csp'
 import './globals.css'
 
 const spaceGrotesk = Space_Grotesk({
@@ -32,47 +33,12 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://kkulykk.github.io/library-games'),
 }
 
-// P2-6: a defense-in-depth Content-Security-Policy. GitHub Pages cannot set
-// response headers, so this ships as a <meta> tag baked into the static export.
-// It is deliberately only emitted in production builds — `next dev` relies on
-// eval + a localhost websocket for HMR that a strict policy would break. Static
-// export cannot mint per-request nonces, so script/style fall back to
-// 'unsafe-inline' (Next hydration + Tailwind); the meaningful win is locking
-// connect-src down to self + the Supabase origin so the localStorage-held room
-// tokens can only be sent back to Supabase.
-function contentSecurityPolicy(): string | null {
-  if (process.env.NODE_ENV !== 'production') return null
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  let supabaseHttp = ''
-  let supabaseWs = ''
-  if (supabaseUrl) {
-    try {
-      const origin = new URL(supabaseUrl).origin
-      supabaseHttp = origin
-      supabaseWs = origin.replace(/^http/, 'ws')
-    } catch {
-      // ignore a malformed URL — connect-src just stays 'self'
-    }
-  }
-  const connectSrc = ["'self'", supabaseHttp, supabaseWs].filter(Boolean).join(' ')
-
-  return [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data: blob:",
-    "font-src 'self'",
-    "worker-src 'self' blob:",
-    `connect-src ${connectSrc}`,
-    "base-uri 'self'",
-    "form-action 'self'",
-    'upgrade-insecure-requests',
-  ].join('; ')
-}
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const csp = contentSecurityPolicy()
+  // Referenced literally so Next inlines them into the static export.
+  const csp = contentSecurityPolicy({
+    nodeEnv: process.env.NODE_ENV,
+    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  })
   return (
     <html
       lang="en"

--- a/src/games/globetrotter/PanoViewer.tsx
+++ b/src/games/globetrotter/PanoViewer.tsx
@@ -288,6 +288,9 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     const vertex = compile(gl.VERTEX_SHADER, VERTEX_SHADER)
     const fragment = compile(gl.FRAGMENT_SHADER, FRAGMENT_SHADER)
     if (!program || !vertex || !fragment) {
+      if (program) gl.deleteProgram(program)
+      if (vertex) gl.deleteShader(vertex)
+      if (fragment) gl.deleteShader(fragment)
       setHint('WebGL would not compile the panorama shader.')
       setStatus('error')
       return
@@ -295,7 +298,11 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     gl.attachShader(program, vertex)
     gl.attachShader(program, fragment)
     gl.linkProgram(program)
+    // A linked program owns its shaders; these handles are ours to drop.
+    gl.deleteShader(vertex)
+    gl.deleteShader(fragment)
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      gl.deleteProgram(program)
       setHint('WebGL would not link the panorama shader.')
       setStatus('error')
       return
@@ -318,6 +325,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
 
     let disposed = false
     let textured = false
+    let texture: WebGLTexture | null = null
     const controller = new AbortController()
 
     function render() {
@@ -350,7 +358,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     )
       .then((source) => {
         if (disposed || gl.isContextLost()) return
-        const texture = gl.createTexture()
+        texture = gl.createTexture()
         gl.bindTexture(gl.TEXTURE_2D, texture)
         // Non-power-of-two source: clamp + linear, wrap handled by fract() in
         // the shader.
@@ -359,6 +367,10 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
         if (!uploadTexture(gl, source)) {
+          // Whatever partial allocation the failed upload left behind goes
+          // back now, rather than sitting on a GPU that just said it was full.
+          if (texture) gl.deleteTexture(texture)
+          texture = null
           setHint('This device could not fit the photosphere in video memory.')
           setStatus('error')
           return
@@ -393,6 +405,16 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
       document.removeEventListener('visibilitychange', repaint)
       window.removeEventListener('pageshow', repaint)
       window.removeEventListener('orientationchange', repaint)
+      // One canvas keeps one context for the component's whole life, and each
+      // round builds a fresh program and texture on it. Without this a
+      // five-round trip strands five panorama textures on the GPU — exactly
+      // the memory pressure that makes a phone take the context away.
+      if (!gl.isContextLost()) {
+        if (texture) gl.deleteTexture(texture)
+        if (quad) gl.deleteBuffer(quad)
+        gl.deleteProgram(program)
+      }
+      texture = null
       renderRef.current = null
     }
   }, [pano.url, attempt])

--- a/src/games/globetrotter/PanoViewer.tsx
+++ b/src/games/globetrotter/PanoViewer.tsx
@@ -79,9 +79,13 @@ async function loadPanoramaFrom(
   onProgress: (ratio: number | null) => void,
   signal: AbortSignal
 ): Promise<TexImageSource> {
+  let status: number | null = null
   try {
     const response = await fetch(url, { mode: 'cors', signal })
-    if (!response.ok) throw new Error(`Panorama ${response.status}`)
+    if (!response.ok) {
+      status = response.status
+      throw new Error(`HTTP ${response.status}`)
+    }
     const total = Number(response.headers.get('content-length') ?? 0)
     const reader = response.body?.getReader()
     let blob: Blob
@@ -114,7 +118,12 @@ async function loadPanoramaFrom(
     // Streaming can fail where a plain image load still succeeds (proxies,
     // odd CORS setups) — try the simple path before giving up.
     onProgress(null)
-    return decodeViaImage(url, false)
+    try {
+      return await decodeViaImage(url, false)
+    } catch {
+      // Report what the server said, not the <img> tag's contentless failure.
+      throw status === null ? error : new Error(`HTTP ${status}`)
+    }
   }
 }
 
@@ -135,6 +144,17 @@ async function loadPanorama(
     }
   }
   throw last instanceof Error ? last : new Error('Panorama failed to load')
+}
+
+/**
+ * Turn a failure into something a player can act on. "It broke" sends people
+ * to the Try again button forever; naming the cause tells them whether it is
+ * their network, their browser or the archive.
+ */
+function failureHint(error: unknown): string {
+  const status = error instanceof Error ? error.message.match(/^HTTP (\d+)$/)?.[1] : undefined
+  if (status) return `Wikimedia answered ${status} for this image.`
+  return 'Could not reach upload.wikimedia.org — a content blocker, VPN or restricted network does this.'
 }
 
 function decodeViaImage(src: string, revoke: boolean): Promise<HTMLImageElement> {
@@ -223,6 +243,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
   const renderRef = useRef<(() => void) | null>(null)
   const [status, setStatus] = useState<Status>('loading')
   const [progress, setProgress] = useState<number | null>(null)
+  const [hint, setHint] = useState<string | null>(null)
   const [dragged, setDragged] = useState(false)
   const [compassDeg, setCompassDeg] = useState(0)
   const [attempt, setAttempt] = useState(0)
@@ -234,6 +255,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     if (!canvas) return
     setStatus('loading')
     setProgress(null)
+    setHint(null)
     setDragged(false)
     cameraRef.current = { yaw: 0, pitch: 0, fov: 75 }
     pointersRef.current.clear()
@@ -249,6 +271,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     const gl = (canvas.getContext('webgl', options) ??
       canvas.getContext('experimental-webgl', options)) as WebGLRenderingContext | null
     if (!gl) {
+      setHint('This browser will not give the page a WebGL canvas.')
       setStatus('error')
       return
     }
@@ -265,6 +288,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     const vertex = compile(gl.VERTEX_SHADER, VERTEX_SHADER)
     const fragment = compile(gl.FRAGMENT_SHADER, FRAGMENT_SHADER)
     if (!program || !vertex || !fragment) {
+      setHint('WebGL would not compile the panorama shader.')
       setStatus('error')
       return
     }
@@ -272,6 +296,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     gl.attachShader(program, fragment)
     gl.linkProgram(program)
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      setHint('WebGL would not link the panorama shader.')
       setStatus('error')
       return
     }
@@ -334,6 +359,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
         if (!uploadTexture(gl, source)) {
+          setHint('This device could not fit the photosphere in video memory.')
           setStatus('error')
           return
         }
@@ -345,8 +371,10 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
         // stretched first paint.
         requestAnimationFrame(render)
       })
-      .catch(() => {
-        if (!disposed) setStatus('error')
+      .catch((error: unknown) => {
+        if (disposed) return
+        setHint(failureHint(error))
+        setStatus('error')
       })
 
     renderRef.current = render
@@ -501,6 +529,11 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
         <div className="gt-pano-loading" data-testid="globetrotter-pano-error">
           <div className="gt-pano-loading-inner">
             <span className="mono gt-pano-loading-text">This photosphere would not load.</span>
+            {hint && (
+              <span className="mono gt-pano-error-hint" data-testid="globetrotter-pano-error-hint">
+                {hint}
+              </span>
+            )}
             <button className="sk-btn sk-btn-sm" type="button" onClick={retry}>
               Try again
             </button>

--- a/src/games/globetrotter/PanoViewer.tsx
+++ b/src/games/globetrotter/PanoViewer.tsx
@@ -154,7 +154,10 @@ async function loadPanorama(
 function failureHint(error: unknown): string {
   const status = error instanceof Error ? error.message.match(/^HTTP (\d+)$/)?.[1] : undefined
   if (status) return `Wikimedia answered ${status} for this image.`
-  return 'Could not reach upload.wikimedia.org — a content blocker, VPN or restricted network does this.'
+  // No status at all means the request never got a reply: this site's own
+  // content-security-policy refusing the origin looks identical to a content
+  // blocker or a network that cannot route there.
+  return 'upload.wikimedia.org could not be reached — a blocked origin, content blocker or offline network.'
 }
 
 function decodeViaImage(src: string, revoke: boolean): Promise<HTMLImageElement> {

--- a/src/games/globetrotter/PanoViewer.tsx
+++ b/src/games/globetrotter/PanoViewer.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
 import { cn } from '@/lib/utils'
 import type { GeoPano } from './locations'
+import { panoCandidates } from './panoTexture'
 
 const COMPASS_DIRS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
 
@@ -14,8 +15,8 @@ function yawToDegrees(yaw: number): number {
 // Minimal WebGL equirectangular panorama viewer (no dependencies): a
 // fullscreen quad whose fragment shader casts a ray per pixel through a
 // yaw/pitch/fov camera and samples the 360° image. Drag to look around,
-// scroll to zoom. Wikimedia Commons serves images with CORS headers, so the
-// texture upload works cross-origin.
+// scroll or pinch to zoom. Wikimedia Commons serves images with CORS headers,
+// so the texture upload works cross-origin.
 //
 // Panoramas are multi-megabyte files, so the download is streamed and its
 // progress surfaced — a silent black rectangle reads as a frozen app.
@@ -53,6 +54,8 @@ void main() {
 
 const MIN_FOV = 30
 const MAX_FOV = 100
+/** Below this the shrink-and-retry ladder gives up — a 512px sphere is unusable anyway. */
+const MIN_TEXTURE_WIDTH = 512
 
 interface Camera {
   yaw: number
@@ -71,7 +74,7 @@ type Status = 'loading' | 'ready' | 'error'
  * Stream the panorama so the download can report progress, falling back to a
  * plain <img> load when streaming is unavailable (then progress is unknown).
  */
-async function loadPanorama(
+async function loadPanoramaFrom(
   url: string,
   onProgress: (ratio: number | null) => void,
   signal: AbortSignal
@@ -97,7 +100,14 @@ async function loadPanorama(
       blob = await response.blob()
     }
     onProgress(1)
-    if (typeof createImageBitmap === 'function') return await createImageBitmap(blob)
+    if (typeof createImageBitmap === 'function') {
+      try {
+        return await createImageBitmap(blob)
+      } catch {
+        // Safari's ImageBitmap decoder gives up on some large JPEGs; the
+        // <img> decoder handles them, and is a valid texture source too.
+      }
+    }
     return await decodeViaImage(URL.createObjectURL(blob), true)
   } catch (error) {
     if (signal.aborted) throw error
@@ -106,6 +116,25 @@ async function loadPanorama(
     onProgress(null)
     return decodeViaImage(url, false)
   }
+}
+
+/** Walk the renditions cheapest-first; only a fully exhausted list is an error. */
+async function loadPanorama(
+  urls: string[],
+  onProgress: (ratio: number | null) => void,
+  signal: AbortSignal
+): Promise<TexImageSource> {
+  let last: unknown
+  for (const url of urls) {
+    try {
+      return await loadPanoramaFrom(url, onProgress, signal)
+    } catch (error) {
+      if (signal.aborted) throw error
+      last = error
+      onProgress(null)
+    }
+  }
+  throw last instanceof Error ? last : new Error('Panorama failed to load')
 }
 
 function decodeViaImage(src: string, revoke: boolean): Promise<HTMLImageElement> {
@@ -124,11 +153,73 @@ function decodeViaImage(src: string, revoke: boolean): Promise<HTMLImageElement>
   })
 }
 
+function sourceSize(source: TexImageSource): { width: number; height: number } {
+  const width = 'width' in source ? Number(source.width) : 0
+  const height = 'height' in source ? Number(source.height) : 0
+  return { width, height }
+}
+
+/** Redraw a decoded panorama at a smaller size — also normalises the source type. */
+function rescale(source: TexImageSource, width: number, height: number): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.width = Math.max(1, Math.floor(width))
+  canvas.height = Math.max(1, Math.floor(height))
+  canvas.getContext('2d')?.drawImage(source as CanvasImageSource, 0, 0, canvas.width, canvas.height)
+  return canvas
+}
+
+/**
+ * Upload the panorama, shrinking on failure until it fits.
+ *
+ * Mobile GPUs reject textures a desktop swallows whole — sometimes by throwing
+ * (an `ImageBitmap` the driver will not take), sometimes by quietly raising
+ * `OUT_OF_MEMORY`. Both are recoverable at half the size, so try the ladder
+ * before calling the round a loss.
+ */
+function uploadTexture(gl: WebGLRenderingContext, source: TexImageSource): boolean {
+  const maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE) as number
+  const { width, height } = sourceSize(source)
+  let upload: TexImageSource = source
+  let currentWidth = width
+  let currentHeight = height
+  if (width > maxSize && width > 0) {
+    currentWidth = maxSize
+    currentHeight = Math.max(1, Math.round((height * maxSize) / width))
+    upload = rescale(source, currentWidth, currentHeight)
+  }
+
+  for (;;) {
+    // Drain stale errors so the check below is about this upload alone.
+    let pending = gl.getError()
+    while (pending !== gl.NO_ERROR) pending = gl.getError()
+    let threw = false
+    try {
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, upload)
+    } catch {
+      threw = true
+    }
+    if (!threw && gl.getError() === gl.NO_ERROR) return true
+    if (gl.isContextLost()) return false
+
+    // A raw ImageBitmap the driver refuses may still upload once it has been
+    // through a 2D canvas, so re-wrap at full size before giving up any pixels.
+    if (upload === source && currentWidth > 0) {
+      upload = rescale(source, currentWidth, currentHeight)
+      continue
+    }
+    if (currentWidth <= MIN_TEXTURE_WIDTH || currentWidth === 0) return false
+    currentWidth = Math.floor(currentWidth / 2)
+    currentHeight = Math.max(1, Math.floor(currentHeight / 2))
+    upload = rescale(source, currentWidth, currentHeight)
+  }
+}
+
 export function PanoViewer({ pano, className }: PanoViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const uniformsRef = useRef<Record<string, WebGLUniformLocation | null>>({})
   const cameraRef = useRef<Camera>({ yaw: 0, pitch: 0, fov: 75 })
-  const dragRef = useRef<{ pointerId: number; x: number; y: number } | null>(null)
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>())
+  const pinchRef = useRef<{ distance: number; fov: number } | null>(null)
   const renderRef = useRef<(() => void) | null>(null)
   const [status, setStatus] = useState<Status>('loading')
   const [progress, setProgress] = useState<number | null>(null)
@@ -145,8 +236,18 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     setProgress(null)
     setDragged(false)
     cameraRef.current = { yaw: 0, pitch: 0, fov: 75 }
+    pointersRef.current.clear()
+    pinchRef.current = null
 
-    const gl = canvas.getContext('webgl', { antialias: false, preserveDrawingBuffer: false })
+    // preserveDrawingBuffer keeps the last frame alive across compositing.
+    // Without it iOS Safari clears the buffer after each composite and the
+    // panorama goes black between drags, since this viewer renders on demand.
+    const options: WebGLContextAttributes = {
+      antialias: false,
+      preserveDrawingBuffer: true,
+    }
+    const gl = (canvas.getContext('webgl', options) ??
+      canvas.getContext('experimental-webgl', options)) as WebGLRenderingContext | null
     if (!gl) {
       setStatus('error')
       return
@@ -191,11 +292,14 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     }
 
     let disposed = false
+    let textured = false
     const controller = new AbortController()
 
     function render() {
       const c = canvasRef.current
-      if (!c || disposed) return
+      if (!c || disposed || !textured || gl!.isContextLost()) return
+      // Cap the backing store: a 3× phone would otherwise allocate a buffer
+      // several times larger than the panorama can fill.
       const dpr = Math.min(2, window.devicePixelRatio || 1)
       const width = Math.max(1, Math.floor(c.clientWidth * dpr))
       const height = Math.max(1, Math.floor(c.clientHeight * dpr))
@@ -213,34 +317,33 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
       gl!.drawArrays(gl!.TRIANGLES, 0, 3)
     }
 
-    loadPanorama(pano.url, (ratio) => !disposed && setProgress(ratio), controller.signal)
+    const viewportWidth = typeof window === 'undefined' ? 1200 : window.innerWidth
+    loadPanorama(
+      panoCandidates(pano.url, viewportWidth),
+      (ratio) => !disposed && setProgress(ratio),
+      controller.signal
+    )
       .then((source) => {
-        if (disposed) return
+        if (disposed || gl.isContextLost()) return
         const texture = gl.createTexture()
         gl.bindTexture(gl.TEXTURE_2D, texture)
         // Non-power-of-two source: clamp + linear, wrap handled by fract() in
-        // the shader. Downscale first if the GPU cannot take the full image.
-        const maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE) as number
-        let upload: TexImageSource = source
-        const sourceWidth = 'width' in source ? source.width : 0
-        if (sourceWidth > maxSize) {
-          const scale = maxSize / sourceWidth
-          const sourceHeight = 'height' in source ? source.height : 0
-          const offscreen = document.createElement('canvas')
-          offscreen.width = Math.floor(sourceWidth * scale)
-          offscreen.height = Math.floor(sourceHeight * scale)
-          offscreen
-            .getContext('2d')
-            ?.drawImage(source as CanvasImageSource, 0, 0, offscreen.width, offscreen.height)
-          upload = offscreen
-        }
+        // the shader.
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, upload)
+        if (!uploadTexture(gl, source)) {
+          setStatus('error')
+          return
+        }
+        textured = true
         setStatus('ready')
         render()
+        // Some mobile browsers only size the canvas correctly on the frame
+        // after layout settles; a second pass costs nothing and avoids a
+        // stretched first paint.
+        requestAnimationFrame(render)
       })
       .catch(() => {
         if (!disposed) setStatus('error')
@@ -249,39 +352,93 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
     renderRef.current = render
     const observer = new ResizeObserver(() => render())
     observer.observe(canvas)
+    // Returning to a backgrounded tab discards the drawing buffer on iOS.
+    const repaint = () => render()
+    document.addEventListener('visibilitychange', repaint)
+    window.addEventListener('pageshow', repaint)
+    window.addEventListener('orientationchange', repaint)
 
     return () => {
       disposed = true
       controller.abort()
       observer.disconnect()
+      document.removeEventListener('visibilitychange', repaint)
+      window.removeEventListener('pageshow', repaint)
+      window.removeEventListener('orientationchange', repaint)
       renderRef.current = null
     }
   }, [pano.url, attempt])
 
+  // A phone under memory pressure has its WebGL context taken away; without
+  // preventDefault the browser will never offer it back.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const onLost = (event: Event) => {
+      event.preventDefault()
+      setStatus('loading')
+      setProgress(null)
+    }
+    const onRestored = () => setAttempt((n) => n + 1)
+    canvas.addEventListener('webglcontextlost', onLost)
+    canvas.addEventListener('webglcontextrestored', onRestored)
+    return () => {
+      canvas.removeEventListener('webglcontextlost', onLost)
+      canvas.removeEventListener('webglcontextrestored', onRestored)
+    }
+  }, [])
+
+  function applyPinch(): boolean {
+    const points = [...pointersRef.current.values()]
+    if (points.length < 2) {
+      pinchRef.current = null
+      return false
+    }
+    const distance = Math.hypot(points[0].x - points[1].x, points[0].y - points[1].y)
+    const pinch = pinchRef.current
+    if (!pinch) {
+      pinchRef.current = { distance, fov: cameraRef.current.fov }
+      return true
+    }
+    if (distance > 0 && pinch.distance > 0) {
+      cameraRef.current.fov = Math.max(
+        MIN_FOV,
+        Math.min(MAX_FOV, (pinch.fov * pinch.distance) / distance)
+      )
+      renderRef.current?.()
+    }
+    return true
+  }
+
   function handlePointerDown(event: ReactPointerEvent<HTMLCanvasElement>) {
-    dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY }
+    pointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
     event.currentTarget.setPointerCapture(event.pointerId)
+    applyPinch()
   }
 
   function handlePointerMove(event: ReactPointerEvent<HTMLCanvasElement>) {
-    const drag = dragRef.current
-    if (!drag || drag.pointerId !== event.pointerId) return
+    const previous = pointersRef.current.get(event.pointerId)
+    if (!previous) return
+    const next = { x: event.clientX, y: event.clientY }
+    pointersRef.current.set(event.pointerId, next)
+    if (!dragged) setDragged(true)
+    if (applyPinch()) return
+
     const camera = cameraRef.current
     const rect = event.currentTarget.getBoundingClientRect()
     // Drag sensitivity scales with fov so zoomed-in panning feels natural.
-    const radPerPx = (camera.fov * Math.PI) / 180 / rect.height
-    camera.yaw += (event.clientX - drag.x) * radPerPx
-    camera.pitch += (event.clientY - drag.y) * radPerPx
+    const radPerPx = (camera.fov * Math.PI) / 180 / Math.max(1, rect.height)
+    camera.yaw += (next.x - previous.x) * radPerPx
+    camera.pitch += (next.y - previous.y) * radPerPx
     camera.pitch = Math.max(-1.45, Math.min(1.45, camera.pitch))
-    drag.x = event.clientX
-    drag.y = event.clientY
-    if (!dragged) setDragged(true)
     setCompassDeg(yawToDegrees(camera.yaw))
     renderRef.current?.()
   }
 
   function handlePointerUp(event: ReactPointerEvent<HTMLCanvasElement>) {
-    if (dragRef.current?.pointerId === event.pointerId) dragRef.current = null
+    pointersRef.current.delete(event.pointerId)
+    pinchRef.current = null
+    applyPinch()
   }
 
   // Wheel zoom needs preventDefault, so attach non-passively.
@@ -317,6 +474,7 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
         aria-label="360° panorama of the mystery location — drag to look around"
         role="img"
       />
@@ -351,7 +509,10 @@ export function PanoViewer({ pano, className }: PanoViewerProps) {
       )}
 
       {status === 'ready' && !dragged && (
-        <div className="gt-pano-hint mono">⇄ Drag to look around · scroll to zoom</div>
+        <div className="gt-pano-hint mono">
+          <span className="gt-pano-hint-desktop">⇄ Drag to look around · scroll to zoom</span>
+          <span className="gt-pano-hint-touch">⇄ Swipe to look · pinch to zoom</span>
+        </div>
       )}
       <a className="gt-pano-watermark mono" href={pano.page} target="_blank" rel="noreferrer">
         © {pano.author} · {pano.license} · Wikimedia Commons

--- a/src/games/globetrotter/WorldMap.tsx
+++ b/src/games/globetrotter/WorldMap.tsx
@@ -11,6 +11,7 @@ import {
   clampView,
   easeInOut,
   lerpView,
+  pinchView,
   project,
   tileBox,
   tileKey,
@@ -19,6 +20,7 @@ import {
   unproject,
   visibleTiles,
   worldView,
+  zoomView,
   WORLD_SIZE,
   type Point,
   type Tile,
@@ -69,6 +71,9 @@ const TILE_ERROR_LIMIT = 6
 
 // Screen-pixel movement below this is a click (drop a pin), above it a pan.
 const CLICK_SLOP_PX = 5
+// A fingertip wobbles far more than a mouse, and it covers the point it is
+// aiming at — hold a tap open wider on touch or every pin drop reads as a pan.
+const TOUCH_CLICK_SLOP_PX = 12
 /** Wait for the camera to rest this long before asking for tiles. */
 const TILE_SETTLE_MS = 220
 /** Name a country only once it is this wide on screen, and never crowd the map. */
@@ -188,12 +193,21 @@ export function WorldMap({
   // Mirrors `view` so a fly-to can read the live camera without re-subscribing.
   const viewRef = useRef(view)
   viewRef.current = view
-  const dragRef = useRef<{
-    pointerId: number
+  // Every pointer currently on the map, so two fingers can pinch and a lifted
+  // finger can hand the gesture back to the one still down.
+  const pointersRef = useRef(new Map<number, Point>())
+  const gestureRef = useRef<{
+    /** One pointer drags the map; two zoom and drag it together. */
+    mode: 'pan' | 'pinch'
+    /** Camera the gesture started from — every frame is measured against it. */
+    origin: ViewBox
     startX: number
     startY: number
-    origin: ViewBox
+    startDistance: number
     moved: boolean
+    /** A second finger joined at some point, so this can never end as a tap. */
+    multi: boolean
+    slop: number
   } | null>(null)
 
   // Measure the element: the projection is square, so the viewBox height has to
@@ -374,18 +388,7 @@ export function WorldMap({
     const anchor = toWorldPoint(clientX, clientY)
     if (!anchor) return
     stopFlight()
-    setView((current) => {
-      const next = clampView({ ...current, w: current.w / factor }, aspect)
-      const ratio = next.w / current.w
-      return clampView(
-        {
-          ...next,
-          x: anchor.x - (anchor.x - current.x) * ratio,
-          y: anchor.y - (anchor.y - current.y) * ratio,
-        },
-        aspect
-      )
-    })
+    setView((current) => zoomView(current, anchor, factor, aspect))
   }
 
   function zoomCentered(factor: number) {
@@ -407,35 +410,93 @@ export function WorldMap({
     return () => svg.removeEventListener('wheel', onWheel)
   })
 
+  /** Midpoint and spread of whatever is currently touching the map. */
+  function pointerStats() {
+    const points = [...pointersRef.current.values()]
+    if (points.length === 0) return { count: 0, midX: 0, midY: 0, distance: 0 }
+    const midX = points.reduce((sum, point) => sum + point.x, 0) / points.length
+    const midY = points.reduce((sum, point) => sum + point.y, 0) / points.length
+    const distance =
+      points.length >= 2 ? Math.hypot(points[0].x - points[1].x, points[0].y - points[1].y) : 0
+    return { count: points.length, midX, midY, distance }
+  }
+
+  /**
+   * (Re)anchor the gesture on the pointers that are down right now. Called
+   * whenever a finger joins or leaves, so the map picks up from where it is
+   * instead of snapping back to where the gesture originally started.
+   */
+  function restartGesture(seed: { moved: boolean; multi: boolean; slop: number }) {
+    const stats = pointerStats()
+    if (stats.count === 0) {
+      gestureRef.current = null
+      return
+    }
+    gestureRef.current = {
+      mode: stats.count >= 2 ? 'pinch' : 'pan',
+      origin: viewRef.current,
+      startX: stats.midX,
+      startY: stats.midY,
+      startDistance: stats.distance,
+      ...seed,
+    }
+  }
+
   function handlePointerDown(event: ReactPointerEvent<SVGSVGElement>) {
     if (event.button !== 0) return
     stopFlight()
-    dragRef.current = {
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
-      origin: view,
-      moved: false,
-    }
+    pointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
     event.currentTarget.setPointerCapture(event.pointerId)
+    const previous = gestureRef.current
+    const multi = pointersRef.current.size > 1 || (previous?.multi ?? false)
+    restartGesture({
+      moved: multi || (previous?.moved ?? false),
+      multi,
+      slop: event.pointerType === 'mouse' ? CLICK_SLOP_PX : TOUCH_CLICK_SLOP_PX,
+    })
   }
 
   function handlePointerMove(event: ReactPointerEvent<SVGSVGElement>) {
-    const drag = dragRef.current
-    if (!drag || drag.pointerId !== event.pointerId) return
+    if (!pointersRef.current.has(event.pointerId)) return
+    pointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+    const gesture = gestureRef.current
     const rect = svgRef.current?.getBoundingClientRect()
-    if (!rect || rect.width === 0) return
-    const dxPx = event.clientX - drag.startX
-    const dyPx = event.clientY - drag.startY
-    if (!drag.moved && Math.hypot(dxPx, dyPx) < CLICK_SLOP_PX) return
-    drag.moved = true
-    const unitsPerPx = drag.origin.w / rect.width
+    if (!gesture || !rect || rect.width === 0 || rect.height === 0) return
+    const stats = pointerStats()
+
+    if (gesture.mode === 'pinch' && stats.count >= 2 && gesture.startDistance > 0) {
+      gesture.moved = true
+      setView(
+        pinchView(
+          gesture.origin,
+          {
+            from: {
+              x: (gesture.startX - rect.left) / rect.width,
+              y: (gesture.startY - rect.top) / rect.height,
+            },
+            to: {
+              x: (stats.midX - rect.left) / rect.width,
+              y: (stats.midY - rect.top) / rect.height,
+            },
+            scale: stats.distance / gesture.startDistance,
+          },
+          aspect
+        )
+      )
+      return
+    }
+
+    const dxPx = stats.midX - gesture.startX
+    const dyPx = stats.midY - gesture.startY
+    if (!gesture.moved && Math.hypot(dxPx, dyPx) < gesture.slop) return
+    gesture.moved = true
+    const unitsPerPx = gesture.origin.w / rect.width
     setView(
       clampView(
         {
-          ...drag.origin,
-          x: drag.origin.x - dxPx * unitsPerPx,
-          y: drag.origin.y - dyPx * unitsPerPx,
+          ...gesture.origin,
+          x: gesture.origin.x - dxPx * unitsPerPx,
+          y: gesture.origin.y - dyPx * unitsPerPx,
         },
         aspect
       )
@@ -443,13 +504,29 @@ export function WorldMap({
   }
 
   function handlePointerUp(event: ReactPointerEvent<SVGSVGElement>) {
-    const drag = dragRef.current
-    if (!drag || drag.pointerId !== event.pointerId) return
-    dragRef.current = null
-    if (drag.moved || !interactive || !onSelect) return
+    if (!pointersRef.current.delete(event.pointerId)) return
+    const gesture = gestureRef.current
+    if (pointersRef.current.size > 0) {
+      // One finger of a pinch lifted: carry on panning with what is left,
+      // still disqualified from dropping a pin when it finally comes up.
+      restartGesture({ moved: true, multi: true, slop: gesture?.slop ?? CLICK_SLOP_PX })
+      return
+    }
+    gestureRef.current = null
+    if (!gesture || gesture.moved || gesture.multi || !interactive || !onSelect) return
     const point = toWorldPoint(event.clientX, event.clientY)
     if (!point) return
     onSelect(unproject(point.x, point.y))
+  }
+
+  /** A cancelled pointer (browser took the gesture over) drops a pin nowhere. */
+  function handlePointerCancel(event: ReactPointerEvent<SVGSVGElement>) {
+    if (!pointersRef.current.delete(event.pointerId)) return
+    if (pointersRef.current.size > 0) {
+      restartGesture({ moved: true, multi: true, slop: gestureRef.current?.slop ?? CLICK_SLOP_PX })
+      return
+    }
+    gestureRef.current = null
   }
 
   const targetXY = target ? project(target.lat, target.lng) : null
@@ -468,6 +545,7 @@ export function WorldMap({
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
         className={cn('gt-map-svg', interactive && 'is-pickable', flying && 'is-flying')}
       >
         <defs>

--- a/src/games/globetrotter/mercator.test.ts
+++ b/src/games/globetrotter/mercator.test.ts
@@ -8,6 +8,7 @@ import {
   GUESS_HOLD_MS,
   lerpView,
   MAX_MERCATOR_LAT,
+  pinchView,
   project,
   revealTour,
   tileBox,
@@ -93,6 +94,53 @@ describe('view box', () => {
   it('survives a degenerate aspect ratio', () => {
     expect(clampView({ x: 0, y: 0, w: WORLD_SIZE, h: 1 }, 0).h).toBe(WORLD_SIZE / 2)
     expect(clampView({ x: 0, y: 0, w: WORLD_SIZE, h: 1 }, Number.NaN).h).toBe(WORLD_SIZE / 2)
+  })
+})
+
+describe('pinchView', () => {
+  // A quarter of the world, centred — plenty of room to zoom either way.
+  const origin: ViewBox = { x: 64, y: 64, w: 128, h: 64 }
+  const centre = { x: 0.5, y: 0.5 }
+
+  it('keeps the world under the fingers as they spread', () => {
+    const view = pinchView(origin, { from: centre, to: centre, scale: 2 }, 2)
+    expect(view.w).toBeCloseTo(64, 6)
+    // The point under the midpoint before the pinch is still under it after.
+    expect(view.x + view.w / 2).toBeCloseTo(origin.x + origin.w / 2, 6)
+    expect(view.y + view.h / 2).toBeCloseTo(origin.y + origin.h / 2, 6)
+  })
+
+  it('zooms out when the fingers close', () => {
+    expect(pinchView(origin, { from: centre, to: centre, scale: 0.5 }, 2).w).toBeCloseTo(256, 6)
+  })
+
+  it('anchors on the fingers, not the centre of the map', () => {
+    const corner = { x: 0.25, y: 0.25 }
+    const view = pinchView(origin, { from: corner, to: corner, scale: 2 }, 2)
+    expect(view.x + view.w * 0.25).toBeCloseTo(origin.x + origin.w * 0.25, 6)
+    expect(view.y + view.h * 0.25).toBeCloseTo(origin.y + origin.h * 0.25, 6)
+  })
+
+  it('drags the map when both fingers slide without spreading', () => {
+    const view = pinchView(origin, { from: centre, to: { x: 0.75, y: 0.5 }, scale: 1 }, 2)
+    expect(view.w).toBeCloseTo(origin.w, 6)
+    expect(view.x).toBeCloseTo(origin.x - origin.w * 0.25, 6)
+  })
+
+  it('stays inside the world and the zoom limits', () => {
+    const edge = pinchView(origin, { from: centre, to: { x: 3, y: 3 }, scale: 1 }, 2)
+    expect(edge.x).toBeGreaterThanOrEqual(0)
+    expect(edge.y).toBeGreaterThanOrEqual(0)
+    const deep = pinchView(origin, { from: centre, to: centre, scale: 1e6 }, 2)
+    expect(deep.w).toBeCloseTo(WORLD_SIZE / 4096, 8)
+  })
+
+  it('treats a degenerate scale as no zoom rather than collapsing', () => {
+    expect(pinchView(origin, { from: centre, to: centre, scale: 0 }, 2).w).toBeCloseTo(origin.w, 6)
+    expect(pinchView(origin, { from: centre, to: centre, scale: Number.NaN }, 2).w).toBeCloseTo(
+      origin.w,
+      6
+    )
   })
 })
 

--- a/src/games/globetrotter/mercator.ts
+++ b/src/games/globetrotter/mercator.ts
@@ -100,6 +100,36 @@ export function zoomView(view: ViewBox, anchor: Point, factor: number, aspect: n
   )
 }
 
+/** A two-finger gesture, in fractions of the map element (0 = left/top, 1 = right/bottom). */
+export interface PinchGesture {
+  /** Where the midpoint between the fingers sat when the gesture began. */
+  from: Point
+  /** Where that midpoint sits now. */
+  to: Point
+  /** Current finger separation ÷ the separation the gesture began at. */
+  scale: number
+}
+
+/**
+ * Zoom and pan in one step, the way a pinch actually behaves: the piece of the
+ * world the fingers grabbed stays pinned under them, so spreading zooms in and
+ * sliding both fingers drags the map at the same time.
+ */
+export function pinchView(origin: ViewBox, gesture: PinchGesture, aspect: number): ViewBox {
+  const scale = gesture.scale > 0 && Number.isFinite(gesture.scale) ? gesture.scale : 1
+  const zoomed = clampView({ ...origin, w: origin.w / scale }, aspect)
+  const anchorX = origin.x + gesture.from.x * origin.w
+  const anchorY = origin.y + gesture.from.y * origin.h
+  return clampView(
+    {
+      ...zoomed,
+      x: anchorX - gesture.to.x * zoomed.w,
+      y: anchorY - gesture.to.y * zoomed.h,
+    },
+    aspect
+  )
+}
+
 /** Roughly 25 km across at the equator — close enough to read streets. */
 export const CLOSE_VIEW_WIDTH = (WORLD_SIZE * 25) / 40075
 

--- a/src/games/globetrotter/panoTexture.test.ts
+++ b/src/games/globetrotter/panoTexture.test.ts
@@ -1,0 +1,50 @@
+import { panoCandidates, panoUrlAtWidth, preferredTextureWidth } from './panoTexture'
+
+const FULL =
+  'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Pont_de_Bir-Hakeim%2C_April_2007.jpg/3840px-Pont_de_Bir-Hakeim%2C_April_2007.jpg'
+
+describe('preferredTextureWidth', () => {
+  it('asks phones for the smallest rendition', () => {
+    expect(preferredTextureWidth(390)).toBe(2048)
+    expect(preferredTextureWidth(480)).toBe(2048)
+  })
+
+  it('gives tablets a middle rendition', () => {
+    expect(preferredTextureWidth(481)).toBe(2560)
+    expect(preferredTextureWidth(900)).toBe(2560)
+  })
+
+  it('leaves desktops on the full-size rendition', () => {
+    expect(preferredTextureWidth(901)).toBe(3840)
+    expect(preferredTextureWidth(2560)).toBe(3840)
+  })
+})
+
+describe('panoUrlAtWidth', () => {
+  it('rewrites only the rendition width, not the file name', () => {
+    expect(panoUrlAtWidth(FULL, 2048)).toBe(
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Pont_de_Bir-Hakeim%2C_April_2007.jpg/2048px-Pont_de_Bir-Hakeim%2C_April_2007.jpg'
+    )
+  })
+
+  it('never upscales a rendition that is already narrow enough', () => {
+    const small = panoUrlAtWidth(FULL, 1024)
+    expect(panoUrlAtWidth(small, 3840)).toBe(small)
+    expect(panoUrlAtWidth(small, 1024)).toBe(small)
+  })
+
+  it('leaves non-thumbnail URLs untouched', () => {
+    const original = 'https://upload.wikimedia.org/wikipedia/commons/d/d1/Photosphere.jpg'
+    expect(panoUrlAtWidth(original, 2048)).toBe(original)
+  })
+})
+
+describe('panoCandidates', () => {
+  it('tries the phone-sized rendition first and keeps the original as a fallback', () => {
+    expect(panoCandidates(FULL, 390)).toEqual([panoUrlAtWidth(FULL, 2048), FULL])
+  })
+
+  it('does not duplicate the URL when no smaller rendition exists', () => {
+    expect(panoCandidates(FULL, 1440)).toEqual([FULL])
+  })
+})

--- a/src/games/globetrotter/panoTexture.test.ts
+++ b/src/games/globetrotter/panoTexture.test.ts
@@ -1,47 +1,90 @@
-import { panoCandidates, panoUrlAtWidth, preferredTextureWidth } from './panoTexture'
+import {
+  panoCandidates,
+  panoUrlAtWidth,
+  preferredTextureWidth,
+  standardThumbWidth,
+  STANDARD_THUMB_WIDTHS,
+} from './panoTexture'
 
 const FULL =
   'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Pont_de_Bir-Hakeim%2C_April_2007.jpg/3840px-Pont_de_Bir-Hakeim%2C_April_2007.jpg'
 
-describe('preferredTextureWidth', () => {
-  it('asks phones for the smallest rendition', () => {
-    expect(preferredTextureWidth(390)).toBe(2048)
-    expect(preferredTextureWidth(480)).toBe(2048)
+/** The width in a `.../NNNpx-name.jpg` thumbnail URL. */
+function widthOf(url: string): number {
+  return Number(url.match(/\/(\d+)px-/)![1])
+}
+
+describe('standardThumbWidth', () => {
+  it('snaps down to a width Wikimedia will actually serve', () => {
+    // 2048 and 2560 are the tempting round numbers, and both are refused.
+    expect(standardThumbWidth(2048)).toBe(1920)
+    expect(standardThumbWidth(2560)).toBe(1920)
+    expect(standardThumbWidth(1919)).toBe(1280)
   })
 
-  it('gives tablets a middle rendition', () => {
-    expect(preferredTextureWidth(481)).toBe(2560)
-    expect(preferredTextureWidth(900)).toBe(2560)
+  it('passes standard widths through untouched', () => {
+    for (const width of STANDARD_THUMB_WIDTHS) expect(standardThumbWidth(width)).toBe(width)
+  })
+
+  it('never returns more than asked for, and never nothing', () => {
+    expect(standardThumbWidth(1e6)).toBe(3840)
+    expect(standardThumbWidth(0)).toBe(20)
+  })
+})
+
+describe('preferredTextureWidth', () => {
+  it('gives phones and small tablets the 1920px rendition', () => {
+    expect(preferredTextureWidth(390)).toBe(1920)
+    expect(preferredTextureWidth(900)).toBe(1920)
   })
 
   it('leaves desktops on the full-size rendition', () => {
     expect(preferredTextureWidth(901)).toBe(3840)
     expect(preferredTextureWidth(2560)).toBe(3840)
   })
+
+  it('only ever picks a servable width', () => {
+    for (const viewport of [320, 390, 768, 900, 1024, 1440, 2560]) {
+      expect(STANDARD_THUMB_WIDTHS).toContain(preferredTextureWidth(viewport))
+    }
+  })
 })
 
 describe('panoUrlAtWidth', () => {
   it('rewrites only the rendition width, not the file name', () => {
-    expect(panoUrlAtWidth(FULL, 2048)).toBe(
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Pont_de_Bir-Hakeim%2C_April_2007.jpg/2048px-Pont_de_Bir-Hakeim%2C_April_2007.jpg'
+    expect(panoUrlAtWidth(FULL, 1920)).toBe(
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Pont_de_Bir-Hakeim%2C_April_2007.jpg/1920px-Pont_de_Bir-Hakeim%2C_April_2007.jpg'
     )
   })
 
+  it('snaps a non-standard request onto a servable width', () => {
+    // Requesting 2048 verbatim returns HTTP 400 from upload.wikimedia.org.
+    expect(widthOf(panoUrlAtWidth(FULL, 2048))).toBe(1920)
+  })
+
   it('never upscales a rendition that is already narrow enough', () => {
-    const small = panoUrlAtWidth(FULL, 1024)
+    const small = panoUrlAtWidth(FULL, 1280)
     expect(panoUrlAtWidth(small, 3840)).toBe(small)
-    expect(panoUrlAtWidth(small, 1024)).toBe(small)
+    expect(panoUrlAtWidth(small, 1280)).toBe(small)
   })
 
   it('leaves non-thumbnail URLs untouched', () => {
     const original = 'https://upload.wikimedia.org/wikipedia/commons/d/d1/Photosphere.jpg'
-    expect(panoUrlAtWidth(original, 2048)).toBe(original)
+    expect(panoUrlAtWidth(original, 1920)).toBe(original)
   })
 })
 
 describe('panoCandidates', () => {
   it('tries the phone-sized rendition first and keeps the original as a fallback', () => {
-    expect(panoCandidates(FULL, 390)).toEqual([panoUrlAtWidth(FULL, 2048), FULL])
+    expect(panoCandidates(FULL, 390)).toEqual([panoUrlAtWidth(FULL, 1920), FULL])
+  })
+
+  it('only ever offers servable widths', () => {
+    for (const viewport of [390, 768, 1440]) {
+      for (const url of panoCandidates(FULL, viewport)) {
+        expect(STANDARD_THUMB_WIDTHS).toContain(widthOf(url))
+      }
+    }
   })
 
   it('does not duplicate the URL when no smaller rendition exists', () => {

--- a/src/games/globetrotter/panoTexture.ts
+++ b/src/games/globetrotter/panoTexture.ts
@@ -1,26 +1,49 @@
 // Pure helpers for picking which rendition of a panorama to download.
 //
-// A 3840px photosphere is several megabytes on the wire and ~30 MB of RGBA
-// once uploaded to the GPU — fine on a desktop, but enough for a phone to
-// stall on cellular or for mobile Safari to refuse the texture and drop the
-// WebGL context. Only ~20% of the sphere is on screen at any moment, so a
-// narrower rendition still gives a phone more texels than it has pixels.
+// A 3840px photosphere is ~1.2 MB on the wire and ~30 MB of RGBA once uploaded
+// to the GPU — fine on a desktop, but enough for a phone to stall on cellular
+// or for mobile Safari to refuse the texture. Only ~20% of the sphere is on
+// screen at any moment, so a narrower rendition still gives a phone more texels
+// than it has pixels, at a quarter of the bytes.
+
+/**
+ * The only widths Wikimedia will serve.
+ *
+ * Hotlinking any other width is rejected outright — HTTP 400, "Use thumbnail
+ * sizes listed on https://w.wiki/GHai" — so a rendition has to be snapped onto
+ * this ladder. Asking for a convenient round number like 2048 gets nothing at
+ * all. (Requests that go through the API, e.g. `iiurlwidth`, are rounded *up*
+ * to the next of these instead of being refused.)
+ *
+ * @see https://www.mediawiki.org/wiki/Common_thumbnail_sizes
+ */
+export const STANDARD_THUMB_WIDTHS: readonly number[] = [
+  20, 40, 60, 120, 250, 330, 500, 960, 1280, 1920, 3840,
+]
+
+/** The widest standard rendition that fits in `width`. */
+export function standardThumbWidth(width: number): number {
+  let best = STANDARD_THUMB_WIDTHS[0]
+  for (const candidate of STANDARD_THUMB_WIDTHS) {
+    if (candidate <= width) best = candidate
+  }
+  return best
+}
 
 /** Widest rendition worth downloading for a viewport this size. */
 export function preferredTextureWidth(viewportWidth: number): number {
-  if (viewportWidth <= 480) return 2048
-  if (viewportWidth <= 900) return 2560
-  return 3840
+  return viewportWidth <= 900 ? 1920 : 3840
 }
 
 /**
  * Commons thumbnails are addressed by pixel width (`.../3840px-Foo.jpg`), so a
- * narrower rendition is one string away. Never upscales, and leaves any URL
- * that is not a Commons thumbnail untouched.
+ * narrower rendition is one string away. Snaps to a servable width, never
+ * upscales, and leaves any URL that is not a Commons thumbnail untouched.
  */
 export function panoUrlAtWidth(url: string, width: number): string {
+  const target = standardThumbWidth(width)
   return url.replace(/\/(\d+)px-/, (whole, current: string) =>
-    Number(current) <= width ? whole : `/${width}px-`
+    Number(current) <= target ? whole : `/${target}px-`
   )
 }
 

--- a/src/games/globetrotter/panoTexture.ts
+++ b/src/games/globetrotter/panoTexture.ts
@@ -1,0 +1,31 @@
+// Pure helpers for picking which rendition of a panorama to download.
+//
+// A 3840px photosphere is several megabytes on the wire and ~30 MB of RGBA
+// once uploaded to the GPU — fine on a desktop, but enough for a phone to
+// stall on cellular or for mobile Safari to refuse the texture and drop the
+// WebGL context. Only ~20% of the sphere is on screen at any moment, so a
+// narrower rendition still gives a phone more texels than it has pixels.
+
+/** Widest rendition worth downloading for a viewport this size. */
+export function preferredTextureWidth(viewportWidth: number): number {
+  if (viewportWidth <= 480) return 2048
+  if (viewportWidth <= 900) return 2560
+  return 3840
+}
+
+/**
+ * Commons thumbnails are addressed by pixel width (`.../3840px-Foo.jpg`), so a
+ * narrower rendition is one string away. Never upscales, and leaves any URL
+ * that is not a Commons thumbnail untouched.
+ */
+export function panoUrlAtWidth(url: string, width: number): string {
+  return url.replace(/\/(\d+)px-/, (whole, current: string) =>
+    Number(current) <= width ? whole : `/${width}px-`
+  )
+}
+
+/** Candidate URLs, cheapest first — the full-size original is the last resort. */
+export function panoCandidates(url: string, viewportWidth: number): string[] {
+  const sized = panoUrlAtWidth(url, preferredTextureWidth(viewportWidth))
+  return sized === url ? [url] : [sized, url]
+}

--- a/src/games/globetrotter/randomWorld.ts
+++ b/src/games/globetrotter/randomWorld.ts
@@ -21,8 +21,16 @@ import { RESERVE_PANORAMAS, type ReservePanorama } from './randomWorldReserve'
 
 const API = 'https://commons.wikimedia.org/w/api.php'
 const CATEGORY = 'Category:360° panoramas'
-/** Wide enough for a crisp WebGL texture, small enough that Commons renders it fast. */
-const TEXTURE_WIDTH = 2560
+/**
+ * Deck URLs are asked for at Wikimedia's widest standard rendition, and each
+ * player's browser snaps that down to what its own screen can use
+ * (`panoTexture.ts`). Asking for anything off the standard ladder is pointless
+ * here — the API silently rounds *up* to the next standard width, so this used
+ * to read 2560 while every deck was served 3840 anyway.
+ *
+ * @see https://www.mediawiki.org/wiki/Common_thumbnail_sizes
+ */
+const TEXTURE_WIDTH = 3840
 const MIN_SOURCE_WIDTH = 2048
 /** Equirectangular photospheres are 2:1; allow a little slack for odd crops. */
 const ASPECT_TOLERANCE = 0.05

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,0 +1,72 @@
+import { CONNECT_ORIGINS, contentSecurityPolicy, IMAGE_ORIGINS } from './csp'
+
+const SUPABASE = 'https://project.supabase.co'
+
+function production(supabaseUrl?: string): string {
+  const policy = contentSecurityPolicy({ nodeEnv: 'production', supabaseUrl })
+  if (policy === null) throw new Error('expected a production policy')
+  return policy
+}
+
+/** The space-separated sources of one directive. */
+function directive(policy: string, name: string): string[] {
+  const found = policy.split('; ').find((part) => part.startsWith(`${name} `))
+  if (!found) throw new Error(`no ${name} directive in: ${policy}`)
+  return found.slice(name.length + 1).split(' ')
+}
+
+describe('contentSecurityPolicy', () => {
+  it('emits nothing outside production', () => {
+    // next dev needs eval and a localhost websocket for HMR.
+    expect(contentSecurityPolicy({ nodeEnv: 'development' })).toBeNull()
+    expect(contentSecurityPolicy({ nodeEnv: 'test' })).toBeNull()
+    expect(contentSecurityPolicy({})).toBeNull()
+  })
+
+  it('lets the room tokens reach Supabase over both http and websockets', () => {
+    const connect = directive(production(SUPABASE), 'connect-src')
+    expect(connect).toContain('https://project.supabase.co')
+    expect(connect).toContain('wss://project.supabase.co')
+  })
+
+  it('survives a build with a missing or malformed Supabase URL', () => {
+    expect(directive(production(), 'connect-src')).toContain("'self'")
+    expect(directive(production('not a url'), 'connect-src')).toContain("'self'")
+  })
+
+  // The regression this file exists for: the policy shipped with connect-src
+  // and img-src at 'self' + Supabase only, so every Globetrotter call to
+  // Wikimedia and OpenStreetMap was blocked in production while working
+  // locally, where no policy is emitted at all.
+  it('allows every origin the games fetch from', () => {
+    const connect = directive(production(SUPABASE), 'connect-src')
+    for (const origin of CONNECT_ORIGINS) expect(connect).toContain(origin)
+    expect(CONNECT_ORIGINS).toContain('https://commons.wikimedia.org')
+    expect(CONNECT_ORIGINS).toContain('https://upload.wikimedia.org')
+    expect(CONNECT_ORIGINS).toContain('https://nominatim.openstreetmap.org')
+  })
+
+  it('allows every origin the games load images from', () => {
+    const img = directive(production(SUPABASE), 'img-src')
+    for (const origin of IMAGE_ORIGINS) expect(img).toContain(origin)
+    // The panorama's <img> decode fallback and the raster basemap.
+    expect(IMAGE_ORIGINS).toContain('https://upload.wikimedia.org')
+    expect(IMAGE_ORIGINS).toContain('https://tile.openstreetmap.org')
+  })
+
+  it('keeps the blob and data sources the viewer decodes through', () => {
+    const img = directive(production(SUPABASE), 'img-src')
+    expect(img).toContain('blob:')
+    expect(img).toContain('data:')
+  })
+
+  it('stays locked down everywhere it does not need to open up', () => {
+    const policy = production(SUPABASE)
+    expect(policy).toContain("default-src 'self'")
+    expect(policy).toContain("base-uri 'self'")
+    expect(policy).toContain("form-action 'self'")
+    expect(policy).not.toContain('unsafe-eval')
+    // A wildcard host would defeat the point of an allowlist.
+    expect(policy).not.toMatch(/(^|[ ;])\*/)
+  })
+})

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,78 @@
+// P2-6: a defense-in-depth Content-Security-Policy. GitHub Pages cannot set
+// response headers, so this ships as a <meta> tag baked into the static export.
+// Static export cannot mint per-request nonces, so script/style fall back to
+// 'unsafe-inline' (Next hydration + Tailwind); the meaningful win is keeping
+// connect-src to a named list, so the localStorage-held room tokens can only
+// ever be sent to Supabase.
+
+/**
+ * Third-party origins the games talk to at runtime, and what needs each one.
+ *
+ * This is an allowlist, so an origin missing here is not degraded — it is
+ * blocked outright, and a CSP-blocked `fetch` rejects with a bare `TypeError`
+ * indistinguishable from the network being down. Globetrotter shipped that way:
+ * every Wikimedia and OpenStreetMap call failed in production while working
+ * locally, because `next dev` emits no policy at all.
+ *
+ * Reaching a new external service means adding it here in the same change.
+ */
+const ORIGINS = {
+  /** Globetrotter — Random World deck sweeps. `randomWorld.ts` */
+  commonsApi: 'https://commons.wikimedia.org',
+  /** Globetrotter — photosphere downloads, fetched *and* decoded via <img>. `PanoViewer.tsx` */
+  wikimediaUploads: 'https://upload.wikimedia.org',
+  /** Globetrotter — reverse-geocoding the drop point for the reveal. `placeName.ts` */
+  nominatim: 'https://nominatim.openstreetmap.org',
+  /** Globetrotter — OpenStreetMap raster basemap. `WorldMap.tsx` */
+  osmTiles: 'https://tile.openstreetmap.org',
+} as const
+
+/** Origins reached with `fetch`. */
+export const CONNECT_ORIGINS: readonly string[] = [
+  ORIGINS.commonsApi,
+  ORIGINS.wikimediaUploads,
+  ORIGINS.nominatim,
+]
+
+/** Origins loaded as images, including `new Image()` from script. */
+export const IMAGE_ORIGINS: readonly string[] = [ORIGINS.wikimediaUploads, ORIGINS.osmTiles]
+
+export interface CspEnv {
+  /** `process.env.NODE_ENV` — no policy is emitted outside production. */
+  nodeEnv?: string
+  /** `process.env.NEXT_PUBLIC_SUPABASE_URL`, if the build was given one. */
+  supabaseUrl?: string
+}
+
+/**
+ * The policy for a static export, or `null` when one should not be emitted.
+ *
+ * `next dev` gets none: HMR needs eval and a localhost websocket that a strict
+ * policy would break.
+ */
+export function contentSecurityPolicy({ nodeEnv, supabaseUrl }: CspEnv): string | null {
+  if (nodeEnv !== 'production') return null
+
+  const supabase: string[] = []
+  if (supabaseUrl) {
+    try {
+      const origin = new URL(supabaseUrl).origin
+      supabase.push(origin, origin.replace(/^http/, 'ws'))
+    } catch {
+      // ignore a malformed URL — connect-src just keeps its other entries
+    }
+  }
+
+  return [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    `img-src 'self' data: blob: ${IMAGE_ORIGINS.join(' ')}`,
+    "font-src 'self'",
+    "worker-src 'self' blob:",
+    `connect-src ${["'self'", ...supabase, ...CONNECT_ORIGINS].join(' ')}`,
+    "base-uri 'self'",
+    "form-action 'self'",
+    'upgrade-insecure-requests',
+  ].join('; ')
+}


### PR DESCRIPTION
The photosphere box collapsed to the canvas' intrinsic size on mobile:
`.gt-pano` sized itself with `height: 100%` against a parent whose height
comes from flexing, which browsers do not treat as definite. The photo
rendered at ~186px inside a 364px slot, with dead space underneath and the
minimap pushed past the bottom of the screen. The pano and its canvas now
fill their slot by inset instead.

Layout, phone-sized:

- Shell measures `100dvh`, so the board sits between the browser's address
  bar and toolbar rather than running under them.
- The status bar drops from three stacked rows (~180px) to a compact two-row
  grid (~80px).
- The board is pinned to one screenful: the photo takes what is left after a
  capped, self-scrolling field-notes block, and the minimap, hint and
  watermark are positioned so they no longer overlap.
- Topbar, reveal and results screens get matching mobile sizing.

Panorama loading, which was failing outright on iOS:

- Phones and tablets request a narrower Commons rendition (2048/2560px
  instead of 3840px), cutting the download several-fold and the texture
  from ~30 MB to ~8 MB. The full-size original stays as a fallback.
- The texture upload retries through a 2D-canvas copy and then progressively
  smaller sizes when the driver throws or raises OUT_OF_MEMORY.
- `createImageBitmap` failures fall back to the <img> decoder.
- `preserveDrawingBuffer` keeps the last frame alive; without it iOS clears
  the buffer after compositing and an on-demand renderer goes black.
- WebGL context loss is caught and the viewer rebuilds on restore.
- Two-finger pinch zooms, so touch users can finally zoom at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DLuiW76PZtJ8kwAF1UF8hu