### PR TITLE
Stop Globetrotter's solo decks recycling the same photographs

### DIFF
--- a/e2e/games/globetrotter.spec.ts
+++ b/e2e/games/globetrotter.spec.ts
@@ -603,6 +603,10 @@ test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
     await solo.goto()
     await solo.dismissPlayGate()
     await solo.soloButton.click()
+    // The board has to exist before "not loading" means anything — on the
+    // scouting screen there is no panorama, so the loading bar is absent and
+    // `toBeHidden` passes without a round having started.
+    await expect(solo.pano).toBeVisible()
     await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
 
     await solo.placeAndLockGuess(0.4, 0.4)
@@ -630,6 +634,9 @@ test.describe('Globetrotter solo (Random World, mocked Commons)', () => {
     await solo.goto()
     await solo.dismissPlayGate()
     await solo.soloButton.click()
+    // Scouting renders no panorama, so wait for the board itself — otherwise
+    // there is no context on `window.__glContext` to take away below.
+    await expect(solo.pano).toBeVisible()
     await expect(page.getByTestId('globetrotter-pano-loading')).toBeHidden()
     const before = (await readGlCounts(page)).createProgram
 

--- a/src/games/globetrotter/randomWorld.test.ts
+++ b/src/games/globetrotter/randomWorld.test.ts
@@ -11,6 +11,8 @@ interface DoubleOptions {
   perBatch?: number
   /** Fail every sweep with this status (429 = Commons rate limiting). */
   failStatus?: number
+  /** Serve this many sweeps normally before `failStatus` starts biting. */
+  failAfterBatch?: number
   /** Fail only the thumbnail-resolving request. */
   failThumbnails?: boolean
 }
@@ -28,7 +30,7 @@ function makeFetchDouble(options: DoubleOptions = {}) {
     calls.push(url)
     const isSweep = url.includes('generator=categorymembers')
 
-    if (options.failStatus && isSweep) {
+    if (options.failStatus && isSweep && batch >= (options.failAfterBatch ?? 0)) {
       return { ok: false, status: options.failStatus } as Response
     }
     if (options.failThumbnails && !isSweep) {
@@ -113,13 +115,60 @@ describe('fetchRandomWorldDeck', () => {
     }
   })
 
-  it('needs only two requests for a full deck', async () => {
+  it('stays frugal: a full deck costs a sweep per few rounds plus one render', async () => {
     const { fetchFn, calls } = makeFetchDouble({ perBatch: 5 })
     await fetchRandomWorldDeck(5, { fetchFn, random: fixedRandom })
 
-    expect(calls).toHaveLength(2)
-    expect(calls[0]).toContain('generator=categorymembers')
-    expect(calls[1]).toContain('iiurlwidth=')
+    // Two sweeps (three rounds is the most any one window may contribute) and
+    // the single request that renders every thumbnail the deck needs.
+    expect(calls).toHaveLength(3)
+    expect(calls.filter((url) => url.includes('generator=categorymembers'))).toHaveLength(2)
+    expect(calls.filter((url) => url.includes('iiurlwidth='))).toHaveLength(1)
+  })
+
+  // The bug this guards: `prop=coordinates` fills in only `colimit` pages per
+  // request, defaulting to 10. Every file past the tenth came back geotag-less
+  // and was dropped, so sweeps almost never found five usable panoramas and the
+  // deck was topped up from the reserve — the same photos every game.
+  it('asks Commons to geotag every file in the window, not just the first ten', async () => {
+    const { fetchFn, calls } = makeFetchDouble({ perBatch: 5 })
+    await fetchRandomWorldDeck(5, { fetchFn, random: fixedRandom })
+
+    for (const sweep of calls.filter((url) => url.includes('generator=categorymembers'))) {
+      expect(sweep).toContain('colimit=max')
+    }
+  })
+
+  it('draws a deck from several windows instead of one photographer’s series', async () => {
+    // One window offers far more than a deck needs; a single sweep could fill
+    // it, and every round would come from the same contiguous run of uploads.
+    const { fetchFn } = makeFetchDouble({ perBatch: 20 })
+    const deck = await fetchRandomWorldDeck(5, { fetchFn, random: fixedRandom })
+
+    // The double names files `Pano <sweep>-<index>`, so the sweep each round
+    // came from is readable straight off the panorama URL.
+    const sweeps = new Set(
+      deck.map((spot) => decodeURIComponent(spot.pano!.url).match(/Pano (\d+)-/)![1])
+    )
+    expect(sweeps.size).toBeGreaterThan(1)
+    for (const sweep of sweeps) {
+      const fromSweep = deck.filter((spot) =>
+        decodeURIComponent(spot.pano!.url).includes(`Pano ${sweep}-`)
+      )
+      expect(fromSweep.length).toBeLessThanOrEqual(3)
+    }
+  })
+
+  it('finishes a deck from finds an earlier sweep held back when later ones fail', async () => {
+    // Sweep 1 is rich but capped; sweeps 2+ are rate-limited. The finds the cap
+    // turned away complete the deck rather than letting it fall short.
+    const { fetchFn, calls } = makeFetchDouble({ perBatch: 20, failStatus: 429, failAfterBatch: 1 })
+    const deck = await fetchRandomWorldDeck(5, { fetchFn, random: fixedRandom })
+
+    expect(deck).toHaveLength(5)
+    expect(
+      calls.filter((url) => url.includes('generator=categorymembers')).length
+    ).toBeLessThanOrEqual(4)
   })
 
   it('reports progress as the deck fills up', async () => {

--- a/src/games/globetrotter/randomWorld.test.ts
+++ b/src/games/globetrotter/randomWorld.test.ts
@@ -24,6 +24,7 @@ function makeFetchDouble(options: DoubleOptions = {}) {
   const perBatch = options.perBatch ?? 3
   let batch = 0
   const calls: string[] = []
+  const windows = new Map<string, number>()
 
   const fetchFn = (async (input: RequestInfo | URL) => {
     const url = String(input)
@@ -40,15 +41,19 @@ function makeFetchDouble(options: DoubleOptions = {}) {
     let body: unknown
     if (isSweep) {
       batch++
+      const params = new URL(url).searchParams
+      const window = params.get('gcmstart') ?? params.get('gcmstartsortkeyprefix') ?? ''
+      const windowNumber = windows.get(window) ?? windows.size + 1
+      windows.set(window, windowNumber)
       const height = 2000
       const width = Math.round(height * (options.ratio ?? 2))
       const pages: Record<string, unknown> = {}
       for (let i = 0; i < perBatch; i++) {
         // ~5° apart: comfortably past the 50 km minimum separation.
-        const lat = 10 + batch * 5 + i * 5
-        const lng = 20 + batch * 5 + i * 5
+        const lat = 10 + windowNumber * 5 + i * 5
+        const lng = 20 + windowNumber * 5 + i * 5
         pages[String(i)] = {
-          title: `File:Pano ${batch}-${i}.jpg`,
+          title: `File:Pano ${windowNumber}-${i}.jpg`,
           imageinfo: [
             {
               width,
@@ -93,6 +98,13 @@ function makeFetchDouble(options: DoubleOptions = {}) {
 
 const fixedRandom = () => 0.5
 
+function seededRandom(seed: number): () => number {
+  return () => {
+    seed = (seed * 1664525 + 1013904223) >>> 0
+    return seed / 2 ** 32
+  }
+}
+
 describe('fetchRandomWorldDeck', () => {
   it('assembles a deck of distinct, playable panorama locations', async () => {
     const { fetchFn } = makeFetchDouble()
@@ -130,11 +142,12 @@ describe('fetchRandomWorldDeck', () => {
   // request, defaulting to 10. Every file past the tenth came back geotag-less
   // and was dropped, so sweeps almost never found five usable panoramas and the
   // deck was topped up from the reserve — the same photos every game.
-  it('asks Commons to geotag every file in the window, not just the first ten', async () => {
+  it('asks Commons for a wide window and geotags every file in it', async () => {
     const { fetchFn, calls } = makeFetchDouble({ perBatch: 5 })
     await fetchRandomWorldDeck(5, { fetchFn, random: fixedRandom })
 
     for (const sweep of calls.filter((url) => url.includes('generator=categorymembers'))) {
+      expect(sweep).toContain('gcmlimit=500')
       expect(sweep).toContain('colimit=max')
     }
   })
@@ -142,8 +155,16 @@ describe('fetchRandomWorldDeck', () => {
   it('draws a deck from several windows instead of one photographer’s series', async () => {
     // One window offers far more than a deck needs; a single sweep could fill
     // it, and every round would come from the same contiguous run of uploads.
-    const { fetchFn } = makeFetchDouble({ perBatch: 20 })
-    const deck = await fetchRandomWorldDeck(5, { fetchFn, random: fixedRandom })
+    const { fetchFn, calls } = makeFetchDouble({ perBatch: 20 })
+    const deck = await fetchRandomWorldDeck(5, { fetchFn, random: seededRandom(181) })
+
+    const windows = calls
+      .filter((url) => url.includes('generator=categorymembers'))
+      .map((url) => {
+        const params = new URL(url).searchParams
+        return params.get('gcmstart') ?? params.get('gcmstartsortkeyprefix')
+      })
+    expect(new Set(windows).size).toBeGreaterThan(1)
 
     // The double names files `Pano <sweep>-<index>`, so the sweep each round
     // came from is readable straight off the panorama URL.
@@ -159,16 +180,19 @@ describe('fetchRandomWorldDeck', () => {
     }
   })
 
-  it('finishes a deck from finds an earlier sweep held back when later ones fail', async () => {
-    // Sweep 1 is rich but capped; sweeps 2+ are rate-limited. The finds the cap
-    // turned away complete the deck rather than letting it fall short.
+  it('finishes a deck with finds held back by an earlier sweep when the next one fails', async () => {
+    // Sweep 1 is rich but capped; sweep 2 is rate-limited. The finds turned
+    // away by the cap complete the deck immediately rather than letting it fall
+    // short or waiting for more failed sweeps.
     const { fetchFn, calls } = makeFetchDouble({ perBatch: 20, failStatus: 429, failAfterBatch: 1 })
     const deck = await fetchRandomWorldDeck(5, { fetchFn, random: fixedRandom })
 
     expect(deck).toHaveLength(5)
-    expect(
-      calls.filter((url) => url.includes('generator=categorymembers')).length
-    ).toBeLessThanOrEqual(4)
+    expect(calls.filter((url) => url.includes('generator=categorymembers'))).toHaveLength(2)
+    const contributingWindows = new Set(
+      deck.map((spot) => decodeURIComponent(spot.pano!.url).match(/Pano (\d+)-/)![1])
+    )
+    expect(contributingWindows.size).toBe(1)
   })
 
   it('reports progress as the deck fills up', async () => {

--- a/src/games/globetrotter/randomWorld.ts
+++ b/src/games/globetrotter/randomWorld.ts
@@ -236,6 +236,15 @@ function farEnough(candidate: Candidate, taken: Candidate[]): boolean {
   )
 }
 
+function sparesCanComplete(picked: Candidate[], spare: Candidate[], count: number): boolean {
+  const trial = [...picked]
+  for (const candidate of spare) {
+    if (trial.length >= count) return true
+    if (farEnough(candidate, trial)) trial.push(candidate)
+  }
+  return trial.length >= count
+}
+
 function pause(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -284,7 +293,10 @@ async function collectCandidates(
         deps.signal
       )) as PagesResponse
     } catch {
-      // A rate-limited or flaky sweep is not fatal — try the next window.
+      // A rate-limited or flaky sweep is not fatal. If earlier windows already
+      // left enough usable finds behind the diversity cap, use them now instead
+      // of waiting through the rest of the request budget.
+      if (sparesCanComplete(picked, spare, count)) break
       continue
     }
     let taken = 0

--- a/src/games/globetrotter/randomWorld.ts
+++ b/src/games/globetrotter/randomWorld.ts
@@ -6,12 +6,15 @@
 // a static site can query it directly from the browser.
 //
 // Commons rate-limits anonymous bursts (HTTP 429) and rendering a large
-// thumbnail is slow, so the pipeline is deliberately frugal: one cheap
-// `generator=categorymembers` request returns up to 50 candidates with their
-// coordinates and dimensions, and only the handful of files that actually make
-// the deck get a thumbnail rendered — in a single follow-up request. When
-// Commons is unreachable or too stingy, `buildRandomWorldDeck` tops the deck up
-// from the vendored reserve so the mode is always playable.
+// thumbnail is slow, so the pipeline is deliberately frugal: a cheap
+// `generator=categorymembers` request returns a wide window of candidates with
+// their coordinates and dimensions, and only the handful of files that actually
+// make the deck get a thumbnail rendered — in a single follow-up request. The
+// budget is spent on *wider* sweeps rather than more of them, because the limit
+// counts requests and a wide window is what lets a deck span several uploaders
+// instead of five frames of one photographer's series. When Commons is
+// unreachable or too stingy, `buildRandomWorldDeck` tops the deck up from the
+// vendored reserve so the mode is always playable.
 //
 // Pure async data module — no React. `fetch` and `random` are injectable so
 // the whole pipeline is unit-testable offline.
@@ -37,12 +40,37 @@ const ASPECT_TOLERANCE = 0.05
 // Files from one Mapillary drive are seconds apart; keep rounds genuinely
 // distinct by requiring pins at least this far apart.
 const MIN_SEPARATION_KM = 50
-/** Cheap candidate sweeps per deck — each is one request returning ~50 files. */
+/** Cheap candidate sweeps per deck — each is one request returning `BATCH_SIZE` files. */
 const MAX_BATCHES = 4
-const BATCH_SIZE = 50
+/**
+ * Category members per sweep.
+ *
+ * Commons rate-limits by request, not by result, so a wide window is the cheap
+ * way to see more of the category: 500 members is one request where ten sweeps
+ * of 50 would be ten, and a deck drawn from a 500-file slice spans many more
+ * uploaders than one drawn from a 50-file slice — which is usually a single
+ * photographer's series.
+ */
+const BATCH_SIZE = 500
 const REQUEST_TIMEOUT_MS = 12000
 /** Breather between sweeps; a burst of requests is what trips Commons' 429. */
 const BATCH_PAUSE_MS = 350
+/**
+ * Rounds one sweep may contribute before the deck moves to another window.
+ *
+ * A window is a contiguous run of the category, and contiguous runs are one
+ * photographer's series — a hundred burial mounds, one library's reading rooms.
+ * Those clear the separation rule (they are kilometres apart) while still
+ * handing the player five versions of the same photograph, so a deck that comes
+ * from one window is a deck that barely changes.
+ *
+ * Three per sweep costs a five-round deck a second window and leaves half the
+ * sweep budget spare for windows that come back thin or rate-limited. Tighter
+ * caps were measured and are worse: at two per sweep the deck needs three
+ * windows, which trips Commons' burst limit often enough to land back on the
+ * reserve — the very repetition the cap is here to prevent.
+ */
+const MAX_PER_BATCH = 3
 
 // Category members can be walked two ways. By sort key the corpus is dominated
 // by files named "Mapillary (<user>…", so most prefixes dive into street
@@ -224,6 +252,10 @@ async function collectCandidates(
   deps: RandomWorldDeps
 ): Promise<Candidate[]> {
   const picked: Candidate[] = []
+  // Usable finds the per-sweep cap turned away. A later sweep that comes back
+  // rate-limited would otherwise send the deck to the reserve while these sit
+  // unspent, so they finish it instead — at the cost of no extra request.
+  const spare: Candidate[] = []
   for (let batch = 0; batch < MAX_BATCHES && picked.length < count; batch++) {
     if (batch > 0) await pause(BATCH_PAUSE_MS)
     if (deps.signal?.aborted) break
@@ -240,6 +272,14 @@ async function collectCandidates(
           prop: 'imageinfo|coordinates',
           iiprop: 'size|mime|extmetadata',
           iiextmetadatafilter: 'Artist|LicenseShortName',
+          // The sweep's real bottleneck. `prop=coordinates` fills in only
+          // `colimit` pages per request and that defaults to *10*, so all but
+          // ten files of every window came back geotag-less and were dropped by
+          // `readCandidates` as if Commons had never geotagged them. That left
+          // too few usable finds to fill a deck, and the shortfall was topped
+          // up from the 25-photo offline reserve — the same panoramas, game
+          // after game.
+          colimit: 'max',
         },
         deps.signal
       )) as PagesResponse
@@ -247,12 +287,25 @@ async function collectCandidates(
       // A rate-limited or flaky sweep is not fatal — try the next window.
       continue
     }
+    let taken = 0
     for (const candidate of shuffle(readCandidates(response), random)) {
       if (picked.length >= count) break
       if (!farEnough(candidate, picked)) continue
+      if (taken >= MAX_PER_BATCH) {
+        spare.push(candidate)
+        continue
+      }
       picked.push(candidate)
+      taken += 1
       deps.onProgress?.(picked.length, count)
     }
+  }
+
+  for (const candidate of spare) {
+    if (picked.length >= count) break
+    if (!farEnough(candidate, picked)) continue
+    picked.push(candidate)
+    deps.onProgress?.(picked.length, count)
   }
   return picked
 }


### PR DESCRIPTION
Random World sweeps `Category:360° panoramas` for geotagged photospheres, but
`prop=coordinates` only fills in `colimit` pages per request and that defaults
to *10*. Every file past the tenth in a 50-file window came back with no
coordinates and was dropped by `readCandidates` as if Commons had never
geotagged it, so a sweep rarely surfaced more than one usable pin. Decks came
up short, `buildRandomWorldDeck` topped up the shortfall from the 25-photo
vendored reserve, and solo — the only always-Random-World mode — served the
same panoramas game after game.

Measured over eight consecutive decks against live Commons, before and after:

                    before          after
  deck source       4 live,         8 live
                    2 mixed,
                    2 reserve
  HTTP 429s         10              0
  sweeps            26              21
  distinct photos   34/40           40/40

`colimit=max` is the fix. Two changes keep it from trading one kind of
repetition for another:

- Sweeps widen from 50 members to 500. The rate limit counts requests, not
  results, so a wide window is the cheap way to see more of the category, and
  it is what lets a deck span several uploaders.
- No window may supply more than three of the five rounds. A contiguous run of
  the category is one photographer's series, and a hundred burial mounds clear
  the 50 km separation rule while still being five versions of one photograph.
  Uncapped, decks collapsed onto a single series (9 distinct countries across
  six games, against 17 with the cap). Finds the cap turns away are kept and
  spent if a later sweep is rate-limited, so variety never costs a live deck.

Two panorama tests asserted `globetrotter-pano-loading` was hidden straight
after the solo button — vacuously true on the scouting screen, which renders no
panorama at all. The extra sweep's latency turned that latent race into a
failure; both now wait for the board itself.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Np94PxDiJVDsQuu9DPuCNy