### PR TITLE
Skribbl: stop routing every brush stroke through Postgres

### DIFF
--- a/e2e/games/skribbl.spec.ts
+++ b/e2e/games/skribbl.spec.ts
@@ -10,14 +10,6 @@ type SkribblPlayer = {
   avatar: number
 }
 
-type DrawPoint = {
-  x: number
-  y: number
-  color: string
-  size: number
-  tool: 'pen' | 'eraser'
-}
-
 type SkribblState = {
   phase: 'lobby' | 'picking' | 'drawing' | 'round-end' | 'finished'
   players: SkribblPlayer[]
@@ -27,7 +19,6 @@ type SkribblState = {
   word: string | null
   wordChoices: string[]
   hint: string
-  strokes: Array<{ points: DrawPoint[] }>
   messages: Array<{
     id: string
     playerId: string
@@ -96,14 +87,6 @@ function seededDrawingState(players: SkribblPlayer[]): SkribblState {
     word: encodeWord('apple'),
     wordChoices: [],
     hint: '_ _ _ _ _',
-    strokes: [
-      {
-        points: [
-          { x: 100, y: 100, color: '#000000', size: 6, tool: 'pen' },
-          { x: 180, y: 160, color: '#000000', size: 6, tool: 'pen' },
-        ],
-      },
-    ],
     messages: [],
     guessedPlayers: [],
     drawStartTime: Date.now(),

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -209,9 +209,12 @@ function broadcastFunctionAndTriggers() {
 -- realtime.send() INSERTs its payload into realtime.messages, shipping the state
 -- meant every update wrote the whole blob to Postgres a second time for nothing:
 -- with N players in a room, one action cost 1 state write + 1 state insert + N
--- state reads. Sending only the version keeps that insert tiny and lets clients
--- skip the refetch entirely when the signalled version is not ahead of what they
--- already hold. Do NOT put \`state\` back in here.
+-- state reads. Sending only the version drops that second write to a few bytes.
+-- Do NOT put \`state\` back in here.
+--
+-- The version is carried for observability only — clients must NOT use it to skip
+-- the refetch, since their local version is advanced optimistically and can match
+-- a version whose authoritative state differs. See the note in useGameRoom.
 
 create or replace function public.broadcast_room_state()
 returns trigger

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -196,12 +196,22 @@ function broadcastFunctionAndTriggers() {
   for each row execute function public.broadcast_room_state();`
   ).join('\n\n')
   return `-- ─── Shared broadcast trigger function ───────────────────────────────────────
--- Emits the full {state, version} on the PUBLIC topic \`room:CODE\` after every
--- state UPDATE (ACCESS-05, D-09 full payload, D-11 secret-topic model). The 4th
--- arg to realtime.send MUST be \`false\` → PUBLIC channel that any anon client may
--- subscribe to without a JWT or RLS on realtime.messages. Do NOT use
--- realtime.broadcast_changes() (hardwired private) and do NOT pass true here.
+-- Emits {version} on the PUBLIC topic \`room:CODE\` after every state UPDATE
+-- (ACCESS-05, D-11 secret-topic model). The 4th arg to realtime.send MUST be
+-- \`false\` → PUBLIC channel that any anon client may subscribe to without a JWT or
+-- RLS on realtime.messages. Do NOT use realtime.broadcast_changes() (hardwired
+-- private) and do NOT pass true here.
 -- search_path = '' forces fully-qualified public./realtime. names (lint 0011).
+--
+-- This is a SIGNAL, not a state transfer. It used to carry the full \`new.state\`,
+-- but the client never trusted that payload — the topic is public, so it always
+-- re-read authoritative state through get_<game> anyway (CR-03). Since
+-- realtime.send() INSERTs its payload into realtime.messages, shipping the state
+-- meant every update wrote the whole blob to Postgres a second time for nothing:
+-- with N players in a room, one action cost 1 state write + 1 state insert + N
+-- state reads. Sending only the version keeps that insert tiny and lets clients
+-- skip the refetch entirely when the signalled version is not ahead of what they
+-- already hold. Do NOT put \`state\` back in here.
 
 create or replace function public.broadcast_room_state()
 returns trigger
@@ -211,7 +221,7 @@ set search_path = ''
 as $$
 begin
   perform realtime.send(
-    jsonb_build_object('state', new.state, 'version', new.version),
+    jsonb_build_object('version', new.version),
     'state',                       -- event name (client .on('broadcast',{event:'state'}))
     'room:' || new.code,           -- topic = the room code (the secret)
     false                          -- private=false → PUBLIC channel (anon-subscribable)
@@ -494,6 +504,41 @@ function getRpcHeader() {
 -- code-holder. Competitive integrity is honor-system; see README.`
 }
 
+function cleanupJob() {
+  const deletes = GAMES.map(
+    (g) =>
+      `  delete from public.${g.table} where updated_at < now() - interval '24 hours';`
+  ).join('\n')
+  return `-- ─── Scheduled room cleanup (pg_cron) ────────────────────────────────────────
+-- Rooms are never deleted by clients (there is no DELETE policy). Two mechanisms
+-- reclaim them: the opportunistic bounded delete on each create_<game> path, and
+-- this hourly sweep.
+--
+-- The sweep previously covered ONLY uno_rooms, so the other ${GAMES.length - 1} tables
+-- accumulated rooms indefinitely. This function is generated from the GAMES list,
+-- so a new online game is swept automatically.
+
+create extension if not exists pg_cron;
+
+create or replace function public.cleanup_stale_rooms()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+${deletes}
+end;
+$$;
+
+revoke all on function public.cleanup_stale_rooms() from public;
+
+-- Replace any earlier per-table job with the one that sweeps every table.
+select cron.unschedule(jobid) from cron.job where command like '%_rooms where updated_at%';
+select cron.unschedule(jobid) from cron.job where jobname = 'cleanup-stale-rooms';
+select cron.schedule('cleanup-stale-rooms', '0 * * * *', 'select public.cleanup_stale_rooms()');`
+}
+
 function build() {
   const parts = []
   parts.push(header())
@@ -513,6 +558,7 @@ function build() {
   }
   parts.push(getRpcHeader())
   for (const g of GAMES) parts.push(getRpc(g))
+  parts.push(cleanupJob())
   return parts.join('\n\n') + '\n'
 }
 

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -509,8 +509,7 @@ function getRpcHeader() {
 
 function cleanupJob() {
   const deletes = GAMES.map(
-    (g) =>
-      `  delete from public.${g.table} where updated_at < now() - interval '24 hours';`
+    (g) => `  delete from public.${g.table} where updated_at < now() - interval '24 hours';`
   ).join('\n')
   return `-- ─── Scheduled room cleanup (pg_cron) ────────────────────────────────────────
 -- Rooms are never deleted by clients (there is no DELETE policy). Two mechanisms

--- a/src/games/skribbl/SkribblGame.tsx
+++ b/src/games/skribbl/SkribblGame.tsx
@@ -18,13 +18,16 @@ import { RoomEntry } from '@/components/multiplayer/RoomEntry'
 import { DesyncIndicator } from '@/components/multiplayer/DesyncIndicator'
 import { useSkribblRoom, type UseSkribblRoomReturn } from './useSkribblRoom'
 import {
+  applyDrawMessage,
+  chunkSnapshot,
   decodeWord,
   getCurrentDrawer,
-  type DrawPoint,
+  type BroadcastMessage,
   type DrawStroke,
   type GameAction,
   type GameState,
 } from './logic'
+import { SNAPSHOT_CHUNK_SIZE } from './schema'
 import styles from './SkribblGame.module.css'
 
 const SKRIBBL_GENRE = games.find((g) => g.slug === 'skribbl')?.genre
@@ -203,10 +206,10 @@ function DrawingCanvas({
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const drawingRef = useRef(false)
-  const currentStrokeRef = useRef<DrawPoint[]>([])
+  const currentStrokeRef = useRef<DrawStroke | null>(null)
 
   const redraw = useCallback(
-    (preview?: DrawPoint[]) => {
+    (preview?: DrawStroke | null) => {
       const canvas = canvasRef.current
       if (!canvas) return
 
@@ -216,7 +219,7 @@ function DrawingCanvas({
       ctx.fillStyle = '#ffffff'
       ctx.fillRect(0, 0, canvas.width, canvas.height)
 
-      const allStrokes = preview && preview.length > 0 ? [...strokes, { points: preview }] : strokes
+      const allStrokes = preview ? [...strokes, preview] : strokes
 
       for (const stroke of allStrokes) {
         if (stroke.points.length === 0) continue
@@ -226,8 +229,8 @@ function DrawingCanvas({
         ctx.lineJoin = 'round'
 
         const first = stroke.points[0]
-        ctx.strokeStyle = first.tool === 'eraser' ? '#ffffff' : first.color
-        ctx.lineWidth = first.size
+        ctx.strokeStyle = stroke.tool === 'eraser' ? '#ffffff' : stroke.color
+        ctx.lineWidth = stroke.size
         ctx.moveTo(first.x, first.y)
 
         for (let index = 1; index < stroke.points.length; index += 1) {
@@ -259,9 +262,11 @@ function DrawingCanvas({
     const scaleY = canvas.height / rect.height
     const point = 'touches' in event ? event.touches[0] || event.changedTouches[0] : event
 
+    // Round to whole pixels — sub-pixel precision is invisible on an 800×560
+    // canvas but roughly doubles the JSON size of every point sent over the wire.
     return {
-      x: (point.clientX - rect.left) * scaleX,
-      y: (point.clientY - rect.top) * scaleY,
+      x: Math.round((point.clientX - rect.left) * scaleX),
+      y: Math.round((point.clientY - rect.top) * scaleY),
     }
   }
 
@@ -275,7 +280,7 @@ function DrawingCanvas({
     if (!position) return
 
     drawingRef.current = true
-    currentStrokeRef.current = [{ ...position, color, size, tool }]
+    currentStrokeRef.current = { points: [position], color, size, tool }
     redraw(currentStrokeRef.current)
   }
 
@@ -283,22 +288,30 @@ function DrawingCanvas({
     event: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
   ) {
     if (!isDrawer || !drawingRef.current) return
+    const stroke = currentStrokeRef.current
+    if (!stroke) return
     event.preventDefault()
 
     const position = getPosition(event)
     if (!position) return
 
-    currentStrokeRef.current.push({ ...position, color, size, tool })
-    redraw(currentStrokeRef.current)
+    // Drop points the pointer barely moved to. A mousemove stream emits far more
+    // samples than the drawing needs, and each one is payload.
+    const last = stroke.points[stroke.points.length - 1]
+    if (last && Math.abs(last.x - position.x) < 2 && Math.abs(last.y - position.y) < 2) return
+
+    stroke.points.push(position)
+    redraw(stroke)
   }
 
   function endStroke() {
     if (!isDrawer || !drawingRef.current) return
 
     drawingRef.current = false
-    if (currentStrokeRef.current.length > 0) {
-      onStrokeComplete({ points: currentStrokeRef.current })
-      currentStrokeRef.current = []
+    const stroke = currentStrokeRef.current
+    currentStrokeRef.current = null
+    if (stroke && stroke.points.length > 0) {
+      onStrokeComplete(stroke)
     }
   }
 
@@ -1069,14 +1082,22 @@ function GameBoardScreen({
   gameState,
   onlinePlayerIds,
   playerId,
+  strokes,
   onAction,
+  onClear,
   onLeave,
+  onStroke,
+  onUndo,
 }: {
   gameState: GameState
   onlinePlayerIds: string[]
   playerId: string
+  strokes: DrawStroke[]
   onAction: (action: GameAction) => void
+  onClear: () => void
   onLeave: () => void
+  onStroke: (stroke: DrawStroke) => void
+  onUndo: () => void
 }) {
   const [color, setColor] = useState('#000000')
   const [size, setSize] = useState(6)
@@ -1196,12 +1217,12 @@ function GameBoardScreen({
 
       <div className={styles.canvasColumn}>
         <DrawingCanvas
-          strokes={gameState.strokes}
+          strokes={strokes}
           isDrawer={isDrawer}
           color={tool === 'eraser' ? '#ffffff' : color}
           size={size}
           tool={tool}
-          onStrokeComplete={(stroke) => onAction({ type: 'ADD_STROKE', playerId, stroke })}
+          onStrokeComplete={onStroke}
         />
 
         {isDrawer ? (
@@ -1264,18 +1285,13 @@ function GameBoardScreen({
               >
                 <Eraser className="h-4 w-4" />
               </button>
-              <button
-                type="button"
-                title="Undo"
-                onClick={() => onAction({ type: 'UNDO_STROKE', playerId })}
-                className={styles.toolButton}
-              >
+              <button type="button" title="Undo" onClick={onUndo} className={styles.toolButton}>
                 <Undo2 className="h-4 w-4" />
               </button>
               <button
                 type="button"
                 title="Clear all"
-                onClick={() => onAction({ type: 'CLEAR_CANVAS', playerId })}
+                onClick={onClear}
                 className={cn(styles.toolButton, styles.toolButtonDanger)}
               >
                 <Trash2 className="h-4 w-4" />
@@ -1308,6 +1324,7 @@ export function SkribblGame() {
     process.env.NEXT_PUBLIC_E2E_FAKE_SUPABASE === '1' ? 'entry' : 'howto'
   )
   const {
+    broadcast,
     connectionStatus,
     createRoom,
     dispatch,
@@ -1315,6 +1332,7 @@ export function SkribblGame() {
     gameState,
     joinRoom,
     leaveRoom,
+    onBroadcast: onBroadcastRef,
     onlinePlayerIds,
     playerId,
     restoreSession,
@@ -1323,11 +1341,95 @@ export function SkribblGame() {
     status,
   } = useSkribblRoom()
 
+  // The canvas lives here, not in the room state: strokes are ephemeral and go
+  // over the broadcast channel so they never hit Postgres.
+  const [strokes, setStrokes] = useState<DrawStroke[]>([])
+  const strokesRef = useRef<DrawStroke[]>([])
+
+  const drawer = gameState ? getCurrentDrawer(gameState) : null
+  const drawerId = drawer?.id ?? null
+  const drawerIdRef = useRef<string | null>(null)
+
+  // Mirror render values into refs so the broadcast handler and the snapshot
+  // effect can read the latest without re-subscribing. Declared before the
+  // effects that consume them so they are always synced first.
+  useEffect(() => {
+    strokesRef.current = strokes
+  }, [strokes])
+
+  useEffect(() => {
+    drawerIdRef.current = drawerId
+  }, [drawerId])
+
   useEffect(() => {
     if (inviteCode) {
       setEntryMode('entry')
     }
   }, [inviteCode])
+
+  // Each turn starts on a blank canvas. Keyed on drawStartTime so a new turn
+  // clears it even when the same player draws again.
+  useEffect(() => {
+    setStrokes([])
+  }, [gameState?.drawStartTime])
+
+  // Incoming draw messages. applyDrawMessage drops anything not sent by the
+  // current drawer — the broadcast topic is public.
+  useEffect(() => {
+    if (!onBroadcastRef) return
+    onBroadcastRef.current = (message: BroadcastMessage) => {
+      setStrokes((current) => applyDrawMessage(current, message, drawerIdRef.current))
+    }
+    return () => {
+      onBroadcastRef.current = null
+    }
+  }, [onBroadcastRef])
+
+  const applyLocally = useCallback((message: BroadcastMessage) => {
+    setStrokes((current) => applyDrawMessage(current, message, drawerIdRef.current))
+    return message
+  }, [])
+
+  // The drawer applies its own strokes immediately (so the canvas never lags the
+  // pointer) and broadcasts the same message to everyone else.
+  const handleStroke = useCallback(
+    (stroke: DrawStroke) => {
+      if (!playerId || !broadcast) return
+      broadcast(applyLocally({ type: 'stroke', playerId, stroke }))
+    },
+    [applyLocally, broadcast, playerId]
+  )
+
+  const handleUndo = useCallback(() => {
+    if (!playerId || !broadcast) return
+    broadcast(applyLocally({ type: 'undo', playerId }))
+  }, [applyLocally, broadcast, playerId])
+
+  const handleClear = useCallback(() => {
+    if (!playerId || !broadcast) return
+    broadcast(applyLocally({ type: 'clear', playerId }))
+  }, [applyLocally, broadcast, playerId])
+
+  // Late joiners and reconnecting players would otherwise see a blank canvas,
+  // since nothing about the drawing is persisted. When presence reports someone
+  // new, the drawer re-sends the canvas in payload-sized chunks.
+  const knownPeersRef = useRef<string[]>([])
+  useEffect(() => {
+    const known = knownPeersRef.current
+    const newcomers = onlinePlayerIds.filter((id) => !known.includes(id))
+    knownPeersRef.current = onlinePlayerIds
+
+    if (newcomers.length === 0) return
+    if (!playerId || !broadcast) return
+    if (drawerId !== playerId) return
+    if (gameState?.phase !== 'drawing') return
+    // Nothing drawn yet — the newcomer's canvas is already blank.
+    if (strokesRef.current.length === 0) return
+
+    chunkSnapshot(strokesRef.current, SNAPSHOT_CHUNK_SIZE).forEach((chunk, index) => {
+      broadcast({ type: 'snapshot', playerId, strokes: chunk, reset: index === 0 })
+    })
+  }, [broadcast, drawerId, gameState?.phase, onlinePlayerIds, playerId])
 
   const crumb = makeCrumb(gameState, roomCode, playerId, inviteCode)
   const handleAction = useCallback(
@@ -1418,8 +1520,12 @@ export function SkribblGame() {
           gameState={gameState}
           onlinePlayerIds={onlinePlayerIds}
           playerId={playerId}
+          strokes={strokes}
           onAction={handleAction}
+          onClear={handleClear}
           onLeave={handleLeave}
+          onStroke={handleStroke}
+          onUndo={handleUndo}
         />
       ) : gameState.phase === 'round-end' ? (
         <RoundEndScreen

--- a/src/games/skribbl/logic.test.ts
+++ b/src/games/skribbl/logic.test.ts
@@ -1,8 +1,11 @@
 import {
   createLobbyState,
   addPlayer,
+  applyDrawMessage,
+  chunkSnapshot,
   removePlayer,
   applyAction,
+  MAX_STROKES,
   generateHint,
   revealHintLetters,
   calculateGuessScore,
@@ -11,6 +14,7 @@ import {
   getCurrentDrawer,
   encodeWord,
   decodeWord,
+  type DrawStroke,
   type Player,
   type GameState,
 } from './logic'
@@ -222,50 +226,98 @@ describe('PICK_WORD', () => {
   })
 })
 
-describe('ADD_STROKE / CLEAR_CANVAS / UNDO_STROKE', () => {
-  function drawingState(): GameState {
-    const state = startedGame()
-    const drawer = getCurrentDrawer(state)!
-    return applyAction(state, {
-      type: 'PICK_WORD',
-      playerId: drawer.id,
-      word: state.wordChoices[0],
-    })
-  }
-
-  it('drawer can add strokes', () => {
-    const state = drawingState()
-    const drawer = getCurrentDrawer(state)!
-    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
-    const next = applyAction(state, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
-    expect(next.strokes).toHaveLength(1)
+describe('applyDrawMessage', () => {
+  const DRAWER = 'drawer-1'
+  const stroke = (x = 0): DrawStroke => ({
+    points: [{ x, y: 0 }],
+    color: '#000',
+    size: 3,
+    tool: 'pen',
   })
 
-  it('non-drawer cannot add strokes', () => {
-    const state = drawingState()
-    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
-    const next = applyAction(state, { type: 'ADD_STROKE', playerId: 'p2', stroke })
-    expect(next.strokes).toHaveLength(0)
+  it('appends a stroke from the drawer', () => {
+    const next = applyDrawMessage(
+      [],
+      { type: 'stroke', playerId: DRAWER, stroke: stroke() },
+      DRAWER
+    )
+    expect(next).toHaveLength(1)
   })
 
-  it('drawer can clear canvas', () => {
-    const state = drawingState()
-    const drawer = getCurrentDrawer(state)!
-    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
-    let next = applyAction(state, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
-    next = applyAction(next, { type: 'CLEAR_CANVAS', playerId: drawer.id })
-    expect(next.strokes).toHaveLength(0)
+  it('ignores a stroke from anyone who is not the drawer', () => {
+    const next = applyDrawMessage([], { type: 'stroke', playerId: 'p2', stroke: stroke() }, DRAWER)
+    expect(next).toHaveLength(0)
   })
 
-  it('drawer can undo last stroke', () => {
-    const state = drawingState()
-    const drawer = getCurrentDrawer(state)!
-    const stroke = { points: [{ x: 0, y: 0, color: '#000', size: 3, tool: 'pen' as const }] }
-    let next = applyAction(state, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
-    next = applyAction(next, { type: 'ADD_STROKE', playerId: drawer.id, stroke })
-    expect(next.strokes).toHaveLength(2)
-    next = applyAction(next, { type: 'UNDO_STROKE', playerId: drawer.id })
-    expect(next.strokes).toHaveLength(1)
+  it('ignores everything when there is no drawer', () => {
+    const next = applyDrawMessage([], { type: 'stroke', playerId: DRAWER, stroke: stroke() }, null)
+    expect(next).toHaveLength(0)
+  })
+
+  it('undo removes the last stroke', () => {
+    const start = [stroke(1), stroke(2)]
+    const next = applyDrawMessage(start, { type: 'undo', playerId: DRAWER }, DRAWER)
+    expect(next).toHaveLength(1)
+    expect(next[0].points[0].x).toBe(1)
+  })
+
+  it('undo on an empty canvas is a no-op that preserves identity', () => {
+    const start: DrawStroke[] = []
+    expect(applyDrawMessage(start, { type: 'undo', playerId: DRAWER }, DRAWER)).toBe(start)
+  })
+
+  it('clear empties the canvas', () => {
+    const next = applyDrawMessage([stroke()], { type: 'clear', playerId: DRAWER }, DRAWER)
+    expect(next).toHaveLength(0)
+  })
+
+  it('a reset snapshot replaces the canvas', () => {
+    const next = applyDrawMessage(
+      [stroke(1)],
+      { type: 'snapshot', playerId: DRAWER, strokes: [stroke(9)], reset: true },
+      DRAWER
+    )
+    expect(next).toHaveLength(1)
+    expect(next[0].points[0].x).toBe(9)
+  })
+
+  it('a non-reset snapshot chunk appends to the canvas', () => {
+    const next = applyDrawMessage(
+      [stroke(1)],
+      { type: 'snapshot', playerId: DRAWER, strokes: [stroke(9)], reset: false },
+      DRAWER
+    )
+    expect(next.map((s) => s.points[0].x)).toEqual([1, 9])
+  })
+
+  it('caps the canvas at MAX_STROKES, dropping the oldest', () => {
+    const start = Array.from({ length: MAX_STROKES }, (_, index) => stroke(index))
+    const next = applyDrawMessage(
+      start,
+      { type: 'stroke', playerId: DRAWER, stroke: stroke(9999) },
+      DRAWER
+    )
+    expect(next).toHaveLength(MAX_STROKES)
+    expect(next[next.length - 1].points[0].x).toBe(9999)
+    expect(next[0].points[0].x).toBe(1)
+  })
+})
+
+describe('chunkSnapshot', () => {
+  const stroke = (): DrawStroke => ({
+    points: [{ x: 0, y: 0 }],
+    color: '#000',
+    size: 3,
+    tool: 'pen',
+  })
+
+  it('returns a single empty chunk for an empty canvas', () => {
+    expect(chunkSnapshot([], 40)).toEqual([[]])
+  })
+
+  it('splits strokes into chunks no larger than chunkSize', () => {
+    const chunks = chunkSnapshot(Array.from({ length: 95 }, stroke), 40)
+    expect(chunks.map((c) => c.length)).toEqual([40, 40, 15])
   })
 })
 

--- a/src/games/skribbl/logic.ts
+++ b/src/games/skribbl/logic.ts
@@ -1,7 +1,7 @@
 import skribblWords from '@/data/words/skribbl-words.json'
 import { shuffle } from '@/lib/shuffle'
-import type { GameState } from './schema'
-export type { GameState }
+import type { BroadcastMessage, GameState } from './schema'
+export type { BroadcastMessage, GameState }
 
 let msgCounter = 0
 function generateMsgId(): string {
@@ -35,28 +35,80 @@ export interface ChatMessage {
 export interface DrawPoint {
   x: number
   y: number
+}
+
+export interface DrawStroke {
+  points: DrawPoint[]
   color: string
   size: number
   tool: 'pen' | 'eraser'
 }
 
-export interface DrawStroke {
-  points: DrawPoint[]
-}
+// Chat is capped so a long game cannot grow the persisted state without bound —
+// every write rewrites the whole blob, so an unbounded array makes each message
+// cost more than the last.
+export const MAX_MESSAGES = 60
+
+// Ceiling on locally-held strokes. Drawing past this drops the oldest strokes
+// rather than letting one turn's canvas grow without limit.
+export const MAX_STROKES = 600
 
 export type GameAction =
   | { type: 'START_GAME'; playerId: string }
   | { type: 'UPDATE_SETTINGS'; playerId: string; totalRounds?: number; turnDuration?: number }
   | { type: 'REMOVE_PLAYER'; playerId: string; targetPlayerId: string }
   | { type: 'PICK_WORD'; playerId: string; word: string }
-  | { type: 'ADD_STROKE'; playerId: string; stroke: DrawStroke }
-  | { type: 'CLEAR_CANVAS'; playerId: string }
-  | { type: 'UNDO_STROKE'; playerId: string }
   | { type: 'GUESS'; playerId: string; text: string }
   | { type: 'REVEAL_HINT'; playerId: string; ratio: number }
   | { type: 'END_TURN'; playerId: string }
   | { type: 'NEXT_TURN'; playerId: string }
   | { type: 'PLAY_AGAIN'; playerId: string }
+
+// ─── Drawing (broadcast, never persisted) ────────────────────────────────────
+
+// Fold an incoming draw broadcast into the local canvas. Pure so it can be unit
+// tested and so the same reducer runs for the drawer's own optimistic updates and
+// for peers receiving them.
+//
+// `drawerId` is the authority check: the broadcast topic is public, so a message
+// from anyone who is not the current drawer is dropped. A null drawerId (no
+// active turn) drops everything.
+export function applyDrawMessage(
+  strokes: DrawStroke[],
+  message: BroadcastMessage,
+  drawerId: string | null
+): DrawStroke[] {
+  if (!drawerId || message.playerId !== drawerId) return strokes
+
+  if (message.type === 'stroke') {
+    return [...strokes, message.stroke].slice(-MAX_STROKES)
+  }
+
+  if (message.type === 'undo') {
+    if (strokes.length === 0) return strokes
+    return strokes.slice(0, -1)
+  }
+
+  if (message.type === 'clear') {
+    if (strokes.length === 0) return strokes
+    return []
+  }
+
+  // snapshot: the first chunk replaces the canvas, subsequent chunks extend it.
+  const base = message.reset ? [] : strokes
+  return [...base, ...message.strokes].slice(-MAX_STROKES)
+}
+
+// Split a canvas into broadcast-sized chunks. Always yields at least one chunk so
+// an empty canvas still clears a late joiner's stale strokes.
+export function chunkSnapshot(strokes: DrawStroke[], chunkSize: number): DrawStroke[][] {
+  if (strokes.length === 0) return [[]]
+  const chunks: DrawStroke[][] = []
+  for (let index = 0; index < strokes.length; index += chunkSize) {
+    chunks.push(strokes.slice(index, index + chunkSize))
+  }
+  return chunks
+}
 
 // ─── Word list ────────────────────────────────────────────────────────────────
 
@@ -172,7 +224,6 @@ export function createLobbyState(host: Player): GameState {
     word: null,
     wordChoices: [],
     hint: '',
-    strokes: [],
     messages: [],
     guessedPlayers: [],
     drawStartTime: null,
@@ -211,7 +262,6 @@ function startPickingPhase(state: GameState): GameState {
     wordChoices: choices.map(encodeWord),
     word: null,
     hint: '',
-    strokes: [],
     messages: [],
     guessedPlayers: [],
     drawStartTime: null,
@@ -319,28 +369,6 @@ export function applyAction(state: GameState, action: GameAction): GameState {
     }
   }
 
-  if (action.type === 'ADD_STROKE') {
-    if (state.phase !== 'drawing') return state
-    const drawer = getCurrentDrawer(state)
-    if (drawer?.id !== action.playerId) return state
-    return { ...state, strokes: [...state.strokes, action.stroke] }
-  }
-
-  if (action.type === 'CLEAR_CANVAS') {
-    if (state.phase !== 'drawing') return state
-    const drawer = getCurrentDrawer(state)
-    if (drawer?.id !== action.playerId) return state
-    return { ...state, strokes: [] }
-  }
-
-  if (action.type === 'UNDO_STROKE') {
-    if (state.phase !== 'drawing') return state
-    const drawer = getCurrentDrawer(state)
-    if (drawer?.id !== action.playerId) return state
-    if (state.strokes.length === 0) return state
-    return { ...state, strokes: state.strokes.slice(0, -1) }
-  }
-
   if (action.type === 'GUESS') {
     if (state.phase !== 'drawing') return state
     const drawer = getCurrentDrawer(state)
@@ -391,7 +419,7 @@ export function applyAction(state: GameState, action: GameAction): GameState {
         ...state,
         players,
         guessedPlayers: newGuessedPlayers,
-        messages: [...state.messages, msg],
+        messages: [...state.messages, msg].slice(-MAX_MESSAGES),
         scoreDeltas: {
           ...state.scoreDeltas,
           [action.playerId]: guessScore,
@@ -418,7 +446,7 @@ export function applyAction(state: GameState, action: GameAction): GameState {
       text: action.text.trim(),
       isClose: isCloseGuess(guess, answer),
     }
-    return { ...state, messages: [...state.messages, msg] }
+    return { ...state, messages: [...state.messages, msg].slice(-MAX_MESSAGES) }
   }
 
   if (action.type === 'REVEAL_HINT') {

--- a/src/games/skribbl/schema.test.ts
+++ b/src/games/skribbl/schema.test.ts
@@ -1,4 +1,4 @@
-import { GameStateSchema } from './schema'
+import { BroadcastMessageSchema, GameStateSchema, SNAPSHOT_CHUNK_SIZE } from './schema'
 
 const validGameState = {
   phase: 'lobby' as const,
@@ -9,7 +9,6 @@ const validGameState = {
   word: null,
   wordChoices: [],
   hint: '',
-  strokes: [],
   messages: [],
   guessedPlayers: [],
   drawStartTime: null,
@@ -23,14 +22,13 @@ describe('skribbl GameStateSchema', () => {
     expect(GameStateSchema.safeParse(validGameState).success).toBe(true)
   })
 
-  it('accepts a drawing state with strokes and messages', () => {
+  it('accepts a drawing state with messages', () => {
     const state = {
       ...validGameState,
       phase: 'drawing' as const,
       word: 'cat',
       hint: '_ _ _',
       drawStartTime: Date.now(),
-      strokes: [{ points: [{ x: 10, y: 20, color: '#000', size: 4, tool: 'pen' as const }] }],
       messages: [
         {
           id: 'msg1',
@@ -57,12 +55,14 @@ describe('skribbl GameStateSchema', () => {
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
   })
 
-  it('rejects a draw point with an invalid tool', () => {
-    const invalid = {
+  it('rejects a state that still carries strokes', () => {
+    // Strokes are broadcast-only now; a room row must never grow a canvas again.
+    const parsed = GameStateSchema.safeParse({
       ...validGameState,
-      strokes: [{ points: [{ x: 10, y: 20, color: '#000', size: 4, tool: 'spray' }] }],
-    }
-    expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+      strokes: [{ points: [{ x: 1, y: 2 }], color: '#000', size: 4, tool: 'pen' }],
+    })
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && 'strokes' in parsed.data).toBe(false)
   })
 
   it('accepts a player name with an emoji', () => {
@@ -79,5 +79,56 @@ describe('skribbl GameStateSchema', () => {
       players: [{ id: 'p1', name: 'a'.repeat(21), isHost: true, score: 0, avatar: 0 }],
     }
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
+  })
+})
+
+describe('skribbl BroadcastMessageSchema', () => {
+  const stroke = { points: [{ x: 10, y: 20 }], color: '#000', size: 4, tool: 'pen' as const }
+
+  it('accepts a stroke message', () => {
+    expect(
+      BroadcastMessageSchema.safeParse({ type: 'stroke', playerId: 'p1', stroke }).success
+    ).toBe(true)
+  })
+
+  it('accepts undo and clear messages', () => {
+    expect(BroadcastMessageSchema.safeParse({ type: 'undo', playerId: 'p1' }).success).toBe(true)
+    expect(BroadcastMessageSchema.safeParse({ type: 'clear', playerId: 'p1' }).success).toBe(true)
+  })
+
+  it('accepts a snapshot chunk', () => {
+    expect(
+      BroadcastMessageSchema.safeParse({
+        type: 'snapshot',
+        playerId: 'p1',
+        strokes: [stroke],
+        reset: true,
+      }).success
+    ).toBe(true)
+  })
+
+  it('rejects a snapshot larger than one chunk', () => {
+    expect(
+      BroadcastMessageSchema.safeParse({
+        type: 'snapshot',
+        playerId: 'p1',
+        strokes: Array.from({ length: SNAPSHOT_CHUNK_SIZE + 1 }, () => stroke),
+        reset: true,
+      }).success
+    ).toBe(false)
+  })
+
+  it('rejects an invalid tool', () => {
+    expect(
+      BroadcastMessageSchema.safeParse({
+        type: 'stroke',
+        playerId: 'p1',
+        stroke: { ...stroke, tool: 'spray' },
+      }).success
+    ).toBe(false)
+  })
+
+  it('rejects an unknown message type', () => {
+    expect(BroadcastMessageSchema.safeParse({ type: 'wipe', playerId: 'p1' }).success).toBe(false)
   })
 })

--- a/src/games/skribbl/schema.ts
+++ b/src/games/skribbl/schema.ts
@@ -10,16 +10,19 @@ const PlayerSchema = z.object({
   avatar: z.number().int().min(0).max(7).default(0),
 })
 
+// A point is only a coordinate. `color`/`size`/`tool` are constant for the whole
+// stroke, so they live on the stroke — repeating them per point roughly
+// quintupled the wire size of every drawing.
 const DrawPointSchema = z.object({
   x: z.number(),
   y: z.number(),
-  color: z.string(),
-  size: z.number(),
-  tool: z.enum(['pen', 'eraser']),
 })
 
 const DrawStrokeSchema = z.object({
-  points: z.array(DrawPointSchema),
+  points: z.array(DrawPointSchema).max(4000),
+  color: z.string().max(32),
+  size: z.number(),
+  tool: z.enum(['pen', 'eraser']),
 })
 
 const ChatMessageSchema = z.object({
@@ -32,6 +35,12 @@ const ChatMessageSchema = z.object({
   isClose: z.boolean().optional(),
 })
 
+// NOTE: `strokes` is deliberately NOT part of the persisted state. Drawing is the
+// highest-frequency event in the game and every state write rewrites the whole
+// jsonb blob, re-inserts it into realtime.messages, and is re-read by every
+// player — so persisting a growing stroke array made a round cost O(strokes²) in
+// database I/O. Strokes now travel over the ephemeral broadcast channel instead
+// (see BroadcastMessageSchema) and never touch Postgres.
 export const GameStateSchema = z.object({
   phase: z.enum(['lobby', 'picking', 'drawing', 'round-end', 'finished']),
   players: z.array(PlayerSchema),
@@ -41,7 +50,6 @@ export const GameStateSchema = z.object({
   word: z.string().nullable(),
   wordChoices: z.array(z.string()),
   hint: z.string(),
-  strokes: z.array(DrawStrokeSchema),
   messages: z.array(ChatMessageSchema),
   guessedPlayers: z.array(z.string()),
   drawStartTime: z.number().nullable(),
@@ -50,4 +58,36 @@ export const GameStateSchema = z.object({
   scoreDeltas: z.record(z.string(), z.number()).default({}),
 })
 
+// Max strokes carried by a single `snapshot` message. A full canvas is sent as
+// however many chunks it takes, so one message can never exceed Realtime's
+// payload ceiling no matter how much the drawer has scribbled.
+export const SNAPSHOT_CHUNK_SIZE = 40
+
+// The broadcast topic is public — any client that knows the room code can post to
+// it. Receivers must therefore both `safeParse` this schema AND check that
+// `playerId` is the current drawer before applying anything.
+export const BroadcastMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('stroke'),
+    playerId: z.string(),
+    stroke: DrawStrokeSchema,
+  }),
+  z.object({
+    type: z.literal('undo'),
+    playerId: z.string(),
+  }),
+  z.object({
+    type: z.literal('clear'),
+    playerId: z.string(),
+  }),
+  z.object({
+    type: z.literal('snapshot'),
+    playerId: z.string(),
+    strokes: z.array(DrawStrokeSchema).max(SNAPSHOT_CHUNK_SIZE),
+    // First chunk of a snapshot replaces the canvas; later chunks append to it.
+    reset: z.boolean(),
+  }),
+])
+
 export type GameState = z.infer<typeof GameStateSchema>
+export type BroadcastMessage = z.infer<typeof BroadcastMessageSchema>

--- a/src/games/skribbl/useSkribblRoom.ts
+++ b/src/games/skribbl/useSkribblRoom.ts
@@ -5,18 +5,16 @@ import {
   addPlayer,
   applyAction,
   createLobbyState,
+  type BroadcastMessage,
   type GameAction,
   type GameState,
   type Player,
 } from './logic'
-import { GameStateSchema } from './schema'
+import { BroadcastMessageSchema, GameStateSchema } from './schema'
 
 export type { RoomStatus } from '@/hooks/useGameRoom'
 
-export type UseSkribblRoomReturn = Omit<
-  UseGameRoomReturn<GameState, GameAction>,
-  'broadcast' | 'onBroadcast'
->
+export type UseSkribblRoomReturn = UseGameRoomReturn<GameState, GameAction, BroadcastMessage>
 
 function resolveAvatar(extras?: Record<string, unknown>, playerIndex = 0): number {
   const avatar = extras?.avatar
@@ -27,7 +25,7 @@ function resolveAvatar(extras?: Record<string, unknown>, playerIndex = 0): numbe
 }
 
 export function useSkribblRoom(): UseSkribblRoomReturn {
-  return useGameRoom<GameState, GameAction>({
+  return useGameRoom<GameState, GameAction, BroadcastMessage>({
     tableName: 'skribbl_rooms',
     channelPrefix: 'skribbl',
     sessionKey: 'skribbl_session',
@@ -43,5 +41,11 @@ export function useSkribblRoom(): UseSkribblRoomReturn {
         avatar: resolveAvatar(extras, playerIndex),
       }) as Player,
     addPlayer,
+    // Strokes are ephemeral and go peer-to-peer over Realtime — they are never
+    // written to Postgres. See the note on GameStateSchema.
+    broadcast: {
+      channelPrefix: 'skribbl-draw',
+      schema: BroadcastMessageSchema,
+    },
   })
 }

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -9,6 +9,12 @@ import type { ZodType } from 'zod'
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000
 
+// A burst of writes (several players acting at once) fires one broadcast signal
+// per write, and every client answers each signal with its own SELECT — so read
+// load grows as writes × players. Collapsing signals inside this window turns a
+// burst into a single read without making the UI feel laggy.
+const REFETCH_DEBOUNCE_MS = 120
+
 // Runtime guard for presence rows crossing the (untrusted) presence channel into React.
 // Strictly stronger than the previous unchecked player_id cast: a malformed presence row is
 // now filtered out instead of blindly trusted (T-04-02).
@@ -233,6 +239,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
   const onBroadcastRef = useRef<((message: TBroadcast) => void) | null>(null)
   const gameStateRef = useRef<TState | null>(null)
   const versionRef = useRef(0)
+  const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Per-room write capability for the dispatch RPC; set by create/join/restore (D-01..D-04).
   const roomTokenRef = useRef('')
 
@@ -335,14 +342,30 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         if (row) applyIfNewer(row.state, row.version)
       }
 
+      // Coalesce a burst of signals into one read (REFETCH_DEBOUNCE_MS).
+      const scheduleRefetch = () => {
+        if (refetchTimerRef.current !== null) return
+        refetchTimerRef.current = setTimeout(() => {
+          refetchTimerRef.current = null
+          void refetchAuthoritativeState()
+        }, REFETCH_DEBOUNCE_MS)
+      }
+
       // State sync is broadcast-signalled now (ACCESS-05, D-08): the postgres_changes UPDATE
       // arm is gone. Subscribe to the plan-01 trigger's public `room:CODE` topic, event
       // 'state', and use it only as a wakeup to refetch authoritative state.
       stateChannelRef.current?.unsubscribe()
       stateChannelRef.current = supabaseClient
         .channel(`room:${code}`)
-        .on('broadcast', { event: 'state' }, () => {
-          void refetchAuthoritativeState()
+        .on('broadcast', { event: 'state' }, (payload: { payload?: { version?: unknown } }) => {
+          // The signal carries only the new version — never trusted state. When it
+          // is not ahead of what we hold there is nothing to fetch, which skips the
+          // writer refetching the echo of its own optimistic update. A forged
+          // version can only cost an extra read: the value written to versionRef
+          // still comes from the authoritative SELECT (CR-03).
+          const signalled = payload?.payload?.version
+          if (typeof signalled === 'number' && signalled <= versionRef.current) return
+          scheduleRefetch()
         })
         // Refetch-on-reconnect (D-10): on (re)subscribe, re-read the current {state, version}
         // through the code-gated get_<game> RPC, recovering any signal missed while
@@ -682,6 +705,10 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
         })
       }
     } finally {
+      if (refetchTimerRef.current !== null) {
+        clearTimeout(refetchTimerRef.current)
+        refetchTimerRef.current = null
+      }
       stateChannelRef.current?.unsubscribe()
       stateChannelRef.current = null
       broadcastChannelRef.current?.unsubscribe()
@@ -712,6 +739,10 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     // both events firing, or an event followed by the unmount cleanup below — is a no-op (D-08).
     // MUST NOT clearSession / setStatus / setPlayerId / setGameState / setOnlinePlayerIds.
     const teardown = () => {
+      if (refetchTimerRef.current !== null) {
+        clearTimeout(refetchTimerRef.current)
+        refetchTimerRef.current = null
+      }
       stateChannelRef.current?.unsubscribe()
       stateChannelRef.current = null
       broadcastChannelRef.current?.unsubscribe()
@@ -745,6 +776,7 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
 
   useEffect(() => {
     return () => {
+      if (refetchTimerRef.current !== null) clearTimeout(refetchTimerRef.current)
       stateChannelRef.current?.unsubscribe()
       broadcastChannelRef.current?.unsubscribe()
       presenceChannelRef.current?.unsubscribe()

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -357,14 +357,15 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
       stateChannelRef.current?.unsubscribe()
       stateChannelRef.current = supabaseClient
         .channel(`room:${code}`)
-        .on('broadcast', { event: 'state' }, (payload: { payload?: { version?: unknown } }) => {
-          // The signal carries only the new version — never trusted state. When it
-          // is not ahead of what we hold there is nothing to fetch, which skips the
-          // writer refetching the echo of its own optimistic update. A forged
-          // version can only cost an extra read: the value written to versionRef
-          // still comes from the authoritative SELECT (CR-03).
-          const signalled = payload?.payload?.version
-          if (typeof signalled === 'number' && signalled <= versionRef.current) return
+        .on('broadcast', { event: 'state' }, () => {
+          // Treat the signal purely as a wakeup and ALWAYS re-read. It is tempting to
+          // also skip the read when the signalled version is not ahead of versionRef
+          // — but do not. versionRef is advanced OPTIMISTICALLY by dispatch (and by
+          // joinRoom's `?? currentVersion + 1` fallback), so it can already equal a
+          // version whose authoritative state differs from what we hold. Skipping
+          // there makes that divergence permanently invisible, because no later
+          // signal for that version ever arrives. Measured: skipping cost 2/12 E2E
+          // runs to a hung room; always reading is 0/12.
           scheduleRefetch()
         })
         // Refetch-on-reconnect (D-10): on (re)subscribe, re-read the current {state, version}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -284,9 +284,12 @@ alter table public.globetrotter_rooms add column if not exists room_token uuid n
 -- realtime.send() INSERTs its payload into realtime.messages, shipping the state
 -- meant every update wrote the whole blob to Postgres a second time for nothing:
 -- with N players in a room, one action cost 1 state write + 1 state insert + N
--- state reads. Sending only the version keeps that insert tiny and lets clients
--- skip the refetch entirely when the signalled version is not ahead of what they
--- already hold. Do NOT put `state` back in here.
+-- state reads. Sending only the version drops that second write to a few bytes.
+-- Do NOT put `state` back in here.
+--
+-- The version is carried for observability only — clients must NOT use it to skip
+-- the refetch, since their local version is advanced optimistically and can match
+-- a version whose authoritative state differs. See the note in useGameRoom.
 
 create or replace function public.broadcast_room_state()
 returns trigger

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -271,12 +271,22 @@ alter table public.mindmeld_rooms add column if not exists room_token uuid not n
 alter table public.globetrotter_rooms add column if not exists room_token uuid not null default gen_random_uuid();
 
 -- ─── Shared broadcast trigger function ───────────────────────────────────────
--- Emits the full {state, version} on the PUBLIC topic `room:CODE` after every
--- state UPDATE (ACCESS-05, D-09 full payload, D-11 secret-topic model). The 4th
--- arg to realtime.send MUST be `false` → PUBLIC channel that any anon client may
--- subscribe to without a JWT or RLS on realtime.messages. Do NOT use
--- realtime.broadcast_changes() (hardwired private) and do NOT pass true here.
+-- Emits {version} on the PUBLIC topic `room:CODE` after every state UPDATE
+-- (ACCESS-05, D-11 secret-topic model). The 4th arg to realtime.send MUST be
+-- `false` → PUBLIC channel that any anon client may subscribe to without a JWT or
+-- RLS on realtime.messages. Do NOT use realtime.broadcast_changes() (hardwired
+-- private) and do NOT pass true here.
 -- search_path = '' forces fully-qualified public./realtime. names (lint 0011).
+--
+-- This is a SIGNAL, not a state transfer. It used to carry the full `new.state`,
+-- but the client never trusted that payload — the topic is public, so it always
+-- re-read authoritative state through get_<game> anyway (CR-03). Since
+-- realtime.send() INSERTs its payload into realtime.messages, shipping the state
+-- meant every update wrote the whole blob to Postgres a second time for nothing:
+-- with N players in a room, one action cost 1 state write + 1 state insert + N
+-- state reads. Sending only the version keeps that insert tiny and lets clients
+-- skip the refetch entirely when the signalled version is not ahead of what they
+-- already hold. Do NOT put `state` back in here.
 
 create or replace function public.broadcast_room_state()
 returns trigger
@@ -286,7 +296,7 @@ set search_path = ''
 as $$
 begin
   perform realtime.send(
-    jsonb_build_object('state', new.state, 'version', new.version),
+    jsonb_build_object('version', new.version),
     'state',                       -- event name (client .on('broadcast',{event:'state'}))
     'room:' || new.code,           -- topic = the room code (the secret)
     false                          -- private=false → PUBLIC channel (anon-subscribable)
@@ -1905,3 +1915,38 @@ $$;
 
 revoke all on function public.get_globetrotter(text) from public;
 grant execute on function public.get_globetrotter(text) to anon;
+
+-- ─── Scheduled room cleanup (pg_cron) ────────────────────────────────────────
+-- Rooms are never deleted by clients (there is no DELETE policy). Two mechanisms
+-- reclaim them: the opportunistic bounded delete on each create_<game> path, and
+-- this hourly sweep.
+--
+-- The sweep previously covered ONLY uno_rooms, so the other 6 tables
+-- accumulated rooms indefinitely. This function is generated from the GAMES list,
+-- so a new online game is swept automatically.
+
+create extension if not exists pg_cron;
+
+create or replace function public.cleanup_stale_rooms()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  delete from public.uno_rooms where updated_at < now() - interval '24 hours';
+  delete from public.skribbl_rooms where updated_at < now() - interval '24 hours';
+  delete from public.agario_rooms where updated_at < now() - interval '24 hours';
+  delete from public.cah_rooms where updated_at < now() - interval '24 hours';
+  delete from public.codenames_rooms where updated_at < now() - interval '24 hours';
+  delete from public.mindmeld_rooms where updated_at < now() - interval '24 hours';
+  delete from public.globetrotter_rooms where updated_at < now() - interval '24 hours';
+end;
+$$;
+
+revoke all on function public.cleanup_stale_rooms() from public;
+
+-- Replace any earlier per-table job with the one that sweeps every table.
+select cron.unschedule(jobid) from cron.job where command like '%_rooms where updated_at%';
+select cron.unschedule(jobid) from cron.job where jobname = 'cleanup-stale-rooms';
+select cron.schedule('cleanup-stale-rooms', '0 * * * *', 'select public.cleanup_stale_rooms()');


### PR DESCRIPTION
## Why

Five people playing Skribbl saturated the Supabase database and started returning 504s across the whole project — including unrelated calls like `create_skribbl`.

Every brush stroke cost roughly **7 copies of the full room state** through Postgres:

1. `ADD_STROKE` rewrote the entire state jsonb, and the strokes array only grows during a turn (largest row observed on the live project: **23,665 bytes**)
2. `broadcast_room_state()` passed that same full state to `realtime.send()`, which **INSERTs its payload into `realtime.messages`** — a second full copy written to the database
3. Every client discarded that payload and re-read the row through `get_<game>`, because the `room:CODE` topic is public and its payload is not trustworthy (CR-03)

Since the array grew with each stroke, a turn was **O(strokes²)** in database I/O. Once CPU was pinned, the CAS retry loop piled on (~100 `version conflict` errors inside a 113ms window).

Skribbl was the only high-frequency game still routing this through the database — Agario and Globetrotter already use the ephemeral broadcast channel.

## What changed

**Strokes never touch Postgres.** They leave `GameState` entirely and travel over the broadcast channel; the canvas is local React state.

- `applyDrawMessage()` is a pure reducer for incoming draw messages, and drops anything not sent by the current drawer (the topic is public, so senders are untrusted)
- The drawer re-broadcasts the canvas in chunks when presence reports a new peer, so reconnecting mid-round no longer shows a blank canvas
- `color`/`size`/`tool` move from every point onto the stroke, and points are rounded to whole pixels and deduplicated — roughly 5× less on the wire

**Alongside that:**

- `broadcast_room_state()` sends `{version}` instead of `{state, version}`. Nothing ever trusted the state, so it was pure write amplification.
- `useGameRoom` coalesces refetches within 120ms, so a burst of writes costs one read per client instead of one per signal.
- Chat messages capped at 60 — the array previously grew unbounded inside a blob rewritten on every single write.
- `cleanup_stale_rooms()` is generated from the `GAMES` list and sweeps all 7 tables. The old `pg_cron` job only ever deleted from `uno_rooms`, so the other six accumulated indefinitely (the oldest `skribbl_rooms` row on the live project dated from March).

## A bug I introduced and removed

The first commit *also* skipped the refetch when the signalled version was not ahead of the local one, to stop a writer re-reading its own echo. **That is wrong.** `versionRef` is advanced optimistically — by `dispatch` from the RPC result, and by `joinRoom`'s `?? currentVersion + 1` fallback — so it can already equal a version whose authoritative state differs. Skipping made that divergence permanent, since no later signal for that version is ever sent.

Measured on the Cards Against Humanity spec, which drives several clients concurrently:

| variant | result |
|---|---|
| with the version skip | **2/12 runs hung** until the 30s timeout |
| debounce only | 0/12 |
| `main` | 0/12 |

The coalescing debounce is what actually cuts read load and keeps its full effect. Both the hook and the schema generator now document why the version must not be used to skip a read.

## Testing

- 951 unit tests pass; new coverage for `applyDrawMessage`, `chunkSnapshot`, and `BroadcastMessageSchema`
- 64/68 E2E pass. The 4 failures are `visual-regression` snapshots that fail **identically on `main`** — baselines are `-chromium-linux.png` for CI and no macOS baseline exists, so they cannot fail in CI.
- `pnpm lint` and `pnpm check:schema` clean

## Deploy notes

- **The `cleanup_stale_rooms` migration has not been applied** to the live project. The `broadcast_room_state` change **has** been applied, and is backward compatible — the currently deployed client ignores the payload and refetches on any signal, so a `{version}`-only signal behaves identically for it.
- **Deploying mid-game will desync open tabs.** The new Zod schema drops `strokes`, so a browser running the old build will fail validation against a room written by the new one. Rooms expire after 24h, so it self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)