### PR TITLE
Globetrotter: stale room errors, English map, ghost pins, final scoreboard, fake photospheres

### DIFF
--- a/e2e/games/globetrotter.spec.ts
+++ b/e2e/games/globetrotter.spec.ts
@@ -8,6 +8,8 @@ type GlobetrotterPlayer = {
   name: string
   isHost: boolean
   score: number
+  /** Set when somebody walks out of a finished room — they stay on the board. */
+  left?: boolean
 }
 
 type GlobetrotterLocation = {
@@ -856,7 +858,15 @@ test.describe('Globetrotter gameplay smoke', () => {
       await expect(hostPage.waiting).toContainText('Waiting for 1 more')
       await hostPage.expectStatus('Pins locked: 1 of 2')
 
+      // The host has locked a pin and the guest has not. Where the host pinned
+      // is the guest's answer to find, not a hint to copy off: the guessing map
+      // shows nobody else's guess, only your own once you place it.
+      await guestPage.expandMap()
+      await expect(guestPage.map.locator('.gt-map-ghostpin')).toHaveCount(0)
+      await expect(guestPage.map.locator('.gt-map-pin')).toHaveCount(0)
+
       await guestPage.placeAndLockGuess(0.52, 0.24)
+      await expect(guestPage.map.locator('.gt-map-pin')).not.toHaveCount(0)
 
       await expect(hostPage.reveal).toContainText('Eiffel Tower')
       await expect(guestPage.reveal).toContainText('Eiffel Tower')
@@ -887,6 +897,59 @@ test.describe('Globetrotter gameplay smoke', () => {
 
       const finalRoom = await readGlobetrotterRoom(roomCode)
       expect(finalRoom.state.phase).toBe('finished')
+    } finally {
+      await closePlayers([guest])
+    }
+  })
+})
+
+test.describe('Globetrotter final scoreboard', () => {
+  test('the winner keeps the win after leaving the finished room', async ({ page, browser }) => {
+    const hostPage = new GlobetrotterPage(page)
+    const guest = await createPlayer(browser, 'Guest Globe')
+    const guestPage = new GlobetrotterPage(guest.page)
+
+    try {
+      await hostPage.goto()
+      const roomCode = await hostPage.createRoom('Host Globe')
+      await guestPage.goto()
+      await guestPage.joinRoom(roomCode, guest.name)
+      await hostPage.page.getByTestId('globetrotter-mode-landmarks').click()
+      await hostPage.startGame()
+
+      // Seed the last round already revealed, with the host clearly ahead —
+      // a tie would say nothing about who the board promotes.
+      const started = await readGlobetrotterRoom(roomCode)
+      const decided = seededFinalRevealState(started.state.players)
+      const [winner, runnerUp] = decided.players
+      await updateGlobetrotterRoom(roomCode, started, {
+        ...decided,
+        players: [
+          { ...winner, score: 17000 },
+          { ...runnerUp, score: 12005 },
+        ],
+      })
+      await hostPage.advanceRound()
+
+      await expect(guestPage.finishedBanner).toContainText('Host Globe wins the trip')
+
+      // The winner closes the room. A finished room is a result, not a roster:
+      // dropping their row would hand the trip to the runner-up.
+      await hostPage.leaveRoom()
+      await expect(hostPage.soloButton).toBeVisible()
+
+      await expect(guestPage.finalLeaderboard).toContainText('left')
+      await expect(guestPage.finishedBanner).toContainText('Host Globe wins the trip')
+      await expect(guestPage.finalLeaderboard).toContainText('Host Globe')
+
+      const room = await readGlobetrotterRoom(roomCode)
+      expect(room.state.players.map((player) => player.name)).toEqual(['Host Globe', 'Guest Globe'])
+      const [departed, remaining] = room.state.players
+      expect(departed.left).toBe(true)
+      expect(departed.score).toBeGreaterThan(remaining.score)
+      // ...and the badge moves, so the room is not stuck without a host.
+      expect(departed.isHost).toBe(false)
+      expect(remaining.isHost).toBe(true)
     } finally {
       await closePlayers([guest])
     }

--- a/e2e/games/globetrotter.spec.ts
+++ b/e2e/games/globetrotter.spec.ts
@@ -893,6 +893,23 @@ test.describe('Globetrotter gameplay smoke', () => {
   })
 })
 
+test.describe('Globetrotter entry', () => {
+  test('a failed join does not follow you to the create form', async ({ page }) => {
+    const entry = new GlobetrotterPage(page)
+    await entry.goto()
+
+    await entry.joinRoomExpectingError('ZZZZZZ', 'Lost Globe')
+    await entry.expectError(/Room not found/i)
+
+    // The message belongs to the room that refused you. Carried over to the
+    // create form it reads as the app refusing to make you a room at all.
+    await page.getByRole('button', { name: '← Back' }).click()
+    await page.getByTestId('create-room-button').filter({ visible: true }).first().click()
+
+    await expect(entry.errorBanner).toHaveCount(0)
+  })
+})
+
 test.describe('Globetrotter room scouting', () => {
   test('shows every player the deck being scouted, not an idle lobby', async ({
     page,

--- a/src/app/games/globetrotter/globetrotter-design.css
+++ b/src/app/games/globetrotter/globetrotter-design.css
@@ -1413,7 +1413,13 @@
   color: color-mix(in oklch, var(--ink) 65%, transparent);
   background: color-mix(in oklch, var(--bg) 70%, transparent);
   padding: 1px 5px;
+}
+.gt-scope .gt-map-attribution a {
+  color: inherit;
   text-decoration: none;
+}
+.gt-scope .gt-map-attribution a:hover {
+  text-decoration: underline;
 }
 .gt-scope .gt-pin-anim {
   transform-box: fill-box;

--- a/src/app/games/globetrotter/globetrotter-design.css
+++ b/src/app/games/globetrotter/globetrotter-design.css
@@ -846,6 +846,25 @@
   gap: 8px;
   min-width: 0;
 }
+/* Walked out once the results were up — the row keeps its place and its score,
+   it just stops looking like somebody who is still in the room. */
+.gt-scope .sk-end-row.is-away .sk-end-name,
+.gt-scope .sk-end-row.is-away .sk-end-total {
+  opacity: 0.6;
+}
+.gt-scope .sk-end-left {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.gt-scope .sk-end-row.win .sk-end-left {
+  color: var(--acid-ink);
+  border-color: currentColor;
+}
 .gt-scope .sk-end-delta {
   font-family: var(--font-mono);
   font-size: 12px;
@@ -1395,10 +1414,6 @@
   background: color-mix(in oklch, var(--bg) 70%, transparent);
   padding: 1px 5px;
   text-decoration: none;
-}
-.gt-scope .gt-map-ghostpin {
-  fill: var(--ink-mute);
-  opacity: 0.5;
 }
 .gt-scope .gt-pin-anim {
   transform-box: fill-box;

--- a/src/games/globetrotter/GlobetrotterGame.tsx
+++ b/src/games/globetrotter/GlobetrotterGame.tsx
@@ -307,6 +307,8 @@ interface EntryScreenProps {
   hasSavedSession: boolean
   loading: boolean
   error: string | null
+  /** Drops a stale failure — see `switchMode`. */
+  onClearError?: () => void
   initialCode?: string | null
 }
 
@@ -319,6 +321,7 @@ function EntryScreen({
   hasSavedSession,
   loading,
   error,
+  onClearError,
   initialCode,
 }: EntryScreenProps) {
   const [mode, setMode] = useState<'choose' | 'create' | 'join'>(initialCode ? 'join' : 'choose')
@@ -333,6 +336,17 @@ function EntryScreen({
 
   const isCreate = mode === 'create'
   const canSubmit = name.trim().length >= 2 && (isCreate || code.trim().length >= 6)
+
+  /**
+   * Moving between the create and join forms drops the last failure with it.
+   * "This game has already started." belongs to the room you tried to join;
+   * carrying it over to the create form (which cannot possibly hit it) reads as
+   * the app refusing to make you a room.
+   */
+  function switchMode(next: 'choose' | 'create' | 'join') {
+    onClearError?.()
+    setMode(next)
+  }
 
   function submit() {
     if (!canSubmit || loading) return
@@ -373,7 +387,7 @@ function EntryScreen({
             <button
               className="sk-entry-card"
               data-testid="create-room-button"
-              onClick={() => setMode('create')}
+              onClick={() => switchMode('create')}
             >
               <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="2.5">
                 <path d="M 20 8 L 20 32 M 8 20 L 32 20" />
@@ -386,7 +400,7 @@ function EntryScreen({
             <button
               className="sk-entry-card"
               data-testid="join-room-button"
-              onClick={() => setMode('join')}
+              onClick={() => switchMode('join')}
             >
               <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="2.5">
                 <path d="M 8 20 L 32 20 M 24 12 L 32 20 L 24 28" />
@@ -447,7 +461,7 @@ function EntryScreen({
             </div>
           )}
           <div style={{ display: 'flex', gap: 12, marginTop: 4 }}>
-            <button className="sk-back" onClick={() => setMode('choose')}>
+            <button className="sk-back" onClick={() => switchMode('choose')}>
               ← Back
             </button>
             <button
@@ -653,7 +667,6 @@ interface GameBoardProps {
   isSolo: boolean
   players: BoardPlayer[]
   youLocked: boolean
-  lockedGhosts: Guess[]
   crumbScore: number
   deckNote?: string | null
   drop?: DropControls
@@ -669,7 +682,6 @@ function GameBoard({
   isSolo,
   players,
   youLocked,
-  lockedGhosts,
   crumbScore,
   deckNote = null,
   drop,
@@ -781,7 +793,6 @@ function GameBoard({
             <WorldMap
               interactive={expanded && !youLocked}
               pins={pending && !youLocked ? [{ ...pending, isYou: true, pending: true }] : []}
-              ghosts={lockedGhosts}
               onSelect={(guess) => setPending(guess)}
             />
 
@@ -1043,6 +1054,8 @@ interface FinishedRow {
   avatarIdx: number
   isYou: boolean
   total: number
+  /** Closed their tab after the results — still on the board, just not around. */
+  left?: boolean
 }
 
 interface FinishedScreenProps {
@@ -1100,12 +1113,16 @@ function FinishedScreen({
         </div>
         <div className="sk-end-table" data-testid="globetrotter-final-leaderboard">
           {sorted.map((row, index) => (
-            <div key={row.id} className={cn('sk-end-row', index === 0 && !isSolo && 'win')}>
+            <div
+              key={row.id}
+              className={cn('sk-end-row', index === 0 && !isSolo && 'win', row.left && 'is-away')}
+            >
               <span className="sk-end-rank">{index === 0 && !isSolo ? '👑' : index + 1}</span>
               <span className="sk-end-name">
                 <AvatarSvg idx={row.avatarIdx} size={22} />
                 {row.name}
                 {row.isYou && ' (you)'}
+                {row.left && <span className="sk-end-left mono">left</span>}
               </span>
               <span className="sk-end-delta">
                 {isSolo ? 'TOTAL' : index === 0 ? 'WINNER' : `−${winner.total - row.total}`}
@@ -1229,6 +1246,7 @@ export function GlobetrotterGame() {
     roomCode,
     status,
     error,
+    clearError,
     connectionStatus,
     onlinePlayerIds,
     savedSession,
@@ -1475,7 +1493,6 @@ export function GlobetrotterGame() {
             { id: 'you', name: 'You', score: soloGame.totalScore, locked: false, isYou: true },
           ]}
           youLocked={false}
-          lockedGhosts={[]}
           crumbScore={soloGame.totalScore}
           deckNote={DECK_NOTES[soloSource]}
           onLockGuess={(guess) => setSoloGame(submitSoloGuess(soloGame, guess.lat, guess.lng))}
@@ -1538,6 +1555,7 @@ export function GlobetrotterGame() {
           hasSavedSession={Boolean(savedSession)}
           loading={isLoading}
           error={error}
+          onClearError={clearError}
           initialCode={inviteCode}
         />
       </Shell>
@@ -1607,6 +1625,7 @@ export function GlobetrotterGame() {
             avatarIdx: redacted.players.findIndex((p) => p.id === player.id),
             isYou: player.id === playerId,
             total: player.score,
+            left: player.left,
           }))}
           totalRounds={redacted.totalRounds}
           isSolo={false}
@@ -1650,9 +1669,6 @@ export function GlobetrotterGame() {
   }
 
   const youLocked = Boolean(round.guesses[playerId])
-  const lockedGhosts = redacted.players
-    .filter((player) => player.id !== playerId && round.guesses[player.id])
-    .map((player) => round.guesses[player.id])
 
   return (
     <Shell crumb={`Round ${round.number}`} roomCode={roomCode}>
@@ -1670,7 +1686,6 @@ export function GlobetrotterGame() {
           isYou: player.id === playerId,
         }))}
         youLocked={youLocked}
-        lockedGhosts={lockedGhosts}
         crumbScore={redacted.players.find((p) => p.id === playerId)?.score ?? 0}
         drop={drop}
         onLockGuess={(guess) =>

--- a/src/games/globetrotter/WorldMap.tsx
+++ b/src/games/globetrotter/WorldMap.tsx
@@ -70,6 +70,16 @@ interface WorldMapProps {
 // read while you place a pin.
 const TILE_URL = (tile: Tile) =>
   `https://basemaps.cartocdn.com/rastertiles/voyager/${tile.z}/${tile.x}/${tile.y}.png`
+/**
+ * Deepest tile level the map ever asks for.
+ *
+ * A budget first — one level per camera, and the game is played at country and
+ * city scale — but it is also where the map stops being English. Voyager draws
+ * every *place* name (country, city, district) from the Latin/English tags at
+ * every level, and switches to local-script *street* names from about z13:
+ * 丸の内, вулиця Хрещатик. Zooming past this cap stretches z12 tiles rather
+ * than fetching those, so a player never meets a label they cannot read.
+ */
 const MAX_TILE_ZOOM = 12
 // E2E runs offline against a fake backend; skip the network so specs stay
 // deterministic and fall back to the vector basemap.

--- a/src/games/globetrotter/WorldMap.tsx
+++ b/src/games/globetrotter/WorldMap.tsx
@@ -800,15 +800,19 @@ export function WorldMap({
         )}
       </div>
 
+      {/* Two credits, two links: the data is OpenStreetMap's and the rendering
+          is CARTO's, and CARTO's terms ask for a link to its own attributions
+          page rather than a shared one. */}
       {readyTiles.length > 0 && (
-        <a
-          className="gt-map-attribution mono"
-          href="https://www.openstreetmap.org/copyright"
-          target="_blank"
-          rel="noreferrer"
-        >
-          © OpenStreetMap · © CARTO
-        </a>
+        <div className="gt-map-attribution mono">
+          <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">
+            © OpenStreetMap
+          </a>
+          {' · '}
+          <a href="https://carto.com/attributions" target="_blank" rel="noreferrer">
+            © CARTO
+          </a>
+        </div>
       )}
     </div>
   )

--- a/src/games/globetrotter/WorldMap.tsx
+++ b/src/games/globetrotter/WorldMap.tsx
@@ -46,8 +46,6 @@ export interface MapTarget {
 
 interface WorldMapProps {
   pins?: MapPin[]
-  /** Locked opponents' guesses shown as ghost dots while you still guess. */
-  ghosts?: Guess[]
   /** Revealed answer: gold flag marker + animated connectors to every pin. */
   target?: MapTarget | null
   onSelect?: (guess: Guess) => void
@@ -60,10 +58,18 @@ interface WorldMapProps {
   ariaLabel?: string
 }
 
-// Free, open basemap: OpenStreetMap standard raster tiles (ODbL). Rendered on
-// top of the built-in vector world so the map still works — coastlines,
-// borders and country names — when the tiles are blocked or offline.
-const TILE_URL = (tile: Tile) => `https://tile.openstreetmap.org/${tile.z}/${tile.x}/${tile.y}.png`
+// Free, open basemap: CARTO's Voyager raster tiles, drawn from OpenStreetMap
+// data (ODbL). Rendered on top of the built-in vector world so the map still
+// works — coastlines, borders and country names — when the tiles are blocked
+// or offline.
+//
+// Voyager rather than the standard OSM style because its labels come from the
+// Latin/English name tags: `tile.openstreetmap.org` names every country and
+// city in its own language and script, so a player who cannot read Cyrillic,
+// Greek, Arabic or CJK loses half the map — on a map whose entire job is being
+// read while you place a pin.
+const TILE_URL = (tile: Tile) =>
+  `https://basemaps.cartocdn.com/rastertiles/voyager/${tile.z}/${tile.x}/${tile.y}.png`
 const MAX_TILE_ZOOM = 12
 // E2E runs offline against a fake backend; skip the network so specs stay
 // deterministic and fall back to the vector basemap.
@@ -192,7 +198,6 @@ function useTileLayer(tiles: Tile[], enabled: boolean) {
 
 export function WorldMap({
   pins = [],
-  ghosts = [],
   target = null,
   onSelect,
   interactive = false,
@@ -654,7 +659,7 @@ export function WorldMap({
           {borderPaths}
         </g>
 
-        {/* OpenStreetMap raster tiles fade in over the vector base. */}
+        {/* CARTO raster tiles fade in over the vector base. */}
         {readyTiles.map((tile) => {
           const box = tileBox(tile)
           return (
@@ -704,14 +709,6 @@ export function WorldMap({
               />
             )
           })}
-
-        {/* opponents already locked in (guess mode) — ghost dots */}
-        {ghosts.map((ghost, index) => {
-          const { x, y } = project(ghost.lat, ghost.lng)
-          return (
-            <circle key={`ghost-${index}`} cx={x} cy={y} r={px(5)} className="gt-map-ghostpin" />
-          )
-        })}
 
         {/* pins */}
         {pins.map((pin, index) => {
@@ -810,7 +807,7 @@ export function WorldMap({
           target="_blank"
           rel="noreferrer"
         >
-          © OpenStreetMap
+          © OpenStreetMap · © CARTO
         </a>
       )}
     </div>

--- a/src/games/globetrotter/logic.test.ts
+++ b/src/games/globetrotter/logic.test.ts
@@ -331,6 +331,25 @@ describe('NEXT_ROUND / PLAY_AGAIN', () => {
 })
 
 describe('REMOVE_PLAYER', () => {
+  /** A played-out room: `guest` pinned the target every round and won it. */
+  function finishedState(): GameState {
+    let state = playingState([host, guest, third])
+    for (let round = 1; round <= TOTAL_ROUNDS; round++) {
+      const target = state.currentRound!.location
+      state = applyAction(state, { type: 'SUBMIT_GUESS', playerId: host.id, lat: 40, lng: 40 })
+      state = applyAction(state, { type: 'SUBMIT_GUESS', playerId: third.id, lat: 60, lng: 60 })
+      state = applyAction(state, {
+        type: 'SUBMIT_GUESS',
+        playerId: guest.id,
+        lat: target.lat,
+        lng: target.lng,
+      })
+      state = applyAction(state, { type: 'NEXT_ROUND', playerId: host.id })
+    }
+    expect(state.phase).toBe('finished')
+    return state
+  }
+
   it('removes a player in the lobby', () => {
     let state = createLobbyState(host)
     state = addPlayer(state, guest)
@@ -359,6 +378,47 @@ describe('REMOVE_PLAYER', () => {
     expect(state.players).toHaveLength(2)
     expect(state.currentRound?.phase).toBe('reveal')
     expect(state.currentRound?.roundScores[host.id]).toBeGreaterThanOrEqual(0)
+  })
+
+  it('keeps the winner on the board when they leave a finished room', () => {
+    // The scoreboard is the result of the game. Deleting the leaver's row would
+    // promote whoever came second — a room that rewrites its own ending as
+    // people close their tabs.
+    let state = finishedState()
+    const winner = getWinners(state)[0]
+    expect(winner.id).toBe(guest.id)
+
+    state = applyAction(state, { type: 'REMOVE_PLAYER', playerId: guest.id })
+
+    expect(state.players).toHaveLength(3)
+    expect(getWinners(state).map((p) => p.id)).toEqual([guest.id])
+    expect(getLeaderboard(state)[0].id).toBe(guest.id)
+    expect(state.players.find((p) => p.id === guest.id)?.left).toBe(true)
+    expect(state.log.at(-1)).toContain('left the expedition')
+  })
+
+  it('hands the host badge to somebody still in the finished room', () => {
+    let state = finishedState()
+    state = applyAction(state, { type: 'REMOVE_PLAYER', playerId: host.id })
+
+    const stillHere = state.players.filter((p) => !p.left)
+    expect(stillHere.filter((p) => p.isHost)).toHaveLength(1)
+    expect(state.players.find((p) => p.id === host.id)?.isHost).toBe(false)
+    // Leaving twice must not shuffle the badge again.
+    expect(applyAction(state, { type: 'REMOVE_PLAYER', playerId: host.id })).toBe(state)
+  })
+
+  it('leaves the departed behind when the room plays again', () => {
+    let state = finishedState()
+    state = applyAction(state, { type: 'REMOVE_PLAYER', playerId: guest.id })
+    const newHost = state.players.find((p) => p.isHost)!
+
+    state = applyAction(state, { type: 'PLAY_AGAIN', playerId: newHost.id })
+
+    expect(state.phase).toBe('lobby')
+    expect(state.players.map((p) => p.id)).not.toContain(guest.id)
+    expect(state.players.every((p) => p.score === 0 && !p.left)).toBe(true)
+    expect(state.players.filter((p) => p.isHost)).toHaveLength(1)
   })
 
   it('drops the leaver from a revealed round without touching others', () => {

--- a/src/games/globetrotter/logic.ts
+++ b/src/games/globetrotter/logic.ts
@@ -10,6 +10,8 @@ export interface Player {
   name: string
   isHost: boolean
   score: number
+  /** Walked out after the final round — kept on the scoreboard, see `removePlayer`. */
+  left?: boolean
 }
 
 export interface Guess {
@@ -306,11 +308,12 @@ function nextRound(state: GameState, playerId: string): GameState {
 function playAgain(state: GameState, playerId: string): GameState {
   if (state.phase !== 'finished') return state
   const host = state.players.find((p) => p.id === playerId)
-  if (!host?.isHost) return state
+  if (!host?.isHost || host.left) return state
   return {
     ...state,
     phase: 'lobby',
-    players: state.players.map((p) => ({ ...p, score: 0 })),
+    // The scoreboard held on to whoever walked out; a new lobby does not.
+    players: withHost(state.players.filter((p) => !p.left).map((p) => ({ ...p, score: 0 }))),
     roundNumber: 0,
     deck: [],
     currentRound: null,
@@ -327,8 +330,12 @@ function playAgain(state: GameState, playerId: string): GameState {
  * useful rather than terminal.
  */
 function withHost(players: Player[]): Player[] {
-  if (players.length === 0 || players.some((p) => p.isHost)) return players
-  return players.map((p, index) => (index === 0 ? { ...p, isHost: true } : p))
+  if (players.length === 0 || players.some((p) => p.isHost && !p.left)) return players
+  // Never hand the badge to somebody who has already walked out of a finished
+  // room — they are a scoreboard row, not a player who can press Play again.
+  const heir = players.find((p) => !p.left)
+  if (!heir) return players
+  return players.map((p) => (p.id === heir.id ? { ...p, isHost: true } : p))
 }
 
 /**
@@ -341,6 +348,21 @@ export function removePlayer(state: GameState, playerId: string, droppedBy?: str
   if (!player) return state
   const players = withHost(state.players.filter((p) => p.id !== playerId))
   const departed = droppedBy ? `was dropped by ${droppedBy}` : 'left the expedition'
+
+  // A finished room is a result, not a roster. Deleting the leaver's row here
+  // would hand the win to whoever was second — the game would keep rewriting
+  // its own ending as people close their tabs. So mark them departed instead:
+  // the scoreboard stands, and `playAgain` is where they actually go.
+  if (state.phase === 'finished') {
+    if (player.left) return state
+    return {
+      ...state,
+      players: withHost(
+        state.players.map((p) => (p.id === playerId ? { ...p, isHost: false, left: true } : p))
+      ),
+      log: [...state.log, `${player.name} ${departed}.`],
+    }
+  }
 
   if (state.phase === 'lobby' || !state.currentRound) {
     return { ...state, players }

--- a/src/games/globetrotter/schema.test.ts
+++ b/src/games/globetrotter/schema.test.ts
@@ -57,6 +57,17 @@ describe('globetrotter GameStateSchema', () => {
     expect(GameStateSchema.safeParse(invalid).success).toBe(false)
   })
 
+  it('accepts a player marked as having left a finished room', () => {
+    const state = {
+      ...validGameState,
+      phase: 'finished' as const,
+      players: [{ id: 'p1', name: 'Alice', isHost: true, score: 4200, left: true }],
+    }
+    const parsed = GameStateSchema.safeParse(state)
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data.players[0].left).toBe(true)
+  })
+
   it('rejects a blank player name', () => {
     const invalid = {
       ...validGameState,

--- a/src/games/globetrotter/schema.ts
+++ b/src/games/globetrotter/schema.ts
@@ -7,6 +7,13 @@ const PlayerSchema = z.object({
   name: playerNameSchema,
   isHost: z.boolean(),
   score: z.number().int().min(0),
+  /**
+   * Set when somebody walks out of a *finished* room. A final scoreboard is a
+   * result, not a roster: the leaver keeps their row and their score, and is
+   * only dropped for real when the host starts another game. Absent everywhere
+   * else — a player who leaves mid-game is removed outright.
+   */
+  left: z.boolean().optional(),
 })
 
 const GuessSchema = z.object({

--- a/src/games/globetrotter/sources/panoramax.test.ts
+++ b/src/games/globetrotter/sources/panoramax.test.ts
@@ -173,6 +173,31 @@ describe('panoramaxSource', () => {
     await expect(panoramaxSource.collect(3, deps(fetchFn))).resolves.toEqual([])
   })
 
+  it('judges a picture by the sphere it covers, not by the shape of its file', async () => {
+    // `sensor_array_dimensions` reads like a frame size and is not: it is the
+    // sphere the picture declares, 2:1 whenever it declares a whole one. The
+    // rendition a round downloads is never measured — this one says 2048x1965,
+    // and covering the sphere is what makes it playable.
+    const { fetchFn } = makeFetchDouble(() => ({
+      features: [
+        feature({
+          id: 'oversampled',
+          dimensions: [12626, 6313],
+          exif: {
+            'Xmp.GPano.FullPanoWidthPixels': '12626',
+            'Xmp.GPano.FullPanoHeightPixels': '6313',
+            'Xmp.GPano.CroppedAreaImageWidthPixels': '12626',
+            'Xmp.GPano.CroppedAreaImageHeightPixels': '6313',
+            'Exif.Photo.PixelXDimension': '2048',
+            'Exif.Photo.PixelYDimension': '1965',
+          },
+        }),
+      ],
+    }))
+    const finds = await panoramaxSource.collect(1, deps(fetchFn))
+    expect(finds).toHaveLength(1)
+  })
+
   it('keeps a full sphere that is a rounding error short of its own numbers', async () => {
     // Stitchers round. Demanding an exact match would throw away most of the
     // archive over a missing pixel — the crops worth dropping are missing a

--- a/src/games/globetrotter/sources/panoramax.test.ts
+++ b/src/games/globetrotter/sources/panoramax.test.ts
@@ -12,6 +12,10 @@ interface FeatureOptions {
   host?: string
   fieldOfView?: number
   dimensions?: [number, number]
+  /** `[left, top, right, bottom]` sphere pixels the frame does not cover. */
+  visibleArea?: [number, number, number, number]
+  /** Raw EXIF/XMP tags, merged over the defaults. */
+  exif?: Record<string, string | number>
   license?: string
   producer?: string
 }
@@ -35,6 +39,11 @@ function feature(options: FeatureOptions = {}) {
       'pers:interior_orientation': {
         field_of_view: options.fieldOfView ?? 360,
         sensor_array_dimensions: options.dimensions ?? [5760, 2880],
+        ...(options.visibleArea ? { visible_area: options.visibleArea } : {}),
+      },
+      exif: {
+        'Xmp.GPano.ProjectionType': 'equirectangular',
+        ...options.exif,
       },
     },
   }
@@ -125,6 +134,65 @@ describe('panoramaxSource', () => {
       ],
     }))
     await expect(panoramaxSource.collect(2, deps(fetchFn))).resolves.toEqual([])
+  })
+
+  it('drops a picture that declares 360° while holding a slice of one', async () => {
+    // The archive's own `field_of_view` is read off GPano's "how wide a full
+    // sphere would be" tag, so a phone sweep panorama — 360° of horizon in a
+    // 14880x3904 strip — sails through the API filter and then plays as a
+    // smear of stretched ground. Every one of these is a dead round.
+    const { fetchFn } = makeFetchDouble(() => ({
+      features: [
+        // Samsung sweep: cylindrical, and a third of the declared sphere.
+        feature({
+          id: 'sweep',
+          dimensions: [23800, 11900],
+          exif: {
+            'Xmp.GPano.ProjectionType': 'cylindrical',
+            'Xmp.GPano.FullPanoWidthPixels': '23800',
+            'Xmp.GPano.CroppedAreaImageWidthPixels': '14880',
+            'Xmp.GPano.CroppedAreaImageHeightPixels': '3904',
+          },
+        }),
+        // Same crop, no projection tag: the GPano numbers alone are enough.
+        feature({
+          id: 'strip',
+          dimensions: [16384, 8192],
+          exif: {
+            'Xmp.GPano.FullPanoWidthPixels': '16384',
+            'Xmp.GPano.FullPanoHeightPixels': '8192',
+            'Xmp.GPano.CroppedAreaImageWidthPixels': '16384',
+            'Xmp.GPano.CroppedAreaImageHeightPixels': '2520',
+          },
+        }),
+        // Photosphere the contributor gave up on halfway: 187° wide. Panoramax
+        // reports the missing margins itself.
+        feature({ id: 'half', dimensions: [12626, 6313], visibleArea: [2892, 0, 3158, 1] }),
+      ],
+    }))
+    await expect(panoramaxSource.collect(3, deps(fetchFn))).resolves.toEqual([])
+  })
+
+  it('keeps a full sphere that is a rounding error short of its own numbers', async () => {
+    // Stitchers round. Demanding an exact match would throw away most of the
+    // archive over a missing pixel — the crops worth dropping are missing a
+    // third of the sphere, not 0.5% of it.
+    const { fetchFn } = makeFetchDouble(() => ({
+      features: [
+        feature({
+          id: 'rounded',
+          dimensions: [17020, 8510],
+          visibleArea: [0, 45, 0, 0],
+          exif: {
+            'Xmp.GPano.FullPanoWidthPixels': '17020',
+            'Xmp.GPano.CroppedAreaImageWidthPixels': '17020',
+            'Xmp.GPano.CroppedAreaImageHeightPixels': '8465',
+          },
+        }),
+      ],
+    }))
+    const finds = await panoramaxSource.collect(1, deps(fetchFn))
+    expect(finds).toHaveLength(1)
   })
 
   it('takes at most two rounds from one cell, kilometres apart', async () => {

--- a/src/games/globetrotter/sources/panoramax.ts
+++ b/src/games/globetrotter/sources/panoramax.ts
@@ -202,9 +202,17 @@ function covers(part: number | null, whole: number | null): boolean {
  * down the middle. Same for the half-sphere a Pixel photosphere gives up on.
  *
  * So the picture is made to answer with its own numbers: the projection it
- * claims, and how much of the sphere it declares that it actually fills. Note
- * that a 2:1 frame is *not* the test — a full sphere sampled 2048×1965 is
- * still a full sphere, just oversampled vertically, and maps perfectly well.
+ * claims, and how much of the sphere it declares that it actually fills.
+ *
+ * What is measured is coverage, never the served file's shape. The two are
+ * easy to confuse because `sensor_array_dimensions` looks like a frame size
+ * and is not: it is the sphere the picture *declares* (GPano's
+ * FullPanoWidth/Height), which is 2:1 whenever it describes a whole sphere, so
+ * checking it is a cheap sanity gate on the declaration rather than a rule
+ * about pixels. The rendition a round actually downloads is never measured —
+ * a derivative comes in whatever size the instance generated, and a picture
+ * that only covers 187° is caught by the margins it is missing, not by the
+ * aspect of the JPEG those 187° arrive in.
  */
 function isSpherical(feature: PanoramaxFeature): boolean {
   const optics = feature.properties?.['pers:interior_orientation']

--- a/src/games/globetrotter/sources/panoramax.ts
+++ b/src/games/globetrotter/sources/panoramax.ts
@@ -123,9 +123,15 @@ interface PanoramaxFeature {
     'pers:interior_orientation'?: {
       field_of_view?: number
       sensor_array_dimensions?: unknown
+      /** `[left, top, right, bottom]` margins the frame does not cover, in sphere pixels. */
+      visible_area?: unknown
     }
+    exif?: PanoramaxExif
   }
 }
+
+/** Raw EXIF/XMP as the API hands it over: one flat bag of stringly-typed tags. */
+type PanoramaxExif = Record<string, string | number | undefined>
 
 interface SearchResponse {
   features?: PanoramaxFeature[]
@@ -163,17 +169,79 @@ function sphericalAsset(feature: PanoramaxFeature): string | null {
   return servedFromKnownInstance(href) ? href : null
 }
 
-/** Defence in depth: the search filter already asks for these, so re-check cheaply. */
+/** EXIF arrives as strings ("23800") on some instances and numbers on others. */
+function exifNumber(exif: PanoramaxExif | undefined, key: string): number | null {
+  const raw = exif?.[key]
+  const value = typeof raw === 'string' ? Number(raw) : raw
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null
+}
+
+/**
+ * How much of the declared sphere may be missing before a picture is a crop.
+ *
+ * Not zero: stitchers round, and plenty of honest photospheres come back a
+ * pixel or two short of their own declared height. A real crop is not shy —
+ * the ones this drops are missing a third of the sphere, not 0.5% of it.
+ */
+const COVERAGE_TOLERANCE = 0.02
+
+function covers(part: number | null, whole: number | null): boolean {
+  if (!part || !whole) return true
+  return part / whole >= 1 - COVERAGE_TOLERANCE
+}
+
+/**
+ * True when the pixels really do wrap the whole sphere.
+ *
+ * `field_of_view = 360` is not the promise it looks like. Panoramax reads it
+ * off the `GPano.FullPanoWidthPixels` tag, which says how wide a full sphere
+ * *would* be — not how much of one the file contains. A phone sweep panorama
+ * declares 360 while holding a 14880×3904 strip of the horizon, and the search
+ * filter waves it straight through; the viewer then stretches that strip over
+ * a whole sphere, and the round is an unplayable smear of ground with a seam
+ * down the middle. Same for the half-sphere a Pixel photosphere gives up on.
+ *
+ * So the picture is made to answer with its own numbers: the projection it
+ * claims, and how much of the sphere it declares that it actually fills. Note
+ * that a 2:1 frame is *not* the test — a full sphere sampled 2048×1965 is
+ * still a full sphere, just oversampled vertically, and maps perfectly well.
+ */
 function isSpherical(feature: PanoramaxFeature): boolean {
   const optics = feature.properties?.['pers:interior_orientation']
   if (optics?.field_of_view !== 360) return false
   const dims = optics.sensor_array_dimensions
-  if (Array.isArray(dims) && dims.length === 2) {
-    const [width, height] = dims
-    if (typeof width === 'number' && typeof height === 'number' && height > 0) {
-      if (Math.abs(width / height - 2) > ASPECT_TOLERANCE) return false
-    }
+  const declared = Array.isArray(dims) && dims.length === 2 ? dims : null
+  const [declaredWidth, declaredHeight] =
+    declared && typeof declared[0] === 'number' && typeof declared[1] === 'number'
+      ? (declared as [number, number])
+      : [null, null]
+  if (declaredWidth && declaredHeight) {
+    if (Math.abs(declaredWidth / declaredHeight - 2) > ASPECT_TOLERANCE) return false
   }
+
+  // Panoramax's own read of what is missing: the margins, in pixels of the
+  // declared sphere, that the frame does not cover. Absent on a full sphere.
+  const area = optics.visible_area
+  if (Array.isArray(area) && area.length === 4 && area.every((v) => typeof v === 'number')) {
+    const [left, top, right, bottom] = area as [number, number, number, number]
+    if (declaredWidth && !covers(declaredWidth - left - right, declaredWidth)) return false
+    if (declaredHeight && !covers(declaredHeight - top - bottom, declaredHeight)) return false
+  }
+
+  const exif = feature.properties?.exif
+  // A phone sweep is cylindrical, not equirectangular: 360° of horizon in a
+  // projection the viewer's shader does not speak.
+  const projection = exif?.['Xmp.GPano.ProjectionType']
+  if (typeof projection === 'string' && projection.toLowerCase() !== 'equirectangular') return false
+
+  // The GPano crop tags say the same thing first-hand. Height is often left
+  // implicit, and a full sphere is half its own width.
+  const fullWidth = exifNumber(exif, 'Xmp.GPano.FullPanoWidthPixels')
+  const fullHeight =
+    exifNumber(exif, 'Xmp.GPano.FullPanoHeightPixels') ?? (fullWidth ? fullWidth / 2 : null)
+  if (!covers(exifNumber(exif, 'Xmp.GPano.CroppedAreaImageWidthPixels'), fullWidth)) return false
+  if (!covers(exifNumber(exif, 'Xmp.GPano.CroppedAreaImageHeightPixels'), fullHeight)) return false
+
   return true
 }
 

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -140,6 +140,16 @@ export interface UseGameRoomReturn<TState, TAction, TBroadcast = never> {
   // CLIENT-01: 'desynced' when a realtime payload fails Zod safeParse or the channel reports
   // CHANNEL_ERROR/TIMED_OUT/CLOSED; auto-clears to 'live' on the next valid apply or SUBSCRIBED.
   connectionStatus: 'live' | 'desynced'
+  /**
+   * Drop the last failure message.
+   *
+   * `createRoom`/`joinRoom` each clear it when they run, but a failed attempt
+   * leaves the text on screen until the *next* attempt starts — so an entry
+   * screen that lets a player switch from joining to creating shows them
+   * "This game has already started." over a form that has nothing to do with
+   * it. Call this when the player moves on from whatever failed.
+   */
+  clearError: () => void
   createRoom: (playerName: string, extras?: Record<string, unknown>) => Promise<void>
   joinRoom: (code: string, playerName: string, extras?: Record<string, unknown>) => Promise<void>
   restoreSession: () => Promise<void>
@@ -784,12 +794,21 @@ export function useGameRoom<TState extends BaseGameState, TAction, TBroadcast = 
     }
   }, [])
 
+  const clearError = useCallback(() => {
+    setError(null)
+    // 'error' is a dead end — the hook only leaves it on create/join/restore.
+    // Leaving the status behind would keep every `status === 'error'` branch lit
+    // with no message to show for it.
+    setStatus((current) => (current === 'error' ? 'idle' : current))
+  }, [])
+
   return {
     gameState,
     playerId,
     roomCode,
     status,
     error,
+    clearError,
     savedSession,
     onlinePlayerIds,
     connectionStatus,

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -57,7 +57,7 @@ describe('contentSecurityPolicy', () => {
     for (const origin of IMAGE_ORIGINS) expect(img).toContain(origin)
     // The panorama's <img> decode fallback and the raster basemap.
     expect(IMAGE_ORIGINS).toContain('https://upload.wikimedia.org')
-    expect(IMAGE_ORIGINS).toContain('https://tile.openstreetmap.org')
+    expect(IMAGE_ORIGINS).toContain('https://basemaps.cartocdn.com')
   })
 
   // Panoramax is federated: the catalog is central but the pixels come from

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -25,8 +25,16 @@ const ORIGINS = {
   panoramaxApi: 'https://api.panoramax.xyz',
   /** Globetrotter — reverse-geocoding the drop point for the reveal. `placeName.ts` */
   nominatim: 'https://nominatim.openstreetmap.org',
-  /** Globetrotter — OpenStreetMap raster basemap. `WorldMap.tsx` */
-  osmTiles: 'https://tile.openstreetmap.org',
+  /**
+   * Globetrotter — CARTO's raster basemap (OpenStreetMap data, CARTO styling).
+   * `WorldMap.tsx`
+   *
+   * CARTO rather than `tile.openstreetmap.org` because CARTO renders its labels
+   * from the Latin/English name tags: the standard OSM style names every place
+   * in its own language, which turns half the world into a script the player
+   * cannot read, on a map whose whole job is being read.
+   */
+  cartoTiles: 'https://basemaps.cartocdn.com',
 } as const
 
 /**
@@ -67,7 +75,7 @@ export const CONNECT_ORIGINS: readonly string[] = [
 export const IMAGE_ORIGINS: readonly string[] = [
   ORIGINS.wikimediaUploads,
   ...PANORAMAX_IMAGE_ORIGINS,
-  ORIGINS.osmTiles,
+  ORIGINS.cartoTiles,
 ]
 
 export interface CspEnv {


### PR DESCRIPTION
Five fixes to the online expedition, from the same report.

Room errors outlived what caused them. `createRoom`/`joinRoom` clear the
message when they run, so a failed join left "This game has already started."
sitting over the create form until the next attempt — reading as though the
app were refusing to make you a room. `useGameRoom` now exposes `clearError`,
and the entry screen drops the message when the player switches forms.

The basemap named places in their own language. `tile.openstreetmap.org`
renders every label from the local `name` tag, so half the world arrived in a
script the player cannot read on a map whose whole job is being read. Raster
tiles now come from CARTO's Voyager style — same OpenStreetMap data, labels
from the Latin/English tags — with the CSP origin and the attribution line
updated to match.

Opponents' locked guesses no longer show as ghost dots while you are still
placing your own pin; the reveal map still shows everybody.

Leaving a *finished* room no longer rewrites who won. `removePlayer` deleted
the row outright, which promoted the runner-up every time the winner closed
their tab. A finished room is a result, not a roster: the leaver is marked
`left`, keeps their place and their score (greyed, tagged "left"), hands the
host badge on, and is only dropped for real when the host starts a new game.

Random World kept drawing unplayable rounds. Panoramax reports
`field_of_view: 360` straight off GPano's "how wide a full sphere would be"
tag, so a phone sweep panorama — 360° of horizon in a 14880x3904 strip, and
cylindrical at that — passes the API filter and then plays as a smear of
stretched ground with a seam down it. The source now checks what the picture
actually covers: its projection, the margins Panoramax reports missing, and
the GPano crop tags, with tolerance for stitchers that round. Measured against
the live archive over 25 coverage cells: 588 kept, 11 dropped, and every one
of the drops was a strip or a half-sphere. A 2:1 frame is deliberately not the
test — a full sphere sampled 2048x1965 is still a full sphere.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LRnkYwkWxHLt6BFGKfDn8P